### PR TITLE
sale_payment_method : add force_cancel

### DIFF
--- a/sale_payment_method/sale.py
+++ b/sale_payment_method/sale.py
@@ -305,6 +305,11 @@ class sale_order(orm.Model):
         return action
 
     def action_cancel(self, cr, uid, ids, context=None):
+        if context is None:
+            context = {}
+        if context.get('force_cancel', False):
+            return super(sale_order, self).action_cancel(cr, uid, ids,
+                                                         context=context)
         for sale in self.browse(cr, uid, ids, context=context):
             if sale.payment_ids:
                 raise osv.except_osv(


### PR DESCRIPTION
to be able to cancel order with payment.

My use case is the following :
- customer do an order an pay it
- later, customer retract
- I want to cancel order
- I don't want to do an invoice/refund
- I want to generate refund move when I cancel the order

So I wan to be able to force cancellation of an order, in this case.
