### PR TITLE
7.0 sale automatic workflow auto create payment lines

### DIFF
--- a/sale_automatic_workflow/__openerp__.py
+++ b/sale_automatic_workflow/__openerp__.py
@@ -53,6 +53,7 @@ It is well suited for other E-Commerce connectors as well.
     'website': 'http://www.akretion.com/',
     'depends': ['sale_payment_method',
                 'stock',
+                'account_gain_loss',
                 ],
     'data': ['sale_view.xml',
              'sale_workflow.xml',

--- a/sale_automatic_workflow/automatic_workflow_job.py
+++ b/sale_automatic_workflow/automatic_workflow_job.py
@@ -151,8 +151,7 @@ class automatic_workflow_job(orm.Model):
             cr, uid,
             [('state', 'in', ['done']),
              ('workflow_process_id.create_invoice_on', '=', 'on_picking_done'),
-             ('invoice_state', '=', '2binvoiced'),
-             ('type', '=', 'out')],
+             ('invoice_state', '=', '2binvoiced')],
             context=context)
         _logger.debug('Pickings to invoice: %s', picking_ids)
         if picking_ids:
@@ -162,9 +161,18 @@ class automatic_workflow_job(orm.Model):
                         context = dict(context,
                                 force_company=picking.sale_id.company_id.id,
                                 company_id=picking.sale_id.company_id.id)
-                    picking_obj.action_invoice_create(cr, uid,
+                    if picking.type=='out':
+                        picking_obj.action_invoice_create(cr, uid,
                                                   [picking.id,],
+                                                  type='out_invoice',
                                                   context=context)
+                    elif picking.type=='in':
+                        # Will be refund as this workflow does not apply to the supplier side
+                        picking_obj.action_invoice_create(cr, uid,
+                                                  [picking.id,],
+                                                  type='out_refund',
+                                                  context=context)
+                        
 
     def run(self, cr, uid, ids=None, context=None):
         """ Must be called from ir.cron """

--- a/sale_automatic_workflow/automatic_workflow_job.py
+++ b/sale_automatic_workflow/automatic_workflow_job.py
@@ -154,25 +154,25 @@ class automatic_workflow_job(orm.Model):
              ('invoice_state', '=', '2binvoiced')],
             context=context)
         _logger.debug('Pickings to invoice: %s', picking_ids)
-        if picking_ids:
+        for picking_id in picking_ids:
             with commit(cr):
-                for picking in picking_obj.browse(cr, uid, picking_ids, context=context):
-                    if picking.sale_id:
-                        context = dict(context,
-                                force_company=picking.sale_id.company_id.id,
-                                company_id=picking.sale_id.company_id.id)
-                    if picking.type=='out':
-                        picking_obj.action_invoice_create(cr, uid,
-                                                  [picking.id,],
-                                                  type='out_invoice',
-                                                  context=context)
-                    elif picking.type=='in':
-                        # Will be refund as this workflow does not apply to the supplier side
-                        picking_obj.action_invoice_create(cr, uid,
-                                                  [picking.id,],
-                                                  type='out_refund',
-                                                  context=context)
-                        
+                picking = picking_obj.browse(cr, uid, picking_id, context=context)
+                ctx = context
+                if picking.sale_id:
+                    ctx = dict(ctx,
+                               force_company=picking.sale_id.company_id.id,
+                               company_id=picking.sale_id.company_id.id)
+                if picking.type=='out':
+                    picking_obj.action_invoice_create(cr, uid,
+                                                      [picking_id,],
+                                                      type='out_invoice',
+                                                      context=ctx)
+                elif picking.type=='in':
+                    # Will be refunded as this workflow does not apply to the supplier side
+                    picking_obj.action_invoice_create(cr, uid,
+                                                      [picking_id,],
+                                                      type='out_refund',
+                                                      context=ctx)
 
     def run(self, cr, uid, ids=None, context=None):
         """ Must be called from ir.cron """

--- a/sale_automatic_workflow/automatic_workflow_job.py
+++ b/sale_automatic_workflow/automatic_workflow_job.py
@@ -88,6 +88,7 @@ class automatic_workflow_job(orm.Model):
             with commit(cr):
                 wf_service.trg_validate(uid, 'sale.order',
                                         sale_id, 'order_confirm', cr)
+                sale_obj.browse(cr, uid, sale_id, context=context).action_button_confirm()
 
     def _reconcile_invoices(self, cr, uid, ids=None, context=None):
         invoice_obj = self.pool.get('account.invoice')

