### PR TITLE
[7.0] sale_payment_method : use partner_invoice instead of partner

### DIFF
--- a/sale_payment_method/sale.py
+++ b/sale_payment_method/sale.py
@@ -217,7 +217,7 @@ class sale_order(orm.Model):
         """ """
         partner_obj = self.pool.get('res.partner')
         currency_obj = self.pool.get('res.currency')
-        partner = partner_obj._find_accounting_partner(sale.partner_id)
+        partner = partner_obj._find_accounting_partner(sale.partner_invoice_id)
 
         company = journal.company_id
 


### PR DESCRIPTION
When add payment to sale order, use partner_invoice_id instead of partner_id.

If partner_id and partner_invoice_id are different, invoice can not be reconciled with the payment.
