### PR TITLE
[7.0] Addon to define a default receivable account on a payment method.

### DIFF
--- a/receivable_account_payment_method/__init__.py
+++ b/receivable_account_payment_method/__init__.py
@@ -1,0 +1,22 @@
+##############################################################################
+#
+#    Author: Romain Deheele
+#    Copyright 2014 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from . import account_invoice
+from . import payment_method
+from . import sale

--- a/receivable_account_payment_method/__openerp__.py
+++ b/receivable_account_payment_method/__openerp__.py
@@ -26,7 +26,7 @@
     'license': 'AGPL-3',
     'description': """
 Receivable Account Payment Method
-===================
+==================================
 
 This module adds possibility to configure
 a default receivable account on a payment method:

--- a/receivable_account_payment_method/__openerp__.py
+++ b/receivable_account_payment_method/__openerp__.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Author: Romain Deheele
+#    Copyright 2014 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+{
+    'name': 'Receivable Account Payment Method',
+    'version': '0.1',
+    'category': 'Generic Modules/Others',
+    'license': 'AGPL-3',
+    'description': """
+Receivable Account Payment Method
+===================
+
+This module adds possibility to configure
+a default receivable account on a payment method:
+
+When a default receivable account is specified on a payment method,
+an invoice using this payment method uses it instead of
+receivable account defined on partner.
+""",
+    'author': 'Camptocamp',
+    'website': 'http://www.camptocamp.com/',
+    'depends': ['sale_payment_method',
+                ],
+    'data': ['account_invoice_view.xml',
+             'payment_method_view.xml',
+             ],
+    'demo': [],
+    'test': ['test/receivable_account_payment_method.yml'],
+    'installable': True,
+}

--- a/receivable_account_payment_method/account_invoice.py
+++ b/receivable_account_payment_method/account_invoice.py
@@ -48,7 +48,8 @@ class account_invoice(orm.Model):
                         }
                     }
             if not result:
-                p = self.pool['res.partner'].browse(cr, uid, partner_id)
+                p = self.pool['res.partner'].browse(cr, uid, partner_id,
+                                                    context=context)
                 result = {'value': {
                     'account_id': p.property_account_receivable.id
                     }

--- a/receivable_account_payment_method/account_invoice.py
+++ b/receivable_account_payment_method/account_invoice.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Author: Romain Deheele
+#    Copyright 2014 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.osv import orm, fields
+
+
+class account_invoice(orm.Model):
+    _inherit = 'account.invoice'
+
+    _columns = {
+        'payment_method_id': fields.many2one(
+            'payment.method', 'Payment Method', readonly=True,
+            states={'draft': [('readonly', False)]}
+        ),
+    }
+
+    def onchange_payment_method_id(self, cr, uid, ids, payment_method_id,
+                                   type, partner_id, context=None):
+        """Update account_id according to the account set on the payment_method
+           else update account according to partner's receivable account
+        """
+        result = {}
+        if type in ('out_invoice', 'out_refund'):
+            if payment_method_id:
+                payment_method = self.pool['payment.method'].\
+                    browse(cr, uid, payment_method_id, context=context)
+                if payment_method.receivable_account_id:
+                    result = {'value': {
+                        'account_id': payment_method.receivable_account_id.id
+                        }
+                    }
+            if not result:
+                p = self.pool['res.partner'].browse(cr, uid, partner_id)
+                result = {'value': {
+                    'account_id': p.property_account_receivable.id
+                    }
+                }
+        return result
+
+    def onchange_partner_id(self, cr, uid, ids, type, partner_id,
+                            date_invoice=False, payment_term=False,
+                            partner_bank_id=False, company_id=False,
+                            payment_method_id=False):
+        """this override updates account_id according to the account set
+           on payment_method
+        """
+        result = super(account_invoice, self).\
+            onchange_partner_id(cr, uid, ids, type, partner_id, date_invoice,
+                                payment_term, partner_bank_id, company_id)
+        if type in ('out_invoice', 'out_refund') and payment_method_id:
+            payment_method = self.pool['payment.method'].\
+                browse(cr, uid, payment_method_id)
+            if payment_method.receivable_account_id:
+                result['value']['account_id'] = \
+                    payment_method.receivable_account_id.id
+        return result

--- a/receivable_account_payment_method/account_invoice_view.xml
+++ b/receivable_account_payment_method/account_invoice_view.xml
@@ -22,6 +22,18 @@
             </field>
         </record>
 
+        <!-- Search view -->
+        <record id="view_account_invoice_payment_method_filter" model="ir.ui.view">
+            <field name="name">account.invoice.add.payment_method.filter</field>
+            <field name="model">account.invoice</field>
+            <field name="inherit_id" ref="account.view_account_invoice_filter"/>
+            <field name="arch" type="xml">
+                <filter string="Due Date" position="after">
+                    <filter string="Payment Method" icon="terp-go-month" domain="[]" context="{'group_by':'payment_method_id'}"/>
+                </filter>
+            </field>
+        </record>
+
     </data>
 </openerp>
  

--- a/receivable_account_payment_method/account_invoice_view.xml
+++ b/receivable_account_payment_method/account_invoice_view.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <!-- Form view -->
+        <record id="view_customer_invoice_payment_method" model="ir.ui.view">
+            <field name="name">account.invoice.add.payment_method</field>
+            <field name="model">account.invoice</field>
+            <field name="inherit_id" ref="account.invoice_form"/>
+            <field name="arch" type="xml">
+                <field name="partner_id" position="replace" version="7.0">
+                    <field string="Customer" name="partner_id"
+                        on_change="onchange_partner_id(type,partner_id,date_invoice,payment_term, partner_bank_id,company_id,payment_method_id)"
+                        groups="base.group_user" context="{'search_default_customer':1, 'show_address': 1}"
+                        options='{"always_reload": True}'
+                        domain="[('customer', '=', True)]"/>
+                </field>
+                <field name="payment_term" position="before" version="7.0">
+                    <field name="payment_method_id" on_change="onchange_payment_method_id(payment_method_id, type, partner_id, context)"
+                           attrs="{'invisible': [('type', '!=', 'out_invoice')]}" class="oe_inline"/>
+                </field>
+            </field>
+        </record>
+
+    </data>
+</openerp>
+ 

--- a/receivable_account_payment_method/account_invoice_view.xml
+++ b/receivable_account_payment_method/account_invoice_view.xml
@@ -17,7 +17,7 @@
                 </field>
                 <field name="payment_term" position="before" version="7.0">
                     <field name="payment_method_id" on_change="onchange_payment_method_id(payment_method_id, type, partner_id, context)"
-                           attrs="{'invisible': [('type', '!=', 'out_invoice')]}" class="oe_inline"/>
+                           attrs="{'invisible': [('type', 'not in', ('out_invoice','out_refund'))]}" class="oe_inline"/>
                 </field>
             </field>
         </record>

--- a/receivable_account_payment_method/i18n/fr.po
+++ b/receivable_account_payment_method/i18n/fr.po
@@ -1,0 +1,48 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+#	* receivable_account_payment_method
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenERP Server 7.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-06-19 10:35+0000\n"
+"PO-Revision-Date: 2014-06-19 10:35+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: receivable_account_payment_method
+#: view:account.invoice:0
+msgid "Customer"
+msgstr "Client"
+
+#. module: receivable_account_payment_method
+#: field:payment.method,receivable_account_id:0
+msgid "Account"
+msgstr "Compte"
+
+#. module: receivable_account_payment_method
+#: field:account.invoice,payment_method_id:0
+#: model:ir.model,name:receivable_account_payment_method.model_payment_method
+msgid "Payment Method"
+msgstr "Méthode de paiement"
+
+#. module: receivable_account_payment_method
+#: help:payment.method,receivable_account_id:0
+msgid "The receivable account used for this payment method."
+msgstr "Le compte client utilisé pour ce moyen de paiement."
+
+#. module: receivable_account_payment_method
+#: model:ir.model,name:receivable_account_payment_method.model_account_invoice
+msgid "Invoice"
+msgstr "Facture"
+
+#. module: receivable_account_payment_method
+#: model:ir.model,name:receivable_account_payment_method.model_sale_order
+msgid "Sales Order"
+msgstr "Bon de commande"
+

--- a/receivable_account_payment_method/i18n/receivable_account_payment_method.pot
+++ b/receivable_account_payment_method/i18n/receivable_account_payment_method.pot
@@ -1,0 +1,48 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+#	* receivable_account_payment_method
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenERP Server 7.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-06-19 10:34+0000\n"
+"PO-Revision-Date: 2014-06-19 10:34+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: receivable_account_payment_method
+#: view:account.invoice:0
+msgid "Customer"
+msgstr ""
+
+#. module: receivable_account_payment_method
+#: field:payment.method,receivable_account_id:0
+msgid "Account"
+msgstr ""
+
+#. module: receivable_account_payment_method
+#: field:account.invoice,payment_method_id:0
+#: model:ir.model,name:receivable_account_payment_method.model_payment_method
+msgid "Payment Method"
+msgstr ""
+
+#. module: receivable_account_payment_method
+#: help:payment.method,receivable_account_id:0
+msgid "The receivable account used for this payment method."
+msgstr ""
+
+#. module: receivable_account_payment_method
+#: model:ir.model,name:receivable_account_payment_method.model_account_invoice
+msgid "Invoice"
+msgstr ""
+
+#. module: receivable_account_payment_method
+#: model:ir.model,name:receivable_account_payment_method.model_sale_order
+msgid "Sales Order"
+msgstr ""
+

--- a/receivable_account_payment_method/payment_method.py
+++ b/receivable_account_payment_method/payment_method.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Author: Romain Deheele
+#    Copyright 2014 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.osv import fields, orm
+
+
+class payment_method(orm.Model):
+    _inherit = "payment.method"
+
+    _columns = {
+        'receivable_account_id': fields.many2one(
+            'account.account', 'Account', domain=[('type', '=', 'receivable')],
+            help="The receivable account used for this payment method."),
+    }

--- a/receivable_account_payment_method/payment_method_view.xml
+++ b/receivable_account_payment_method/payment_method_view.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <!-- VIEW FOR THE OBJECT : payment_method -->
+        <record id="payment_method_view_form" model="ir.ui.view">
+            <field name="name">receivable_account_payment_method.payment_method.view_form</field>
+            <field name="model">payment.method</field>
+            <field name="inherit_id" ref="sale_payment_method.payment_method_view_form" />
+            <field name="arch" type="xml">
+                <field name="payment_term_id" position="after">
+                 <group>
+                    <field name="receivable_account_id" />
+                    </group>
+                    <group name="payment_help" class="oe_grey" col="1">
+                            <p attrs="{'invisible': [('receivable_account_id', '=', False)]}">
+                                Invoice using this payment method
+                                will use this account as receivable account.
+                            </p>
+                    </group>
+                </field>
+            </field>
+        </record>
+
+    </data>
+</openerp>

--- a/receivable_account_payment_method/sale.py
+++ b/receivable_account_payment_method/sale.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Author: Romain Deheele
+#    Copyright 2014 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.osv import orm
+
+
+class sale_order(orm.Model):
+    _inherit = 'sale.order'
+
+    def _prepare_invoice(self, cr, uid, order, lines, context=None):
+        """Alter prepared values according to payment_method and
+           possible default receivable account set on payment method
+           Original function prepares the dict of values to create
+           the new invoice for a sales order.
+
+           :param browse_record order: sale.order record to invoice
+           :param list(int) line: list of invoice line IDs that must be
+                                  attached to the invoice
+           :return: dict of value to create() the invoice
+        """
+        if context is None:
+            context = {}
+        invoice_vals = super(sale_order, self).\
+            _prepare_invoice(cr, uid, order, lines, context=context)
+        if order.payment_method_id:
+            if order.payment_method_id.receivable_account_id:
+                payment_method = order.payment_method_id
+                invoice_vals.update({
+                    'account_id': payment_method.receivable_account_id.id,
+                    'payment_method_id': payment_method.id
+                })
+        return invoice_vals

--- a/receivable_account_payment_method/test/receivable_account_payment_method.yml
+++ b/receivable_account_payment_method/test/receivable_account_payment_method.yml
@@ -1,0 +1,34 @@
+-
+  I create a new receivable account
+-
+  !record {model: account.account, id: paypal_account}:
+    code: 110201
+    name: Debtors Paypal
+    type: receivable
+    user_type: account.data_account_type_receivable
+-
+  I create a payment method
+-
+  !record {model: payment.method, id: paypal_method}:
+    name: Paypal
+    receivable_account_id: paypal_account
+-
+  I create a sale order with paypal payment method
+-
+  !record {model: sale.order, id: sale_order_paypal}:
+    name: My paypal order
+    partner_id: base.res_partner_12
+    order_line:
+      - product_id: product.product_product_6
+        product_uom_qty: 2
+-
+  I confirm the sale order
+-
+  !workflow {model: sale.order, action: order_confirm, ref: sale_order_paypal}
+-
+  I check account on the generated invoice.
+-
+  !python {model: sale.order}: |
+    invoice_ids = self.browse(cr, uid, ref("sale_order_paypal")).invoice_ids
+    for invoice in invoice_ids:
+        assert invoice.account_id.id == ref("paypal_account")

--- a/receivable_account_payment_method/test/receivable_account_payment_method.yml
+++ b/receivable_account_payment_method/test/receivable_account_payment_method.yml
@@ -27,7 +27,7 @@
 -
   !workflow {model: sale.order, action: order_confirm, ref: sale_order_paypal}
 -
-  I create advance invoice where type is 'Invoice all the Sale Order'.
+  I create a manual invoice from the confirmed sale order.
 -
   !python {model: sale.advance.payment.inv}: |
     ctx = context.copy()
@@ -35,7 +35,7 @@
     pay_id = self.create(cr, uid, {'advance_payment_method': 'all'})
     self.create_invoices(cr, uid, [pay_id], context=ctx)
 -
-  I check Invoice which made advance where type is 'Invoice all the Sale Order'.
+  I check the receivable account on the generated invoice.
 -
   !python {model: sale.order}: |
     invoice_ids = self.browse(cr, uid, ref("sale_order_paypal")).invoice_ids

--- a/receivable_account_payment_method/test/receivable_account_payment_method.yml
+++ b/receivable_account_payment_method/test/receivable_account_payment_method.yml
@@ -18,6 +18,7 @@
   !record {model: sale.order, id: sale_order_paypal}:
     name: My paypal order
     partner_id: base.res_partner_12
+    payment_method_id: paypal_method
     order_line:
       - product_id: product.product_product_6
         product_uom_qty: 2
@@ -26,7 +27,15 @@
 -
   !workflow {model: sale.order, action: order_confirm, ref: sale_order_paypal}
 -
-  I check account on the generated invoice.
+  I create advance invoice where type is 'Invoice all the Sale Order'.
+-
+  !python {model: sale.advance.payment.inv}: |
+    ctx = context.copy()
+    ctx.update({"active_model": 'sale.order', "active_ids": [ref("sale_order_paypal")], "active_id":ref("sale_order_paypal")})
+    pay_id = self.create(cr, uid, {'advance_payment_method': 'all'})
+    self.create_invoices(cr, uid, [pay_id], context=ctx)
+-
+  I check Invoice which made advance where type is 'Invoice all the Sale Order'.
 -
   !python {model: sale.order}: |
     invoice_ids = self.browse(cr, uid, ref("sale_order_paypal")).invoice_ids


### PR DESCRIPTION
Here is a new addon to define a default receivable account on a payment method.
Goal : when an invoice is generated with this payment method, account_id on customer invoice is populated according to this default receivable account.
Infos:
- new field payment_method_id on invoice (sale payment method is propagated on invoice at confirmation)
- partner and payment method changes are managed : if there is no payment method on invoice or no default receivable account on selected payment method, default receivable account set on partner is chosen.

Original proposal on Launchpad : https://code.launchpad.net/~camptocamp/e-commerce-addons/7.0-receivable_account_payment_method-rde/+merge/223738
