### PR TITLE
6.1-Check account before reconciliation

### DIFF
--- a/sale_automatic_workflow/sale.py
+++ b/sale_automatic_workflow/sale.py
@@ -100,15 +100,18 @@ class account_invoice(Model):
             payment_amount = 0
             invoice_amount = 0
             account_id = invoice.account_id.id
+            partner_id = invoice.partner_id.id
             if invoice.sale_ids and invoice.sale_ids[0].payment_id and invoice.move_id:
                 for move in invoice.sale_ids[0].payment_id.move_ids:
                     if move.credit > 0 and not move.reconcile_id \
-                            and move.account_id.id == account_id:
+                            and move.account_id.id == account_id \
+                            and move.partner_id.id == partner_id:
                         line_ids.append(move.id)
                         payment_amount += move.credit
                 for move in invoice.move_id.line_id:
                     if move.debit > 0 and not move.reconcile_id \
-                            and move.account_id.id == account_id:
+                            and move.account_id.id == account_id \
+                            and move.partner_id.id == partner_id:
                         line_ids.append(move.id)
                         invoice_amount += move.debit
             balance = abs(payment_amount-invoice_amount)

--- a/sale_automatic_workflow/sale.py
+++ b/sale_automatic_workflow/sale.py
@@ -99,13 +99,16 @@ class account_invoice(Model):
             line_ids = []
             payment_amount = 0
             invoice_amount = 0
+            account_id = invoice.account_id.id
             if invoice.sale_ids and invoice.sale_ids[0].payment_id and invoice.move_id:
                 for move in invoice.sale_ids[0].payment_id.move_ids:
-                    if move.credit > 0 and not move.reconcile_id:
+                    if move.credit > 0 and not move.reconcile_id \
+                            and move.account_id.id == account_id:
                         line_ids.append(move.id)
                         payment_amount += move.credit
                 for move in invoice.move_id.line_id:
-                    if move.debit > 0 and not move.reconcile_id:
+                    if move.debit > 0 and not move.reconcile_id \
+                            and move.account_id.id == account_id:
                         line_ids.append(move.id)
                         invoice_amount += move.debit
             balance = abs(payment_amount-invoice_amount)


### PR DESCRIPTION
When we calculate the amount of the payments and of the invoice, we do not check the account, just the credit or debit amount.

I just check if the account of the invoice, match the account of the account.move.line before suming the amount.
This fix a bug to reconcile invoices containing discount/refund lines.
Example : I have an sale order with 2 lines : 
1) Computer => amount = 500
2) Refund/discount => amount = -100

The problem of this second line is that the invoice will generates an account move line with a debit = 100.

So when we sum the debit of the account move line of the invoice, we will have 400 +100 = 500
The payment linked to the sale order has an amount of 400.
It won't try to reconcile even if it should.

Maybe instead of checking if the invoice account match the account move line Account, I should just check if the account move line account is payable/receivable.

I think the bug is also present in v7.0, if confirmed I can propose a patch for the version 7
