### PR TITLE
[IMP][website_sale_require_legal] Reuse template

### DIFF
--- a/website_sale_require_legal/__openerp__.py
+++ b/website_sale_require_legal/__openerp__.py
@@ -4,10 +4,12 @@
 {
     "name": "Require accepting legal terms to checkout",
     "summary": "Force the user to accept legal tems to buy in the web shop",
-    "version": "8.0.1.0.0",
+    "version": "8.0.1.1.0",
     "category": "Website",
-    "website": "http://www.antiun.com",
-    "author": "Antiun Ingeniería S.L., Odoo Community Association (OCA)",
+    "website": "http://www.tecnativa.com",
+    "author": "Antiun Ingeniería S.L., "
+              "Tecnativa, "
+              "Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "application": False,
     "installable": True,

--- a/website_sale_require_legal/views/website_sale.xml
+++ b/website_sale_require_legal/views/website_sale.xml
@@ -15,10 +15,7 @@
                            name="accepted_legal_terms"
                            id="accepted_legal_terms"
                            required="required"/>
-                    I accept the <a href="/page/legal">legal advice</a>, the
-                    <a href="/page/privacy">privacy policy</a>
-                    and the <a href="/page/terms">terms of use</a>
-                    of this website.
+                    <t t-call="website_legal_page.acceptance_full"/>
                 </label>
             </div>
         </div>


### PR DESCRIPTION
Nowadays, `website_legal_page` includes a reusable template that makes this
module more... modular.

You should notice no meaningful difference in UI.

@Tecnativa.
