### PR TITLE
[FIX] website_sale_wishlist: 404 in tour

### DIFF
--- a/website_sale_wishlist/static/src/js/wishlist_tour.js
+++ b/website_sale_wishlist/static/src/js/wishlist_tour.js
@@ -95,15 +95,9 @@ odoo.define("website_sale_wishlist.tour", function (require) {
                 run: "click",
             },
             {
-                //For some reason the first a[href=...] leads to a 404 so
-                // this is just an extra step to get the following step running
-                content: "No wishlist now that it is saved in my account",
-                trigger: "a[href='/page/contactus']",
-                run: "click",
-            },
-            {
                 content: "No wishlist now that it is saved in my account",
                 trigger: "a[href='/shop']",
+                extra_trigger: "b:contains('Sign in')",
                 run: "click",
             },
             {


### PR DESCRIPTION
* Update JS tour to address 404 issue happening when module is combined with OCB and ``website_sale_qty``

I'm not sure why, but the approach used here to prevent a 404 no longer works in conjunction with OCB and the latest version of ``website_sale_qty`` in https://github.com/OCA/e-commerce/pull/153: https://travis-ci.org/OCA/e-commerce/jobs/252199821#L1189. The 404 is likely happening because the next step of the tour begins before the logout process can be completed, so a better solution is to add an extra trigger that will only appear once the user is fully logged out, forcing the tour to wait.

This PR is required for merging #153.