### PR TITLE
7.0 add warning field

### DIFF
--- a/sale_automatic_workflow/automatic_workflow_data.xml
+++ b/sale_automatic_workflow/automatic_workflow_data.xml
@@ -18,6 +18,7 @@
             <field name="validate_invoice" eval="1" />
             <field name="invoice_date_is_order_date" eval="0" />
             <field name="validate_picking" eval="0" />
+            <field name="warning">Be careful, if you save the order with this setting, it could be auto-confirmed, even if you are editing it.</field>
         </record>
 
         <record id="manual_validation" model="sale.workflow.process">

--- a/sale_automatic_workflow/sale.py
+++ b/sale_automatic_workflow/sale.py
@@ -20,6 +20,7 @@
 #
 ###############################################################################
 from openerp.osv import orm, fields
+from openerp.tools.translate import _
 
 
 class sale_order(orm.Model):
@@ -76,6 +77,12 @@ class sale_order(orm.Model):
             result['order_policy'] = workflow.order_policy
         if workflow.invoice_quantity:
             result['invoice_quantity'] = workflow.invoice_quantity
+        if workflow.warning:
+            warning = {
+                'title': _('Workflow Warning'),
+                'message': (workflow.warning),
+            }
+            return {'value': result, 'warning': warning}
         return {'value': result}
 
     def test_create_invoice(self, cr, uid, ids):

--- a/sale_automatic_workflow/sale_workflow_process.py
+++ b/sale_automatic_workflow/sale_workflow_process.py
@@ -63,6 +63,9 @@ class sale_workflow_process(orm.Model):
             'Force Invoice Date',
             help="When checked, the invoice date will be "
                  "the same than the order's date"),
+        'warning': fields.text('Warning Message', translate=True,
+                               help='displayed if filled when the process'
+                               'is changed on sale order'),
     }
 
     _defaults = {

--- a/sale_automatic_workflow/sale_workflow_process.py
+++ b/sale_automatic_workflow/sale_workflow_process.py
@@ -64,8 +64,8 @@ class sale_workflow_process(orm.Model):
             help="When checked, the invoice date will be "
                  "the same than the order's date"),
         'warning': fields.text('Warning Message', translate=True,
-                               help='displayed if filled when the process'
-                               'is changed on sale order'),
+                               help='if set, display the message when a '
+                               'user selects the process on a sale order'),
     }
 
     _defaults = {

--- a/sale_automatic_workflow/sale_workflow_process_view.xml
+++ b/sale_automatic_workflow/sale_workflow_process_view.xml
@@ -26,7 +26,7 @@
                     <field name="create_invoice_on" attrs="{'readonly': [('order_policy', '!=', 'manual')]}" />
                     <field name="validate_invoice"/>
                     <field name="invoice_date_is_order_date"/>
-
+                    <field name="warning"/>
                 </form>
             </field>
         </record>


### PR DESCRIPTION
if the user passes a sale order from the manual to the automatic workflow
process, it can be useful to inform him that a cron could automatically confirm
the order in a close future.
it warns the user via an onchange pop-up box.
