### PR TITLE
[FIX] website_sale_affiliate: Handle case of no session

### DIFF
--- a/website_sale_affiliate/README.rst
+++ b/website_sale_affiliate/README.rst
@@ -62,6 +62,7 @@ Contributors
 ------------
 
 * Brent Hughes <brent.hughes@laslabs.com>
+* Dave Lasley <dave@laslabs.com>
 
 Do not contact contributors directly about support or help with technical issues.
 

--- a/website_sale_affiliate/__manifest__.py
+++ b/website_sale_affiliate/__manifest__.py
@@ -4,9 +4,10 @@
 
 {
     "name": "Affiliate Program",
-    "summary": "Module summary",
-    "version": "10.0.1.0.0",
-    "category": "Uncategorized",
+    "summary": "Create an e-commerce affiliate program for the tracking of "
+               "referrals and conversions.",
+    "version": "10.0.1.0.1",
+    "category": "E-Commerce",
     "website": "https://laslabs.com",
     "author": "LasLabs, Odoo Community Association (OCA)",
     "license": "LGPL-3",

--- a/website_sale_affiliate/models/sale_affiliate_request.py
+++ b/website_sale_affiliate/models/sale_affiliate_request.py
@@ -85,7 +85,9 @@ class AffiliateRequest(models.Model):
         try:
             current_id = request.session['affiliate_request']
             current = self.search([('id', '=', current_id)], limit=1)
-        except KeyError:
+        except (KeyError, RuntimeError):
+            # KeyError if session exists, but no request
+            # RuntimeError if session is non-existent (XML record creations)
             return
         if current._conversions_qualify():
             return current

--- a/website_sale_affiliate/tests/test_sale_affiliate_request.py
+++ b/website_sale_affiliate/tests/test_sale_affiliate_request.py
@@ -108,6 +108,12 @@ class AffiliateRequestCase(SaleCase):
         request_mock.session = {}
         self.assertIsNone(self.AffiliateRequest.current_qualified())
 
+    @patch('%s.request' % MODEL_PATH)
+    def test_current_qualified_no_session(self, request_mock):
+        """Returns None if there is no session."""
+        request_mock.session.__getitem__.side_effect = RuntimeError
+        self.assertIsNone(self.AffiliateRequest.current_qualified())
+
     @patch.object(AffiliateRequest, '_conversions_qualify')
     @patch('%s.request' % MODEL_PATH)
     def test_current_qualified_request_in_session_calls_conversions_qualify(


### PR DESCRIPTION
* Handle the case of no web session, which will raise a `RuntimeError('object unbound')` when attempting to access it. This happens during XML record creations, but likely other places such as in the shell