### PR TITLE
[FIX][website_sale_checkout_country_vat] Do not die without country

### DIFF
--- a/website_sale_checkout_country_vat/__openerp__.py
+++ b/website_sale_checkout_country_vat/__openerp__.py
@@ -6,7 +6,7 @@
 {
     "name": "Website Sale Checkout Country VAT",
     "summary": "Autocomplete VAT in checkout process",
-    "version": "9.0.1.0.0",
+    "version": "9.0.1.1.0",
     "category": "Website",
     'website': 'http://www.tecnativa.com',
     'author': 'Tecnativa, '

--- a/website_sale_checkout_country_vat/views/templates.xml
+++ b/website_sale_checkout_country_vat/views/templates.xml
@@ -10,7 +10,7 @@
             <t t-set="complete_field" t-value="'vat'"/>
             <t t-set="default_value" t-value="checkout.get('vat', '')"/>
             <t t-set="default_country"
-               t-value="countries.search([('code', '=', default_value[:2])]) or countries.search([('id', '=', checkout.get('country_id'))])"/>
+               t-value="countries.search([('code', '=', default_value[:2])]) or countries.search([('id', '=', checkout.get('country_id') or False)])"/>
         </t>
     </xpath>
 </template>


### PR DESCRIPTION
If you leave country field empty before pressing the confirm button at checkout, you were getting a 500 error because `country_id` was `""` (str), which cannot be searched in an int field.

Now we set a default `False` value, which will return an empty recordset without that problem.

@Tecnativa