### PR TITLE
sale_payment_method: set add_payment multicompany aware

### DIFF
--- a/sale_payment_method/sale.py
+++ b/sale_payment_method/sale.py
@@ -210,6 +210,7 @@ class sale_order(orm.Model):
                 'date': date,
                 'ref': sale.name,
                 'period_id': period.id,
+                'company_id': sale.company_id.id,
                 }
 
     def _prepare_payment_move_line(self, cr, uid, move_name, sale, journal,
@@ -244,6 +245,7 @@ class sale_order(orm.Model):
             'date': date,
             'amount_currency': amount_currency,
             'currency_id': currency_id,
+            'company_id': sale.company_id.id,
         }
 
         # payment line (receivable)
@@ -259,6 +261,7 @@ class sale_order(orm.Model):
             'amount_currency': -amount_currency,
             'currency_id': currency_id,
             'sale_ids': [(4, sale.id)],
+            'company_id': sale.company_id.id,
         }
         return debit_line, credit_line
 


### PR DESCRIPTION
The use case is the following :

company B parent of company A

Create quotation in company A
Set user in company B
Add payment to the created quotation

result : there is the following error :
2015-12-30 16:20:54,469 24665 TEST del_test2 openerp.modules.module: ` openerp.osv.orm.except_orm: ('ValidateError', u'Error occurred while validating the field(s) company_id: Account and Period must belong to the same company.')

expected : no error !
