### PR TITLE
[FIX] change called method to confirm sale orders

### DIFF
--- a/sale_automatic_workflow/automatic_workflow_job.py
+++ b/sale_automatic_workflow/automatic_workflow_job.py
@@ -86,7 +86,7 @@ class AutomaticWorkflowJob(models.Model):
         _logger.debug('Sale Orders to validate: %s', sales)
         for sale in sales:
             with commit(self.env.cr):
-                sale.signal_workflow('order_confirm')
+                sale.action_button_confirm()
 
     @api.model
     def _validate_invoices(self):


### PR DESCRIPTION
Hi, 

I am maybe missing something but I think we can change the method called to validate the sale orders in the automatic workflow job. 
Indeed in 8.0 there is now a new method action_button_confirm() called by the button, instead of the workflow action in previous version. 
This method makes easier to override the order confirmation so if someone uses it, instead of action_wait() (like it was usually the case in previous versions), the override is skipt by the automatic workflow job.

Maybe it has been made in purpose and my PR is useless.

Thanks