--- a/sale_automatic_workflow/automatic_workflow_job.py
+++ b/sale_automatic_workflow/automatic_workflow_job.py
@@ -138,10 +138,33 @@ class automatic_workflow_job(orm.Model):
                                                  picking_ids,
                                                  context=context)
 
+    def _invoice_pickings(self, cr, uid, context=None):
+        picking_obj = self.pool.get('stock.picking')
+        # We search on stock.picking (using the type) rather than
+        # stock.picking.out because the ORM seems bugged and can't
+        # search on stock_picking_out.workflow_process_id.
+        # Later, we'll call `validate_picking` on stock.picking.out
+        # because anyway they have the same ID and the call will be at
+        # the correct object level.
+        picking_ids = picking_obj.search(
+            cr, uid,
+            [('state', 'in', ['done']),
+             ('workflow_process_id.create_invoice_on', '=', 'on_picking_done'),
+             ('invoice_state', '=', '2binvoiced'),
+             ('type', '=', 'out')],
+            context=context)
+        _logger.debug('Pickings to invoice: %s', picking_ids)
+        if picking_ids:
+            with commit(cr):
+                picking_obj.action_invoice_create(cr, uid,
+                                                  picking_ids,
+                                                  context=context)
+
     def run(self, cr, uid, ids=None, context=None):
         """ Must be called from ir.cron """
 
         self._validate_sale_orders(cr, uid, context=context)
+        self._invoice_pickings(cr, uid, context=context)
         self._validate_invoices(cr, uid, context=context)
         self._reconcile_invoices(cr, uid, context=context)
         self._validate_pickings(cr, uid, context=context)

--- a/sale_automatic_workflow/invoice.py
+++ b/sale_automatic_workflow/invoice.py
@@ -78,13 +78,18 @@ class account_invoice(orm.Model):
             'total_amount': 0,
             'total_amount_currency': 0,
         }
+        if line_type == 'debit':
+            sign = 1
+        else:
+            sign = -1
+
         for move_line in move_lines:
             if move_line[line_type] > 0:
                 if move_line.date > res['max_date']:
                     res['max_date'] = move_line.date
                 res['line_ids'].append(move_line.id)
                 res['total_amount'] += move_line[line_type]
