### PR TITLE
Add check on invoice account

### DIFF
--- a/sale_automatic_workflow/invoice.py
+++ b/sale_automatic_workflow/invoice.py
@@ -84,8 +84,8 @@ class account_invoice(orm.Model):
             'total_amount_currency': 0,
         }
         for move_line in move_lines:
-            if (move_line[line_type] > 0 and not move_line.reconcile_id
-                    and move_line.account_id.id == invoice_account_id):
+            if (move_line[line_type] > 0 and not move_line.reconcile_id and
+                    move_line.account_id.id == invoice_account_id):
                 if move_line.date > res['max_date']:
                     res['max_date'] = move_line.date
                 res['line_ids'].append(move_line.id)


### PR DESCRIPTION
This PR is to ensure only move lines with the same account as the invoice are considered for the automatic validation; otherwise, any discount line on the invoice will also be used, and lead to the invoice not using the sale order payment.
