### PR TITLE
[FIX] the journal must be required

### DIFF
--- a/sale_quick_payment/wizard/pay_sale_order.py
+++ b/sale_quick_payment/wizard/pay_sale_order.py
@@ -28,7 +28,10 @@ class pay_sale_order(orm.TransientModel):
     _description = 'Wizard to generate a payment from the sale order'
 
     _columns = {
-        'journal_id': fields.many2one('account.journal', 'Journal'),
+        'journal_id': fields.many2one(
+            'account.journal',
+            'Journal',
+            required=True),
         'amount': fields.float('Amount',
                                digits_compute=dp.get_precision('Sale Price')),
         'date': fields.datetime('Payment Date'),


### PR DESCRIPTION
We need the journal for generating a move, so it should be required
