### PR TITLE
[FIX] Only allow adding receivable entries to sale order payment

### DIFF
--- a/sale_payment_method/sale.py
+++ b/sale_payment_method/sale.py
@@ -61,11 +61,14 @@ class sale_order(orm.Model):
         return res
 
     _columns = {
-        'payment_ids': fields.many2many('account.move.line',
-                                        string='Payments Entries'),
-        'payment_method_id': fields.many2one('payment.method',
-                                             'Payment Method',
-                                             ondelete='restrict'),
+        'payment_ids': fields.many2many(
+            'account.move.line',
+            string='Payments Entries',
+            domain=[('account_id.type', '=', 'receivable')]),
+        'payment_method_id': fields.many2one(
+            'payment.method',
+            'Payment Method',
+            ondelete='restrict'),
         'residual': fields.function(
             _get_amount,
             digits_compute=dp.get_precision('Account'),


### PR DESCRIPTION
It should only be possible to link a payment/credit from a receivable account
to a sale order, so filter out all other account types

The accounting behavior doesn't make sense when it is showing all kind of entries. It should only show receivable entries.

To reproduce the bug:

1 - Go to "Quotation and Sales"
2 - Choose an order
3 - Go to "Automation Information" tab 
4 - Click the Edit button
5 - Click the Add payments button

After these steps there will be receivable entries in that table, but also entries from the other side of the payment transactions, for example, the bank entry
