### PR TITLE
Fix product_links when creating a product

### DIFF
--- a/product_links/product_links.py
+++ b/product_links/product_links.py
@@ -36,8 +36,7 @@ class ProductLink(models.Model):
         comodel_name='product.product',
         string='Source Product',
         required=True,
-        ondelete='cascade',
-        default=lambda self: self.env.context.get('product_id', False))
+        ondelete='cascade')
     linked_product_id = fields.Many2one(
         comodel_name='product.product',
         string='Linked product',

--- a/product_links/product_links_view.xml
+++ b/product_links/product_links_view.xml
@@ -8,8 +8,7 @@
                 <form string="Product Links">
                     <group>
                         <field name="product_id"
-                            invisible="not context.get('product_link_main_view')"
-                            select="1"/>
+                               select="1"/>
                         <field name="is_active" select="1" />
                         <field name="linked_product_id" select="1" />
                         <field name="type" select="1" />
@@ -23,8 +22,7 @@
             <field name="model">product.link</field>
             <field name="arch" type="xml">
                 <tree string="Product Links">
-                    <field name="product_id"
-                        invisible="not context.get('product_link_main_view')" />
+                    <field name="product_id"/>
                     <field name="is_active" />
                     <field name="linked_product_id" />
                     <field name="type" />
@@ -39,8 +37,20 @@
             <field name="arch" type="xml">
                 <notebook position="inside">
                     <page string="Product Links">
-                        <field name="product_link_ids" colspan="4"
-                            nolabel="1" context="{'product_id': active_id}"/>
+                        <field name="product_link_ids" colspan="4" nolabel="1">
+                          <tree>
+                                <field name="is_active"/>
+                                <field name="linked_product_id"/>
+                                <field name="type"/>
+                            </tree>
+                          <form>
+                            <group>
+                                <field name="is_active"/>
+                                <field name="linked_product_id"/>
+                                <field name="type"/>
+                            </group>
+                          </form>
+                        </field>
                     </page>
                 </notebook>
             </field>
@@ -51,7 +61,6 @@
             <field name="res_model">product.link</field>
             <field name="view_type">form</field>
             <field name="view_mode">tree,form</field>
-            <field name="context">{'product_link_main_view': True}</field>
         </record>
 
         <menuitem id="product_link_menu"


### PR DESCRIPTION
Hello,
If you create a product and at the same time you want to creates the product links (by the one2many field), it won't be possible.
The reason is that on the product.links form view, the field 'product_id' will be invisible, required and empty.
The product_id field should not be in the form view, even invisible when we  create it from the one2many fields on the product.

It is easy to reproduce. Install this module, create a product and try to add the links before saving your new product.

@fevxie @guewen  the changes are ok for you?
