### PR TITLE
8.0 Recent products: fix access error for auto registered users 

### DIFF
--- a/website_sale_recently_viewed_products/security/ir.model.access.csv
+++ b/website_sale_recently_viewed_products/security/ir.model.access.csv
@@ -1,3 +1,2 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
-access_website_sale_product_view_public,website_sale_product_view_public,model_website_sale_product_view,base.group_public,1,1,1,0
-access_website_sale_product_view_user,website_sale_product_view_user,model_website_sale_product_view,base.group_user,1,1,1,0
+access_website_sale_product_view_public,website_sale_product_view_public,model_website_sale_product_view,,1,1,1,0


### PR DESCRIPTION
### How to reproduce on Runbot:
- Login as admin
- Enable user signup in Setting -> General Settings
- Logout
- Sign up as new user
### What happens

Internal server error
### Why

in `ir.model.access.csv`, the model `website.sale.product.view` is enabled for members of groups `base.group_public` and `base.group_user`. External authenticated users aren't members of either! `base.group_public` is a different thing from no group! (= all groups)

To make a model accessible by anyone we should use an access record with no group, as Odoo itself does on all the models visible in the frontend that should be accessible by everyone.
