### PR TITLE
[FIX] Validate pikcing was broken during the port to the new version

### DIFF
--- a/sale_automatic_workflow/__init__.py
+++ b/sale_automatic_workflow/__init__.py
@@ -27,3 +27,4 @@ from . import automatic_workflow_job
 from . import invoice
 from . import stock_picking
 from . import stock_move
+from . import procurement

--- a/sale_automatic_workflow/automatic_workflow_job.py
+++ b/sale_automatic_workflow/automatic_workflow_job.py
@@ -104,7 +104,7 @@ class AutomaticWorkflowJob(models.Model):
     def _validate_pickings(self):
         picking_obj = self.env['stock.picking']
         pickings = picking_obj.search(
-            [('state', 'in', ['draft', 'confirmed', 'assigned']),
+            [('state', 'in', ['draft', 'waiting', 'confirmed', 'assigned']),
              ('workflow_process_id.validate_picking', '=', True)],
         )
         _logger.debug('Pickings to validate: %s', pickings)

--- a/sale_automatic_workflow/procurement.py
+++ b/sale_automatic_workflow/procurement.py
@@ -25,7 +25,7 @@ from openerp import models, fields
 
 
 class ProcurementGroup(models.Model):
-    _inherit="procurement.group"
+    _inherit = "procurement.group"
 
     workflow_process_id = fields.Many2one(
         'sale.workflow.process',

--- a/sale_automatic_workflow/procurement.py
+++ b/sale_automatic_workflow/procurement.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+###############################################################################
+#
+#   Module for OpenERP
+#   Copyright (C) 2015 Akretion (http://www.akretion.com).
+#   @author Sébastien BEAU <sebastien.beau@akretion.com>
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU Affero General Public License as
+#   published by the Free Software Foundation, either version 3 of the
+#   License, or (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+
+
+from openerp import models, fields
+
+
+class ProcurementGroup(models.Model):
+    _inherit="procurement.group"
+
+    workflow_process_id = fields.Many2one(
+        'sale.workflow.process',
+        string='Automatic Workflow',
+        ondelete='restrict')

--- a/sale_automatic_workflow/sale.py
+++ b/sale_automatic_workflow/sale.py
@@ -40,12 +40,12 @@ class sale_order(models.Model):
             invoice_vals['date_invoice'] = order.date_order
         return invoice_vals
 
-    def _prepare_order_picking(self, cr, uid, order, context=None):
-        picking_vals = super(sale_order, self)._prepare_order_picking(
-            cr, uid, order, context=context)
+    @api.model
+    def _prepare_procurement_group(self, order):
+        res = super(sale_order, self)._prepare_procurement_group(order)
         if order.workflow_process_id:
-            picking_vals['workflow_process_id'] = order.workflow_process_id.id
-        return picking_vals
+            res['workflow_process_id'] = order.workflow_process_id.id
+        return res
 
     @api.onchange('workflow_process_id')
     def onchange_workflow_process_id(self):

--- a/sale_automatic_workflow/stock_picking.py
+++ b/sale_automatic_workflow/stock_picking.py
@@ -27,6 +27,7 @@ class StockPicking(models.Model):
 
     workflow_process_id = fields.Many2one(comodel_name='sale.workflow.process',
                                           string='Sale Workflow Process')
+
     @api.model
     def _prepare_picking_assign(self, move):
         res = super(StockPicking, self)._prepare_picking_assign(move)

--- a/sale_automatic_workflow/stock_picking.py
+++ b/sale_automatic_workflow/stock_picking.py
@@ -27,6 +27,11 @@ class StockPicking(models.Model):
 
     workflow_process_id = fields.Many2one(comodel_name='sale.workflow.process',
                                           string='Sale Workflow Process')
+    @api.model
+    def _prepare_picking_assign(self, move):
+        res = super(StockPicking, self)._prepare_picking_assign(move)
+        res['move_type'] = move.group_id.workflow_process_id.id
+        return res
 
     def _create_invoice_from_picking(self, cr, uid, picking, vals,
                                      context=None):


### PR DESCRIPTION
Hi during the port to the new version the workflow method was not pass correctly to the picking.
Indeed even if a method was set on the sale order no method was set on picking.