-                res['total_amount_currency'] += move_line.amount_currency
+                res['total_amount_currency'] += sign * move_line.amount_currency
         return res
 
     def _prepare_write_off(self, cr, uid, invoice, res_invoice, res_payment,

--- a/sale_automatic_workflow/stock.py
+++ b/sale_automatic_workflow/stock.py
@@ -59,10 +59,18 @@ class stock_picking(orm.Model):
         if picking.sale_id:
             invoice_vals['currency_id'] =\
                 picking.sale_id.pricelist_id.currency_id.id
+            if base_picking.workflow_process_id.invoice_date_is_order_date:
+                invoice_vals['date_invoice'] = picking.sale_id.date_order
+            # Force period to avoid multi-company issues
+            if not invoice_vals.get('period_id'):
+                period_ids = self.pool.get('account.period').find(
+                    cr, uid, invoice_vals.get('date_invoice', False),
+                    context=context)
+                invoice_vals['period_id'] =\
+                    period_ids and period_ids[0] or False
         invoice_vals['workflow_process_id'] =\
             base_picking.workflow_process_id.id
-        if base_picking.workflow_process_id.invoice_date_is_order_date:
-            invoice_vals['date_invoice'] = picking.sale_id.date_order
+
         return invoice_vals
 
     def _prepare_invoice_line(self, cr, uid, group, picking, move_line,

--- a/sale_automatic_workflow/stock.py
+++ b/sale_automatic_workflow/stock.py
@@ -35,9 +35,12 @@ class stock_picking(orm.Model):
                          context=None):
         # Read the correct journal for the shop company
         if not journal_id:
+            journal_type = 'sale'
+            if inv_type == 'out_refund':
+                journal_type = 'sale_refund'
             journal_ids = self.pool.get('account.journal').search(
                 cr, uid,
-                [('type', '=', 'sale'),
+                [('type', '=', journal_type),
                  ('company_id', '=', picking.sale_id.company_id.id)],
                 limit=1)
             journal_id = journal_ids and journal_ids[0] or journal_id

--- a/sale_automatic_workflow/stock.py
+++ b/sale_automatic_workflow/stock.py
@@ -73,6 +73,16 @@ class stock_picking(orm.Model):
 
         return invoice_vals
 
+    def _prepare_shipping_invoice_line(self, cr, uid, picking, invoice, context=None):
+        if context is None:
+            context = {}
+        if picking.sale_id:
+            context = dict(context,
+                           force_company=picking.sale_id.company_id.id,
+                           company_id=picking.sale_id.company_id.id)
+            picking = self.browse(cr, uid, picking.id, context=context)
+        return super(stock_picking, self)._prepare_shipping_invoice_line(cr, uid, picking, invoice, context=context)
+
     def _prepare_invoice_line(self, cr, uid, group, picking, move_line,
                               invoice_id, invoice_vals, context=None):
         if picking.sale_id:

--- a/sale_automatic_workflow/stock.py
+++ b/sale_automatic_workflow/stock.py
@@ -33,12 +33,52 @@ class stock_picking(orm.Model):
 
     def _prepare_invoice(self, cr, uid, picking, partner, inv_type, journal_id,
                          context=None):
+        # Read the correct journal for the shop company
+        if not journal_id:
+            journal_ids = self.pool.get('account.journal').search(
+                cr, uid,
+                [('type', '=', 'sale'),
+                 ('company_id', '=', picking.sale_id.company_id.id)],
+                limit=1)
+            journal_id = journal_ids and journal_ids[0] or journal_id
+        # Re-read partner with correct context to get the
+        # correct accounts from properties
+        if picking.sale_id:
+            context = dict(context,
+                           force_company=picking.sale_id.company_id.id,
+                           company_id=picking.sale_id.company_id.id)
+            picking = self.browse(cr, uid, picking.id, context=context)
+            partner = self.pool.get('res.partner').browse(cr, uid,
+                                                          partner.id,
+                                                          context=context)
         invoice_vals = super(stock_picking, self)._prepare_invoice(
             cr, uid, picking, partner, inv_type, journal_id, context=context)
-        invoice_vals['workflow_process_id'] = picking.workflow_process_id.id
-        if picking.workflow_process_id.invoice_date_is_order_date:
+        base_picking = self.pool.get('stock.picking').browse(cr, uid,
+                                                             picking.id,
+                                                             context=context)
+        if picking.sale_id:
+            invoice_vals['currency_id'] =\
+                picking.sale_id.pricelist_id.currency_id.id
+        invoice_vals['workflow_process_id'] =\
+            base_picking.workflow_process_id.id
+        if base_picking.workflow_process_id.invoice_date_is_order_date:
             invoice_vals['date_invoice'] = picking.sale_id.date_order
         return invoice_vals
+
+    def _prepare_invoice_line(self, cr, uid, group, picking, move_line,
+                              invoice_id, invoice_vals, context=None):
+        if picking.sale_id:
+            context = dict(
+                context,
+                force_company=picking.sale_id.company_id.id,
+                company_id=picking.sale_id.company_id.id)
+            picking = self.browse(cr, uid, picking.id, context=context)
+            move_line = self.pool.get('stock.move').browse(cr, uid,
+                                                           move_line.id,
+                                                           context=context)
+        return super(stock_picking, self)._prepare_invoice_line(
+            cr, uid, group, picking, move_line, invoice_id,
+            invoice_vals, context=context)
 
 
 class stock_picking_out(orm.Model):

--- a/sale_payment_method/sale.py
+++ b/sale_payment_method/sale.py
@@ -97,6 +97,9 @@ class sale_order(orm.Model):
         the payment terms.
         If no amount is defined, it will pay the residual amount of the sale
         order. """
+        if context is None:
+            context = {}
+
         if isinstance(ids, Iterable):
             assert len(ids) == 1, "one sale order at a time can be paid"
             ids = ids[0]
@@ -127,6 +130,10 @@ class sale_order(orm.Model):
         else:
             amounts = [(date, amount)]
 
+        context = context.copy()
+        context['company_id'] = journal.company_id.id
+        context['force_company'] = journal.company_id.id
+        sale = self.browse(cr, uid, sale.id, context=context)
         # reversed is cosmetic, compute returns terms in the 'wrong' order
         for date, amount in reversed(amounts):
             self._add_payment(cr, uid, sale, journal,


### PR DESCRIPTION
When ever Sale Order is got confirmed by Workflow, then Automatic Payment Lines are not get created for the Sale Order. So, to fix this issue, calling the action_button_confirm of SO from automatic workflow.
