### PR TITLE
[ADD] sale_payment_method_transaction_id: link module between sale_payment_method and base_transaction_id

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ install:
   - export PATH=$HOME/maintainer-quality-tools/travis:$PATH
   - travis_install_nightly
   - git clone https://github.com/OCA/sale-workflow $HOME/sale-workflow -b 7.0
+  - git clone https://github.com/OCA/bank-statement-reconcile $HOME/bank-statement-reconcile -b 7.0
 
 script:
   - travis_run_flake8

--- a/sale_payment_method_transaction_id/__init__.py
+++ b/sale_payment_method_transaction_id/__init__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Author: Guewen Baconnier
+#    Copyright 2014 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import sale

--- a/sale_payment_method_transaction_id/__openerp__.py
+++ b/sale_payment_method_transaction_id/__openerp__.py
@@ -19,13 +19,13 @@
 #
 ##############################################################################
 
-{'name' : 'Sale Payment Method - Transaction ID Compatibility',
- 'version' : '1.0',
- 'author' : 'Camptocamp',
+{'name': 'Sale Payment Method - Transaction ID Compatibility',
+ 'version': '1.0',
+ 'author': 'Camptocamp',
  'maintainer': 'Camptocamp',
  'license': 'AGPL-3',
  'category': 'Hidden',
- 'depends' : ['sale_payment_method',
+ 'depends': ['sale_payment_method',
               # base_transaction_id is in
               # https://github.com/OCA/bank-statement-reconcile/tree/7.0
               'base_transaction_id',
@@ -47,4 +47,4 @@ move lines are created with the transaction id.
  'tests': [],
  'installable': True,
  'auto_install': True,
-}
+ }

--- a/sale_payment_method_transaction_id/__openerp__.py
+++ b/sale_payment_method_transaction_id/__openerp__.py
@@ -26,10 +26,10 @@
  'license': 'AGPL-3',
  'category': 'Hidden',
  'depends': ['sale_payment_method',
-              # base_transaction_id is in
-              # https://github.com/OCA/bank-statement-reconcile/tree/7.0
-              'base_transaction_id',
-              ],
+             # base_transaction_id is in
+             # https://github.com/OCA/bank-statement-reconcile/tree/7.0
+             'base_transaction_id',
+             ],
  'description': """
 Sale Payment Method - Transaction ID Compatibility
 ==================================================

--- a/sale_payment_method_transaction_id/__openerp__.py
+++ b/sale_payment_method_transaction_id/__openerp__.py
@@ -26,7 +26,9 @@
  'license': 'AGPL-3',
  'category': 'Hidden',
  'depends' : ['sale_payment_method',
-              'base_transaction_id',  # in lp:banking-addons/bank-statement-reconcile-7.0 
+              # base_transaction_id is in
+              # https://github.com/OCA/bank-statement-reconcile/tree/7.0
+              'base_transaction_id',
               ],
  'description': """
 Sale Payment Method - Transaction ID Compatibility

--- a/sale_payment_method_transaction_id/__openerp__.py
+++ b/sale_payment_method_transaction_id/__openerp__.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Author: Guewen Baconnier
+#    Copyright 2014 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+{'name' : 'Sale Payment Method - Transaction ID Compatibility',
+ 'version' : '1.0',
+ 'author' : 'Camptocamp',
+ 'maintainer': 'Camptocamp',
+ 'license': 'AGPL-3',
+ 'category': 'Hidden',
+ 'depends' : ['sale_payment_method',
+              'base_transaction_id',  # in lp:banking-addons/bank-statement-reconcile-7.0 
+              ],
+ 'description': """
+Sale Payment Method - Transaction ID Compatibility
+==================================================
+
+Link module between the sale payment method module
+and the module adding a transaction ID field (`base_transaction_id` in the
+`lp:banking-addons/bank-statement-reconcile-7.0` branch).
+
+When a payment is created from a sales order with a transaction ID, the
+move lines are created with the transaction id.
+
+ """,
+ 'website': 'http://www.camptocamp.com',
+ 'data': [],
+ 'tests': [],
+ 'installable': True,
+ 'auto_install': True,
+}

--- a/sale_payment_method_transaction_id/sale.py
+++ b/sale_payment_method_transaction_id/sale.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Author: Guewen Baconnier
+#    Copyright 2014 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.osv import orm
+
+
+class sale_order(orm.Model):
+    _inherit = 'sale.order'
+
+    def _prepare_payment_move_line(self, cr, uid, move_name, sale, journal,
+                                   period, amount, date, context=None):
+        debit_line, credit_line = super(sale_order, self).\
+            _prepare_payment_move_line(cr, uid, move_name, sale, journal,
+                                       period, amount, date, context=context)
+        if sale.transaction_id:
+            debit_line['transaction_ref'] = sale.transaction_id
+            credit_line['transaction_ref'] = sale.transaction_id
+        return debit_line, credit_line


### PR DESCRIPTION
Original proposal on: https://code.launchpad.net/~camptocamp/e-commerce-addons/7.0-sale_payment_method-base_transaction_id/+merge/203694
