### PR TITLE
[FIX] website_sale_category_megamenu: Main template now allows to disable or enable via Customize menu on the shop

### DIFF
--- a/website_sale_category_megamenu/views/layout.xml
+++ b/website_sale_category_megamenu/views/layout.xml
@@ -55,7 +55,9 @@
 
     <template id="category_grid"
               inherit_id="website_sale.products"
-              name="Product Categories Grid">
+              name="Product Categories Grid"
+              customize_show="True"
+              active="True">
         <xpath expr="//t[@t-call='website_sale.search']" position="after">
             <t t-if="category">
                 <div class="text-center mt92 mb92">


### PR DESCRIPTION
[FIX] website_sale_category_megamenu: Main template now allows to disable or enable via Customize menu on the shop

FIXES: https://github.com/OCA/e-commerce/issues/61
