### PR TITLE
sale_automatic_workflow : do partial reconciliation

### DIFF
--- a/sale_automatic_workflow/invoice.py
+++ b/sale_automatic_workflow/invoice.py
@@ -158,8 +158,13 @@ class account_invoice(orm.Model):
             if not use_currency:
                 balance = abs(res_invoice['total_amount'] -
                               res_payment['total_amount'])
-                if line_ids and is_zero(cr, uid, currency, balance):
-                    move_line_obj.reconcile(cr, uid, line_ids, context=context)
+                if line_ids:
+                    if is_zero(cr, uid, currency, balance):
+                        move_line_obj.reconcile(
+                            cr, uid, line_ids, context=context)
+                    else:
+                        move_line_obj.reconcile_partial(
+                            cr, uid, line_ids, 'manual', context=context)
             else:
                 balance = abs(res_invoice['total_amount_currency'] -
                               res_payment['total_amount_currency'])


### PR DESCRIPTION
 if the payment doesn't set balance to zero.

My use case is the following :

Customer make a complete payment for 5€
Order is for 5€
Do invoice and update amount to 4€
I do a negative payment on my invoice of 1€
And I except 5€ register on order will complete the payment and set invoice in state paid

I don't want refund to be able to deliver only one document to my customer.
