### PR TITLE
[10.0] [FIX] website_sale_recently_viewed_products: fix link to monksoftware website

### DIFF
--- a/website_sale_recently_viewed_products/__manifest__.py
+++ b/website_sale_recently_viewed_products/__manifest__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##############################################################################
 #
-#     Copyright (c) Leonardo Donelli @ MONK Software http://www.wearemonk.com
+#     Copyright (c) Leonardo Donelli@ MONK Software http://www.monksoftware.it
 #
 #     This is free software: you can redistribute it and/or
 #     modify it under the terms of the GNU Affero General Public License
@@ -24,7 +24,7 @@
     'summary': (
         'Let the users keep track of the products they saw on the ecommerce'),
     'author': "MONK Software,Odoo Community Association (OCA)",
-    'website': "http://www.wearemonk.com",
+    'website': "http://www.monksoftware.it",
     'category': 'Website',
     'version': '8.0.1.0.0',
     'license': 'AGPL-3',


### PR DESCRIPTION
Unfortunately we forgot to renew our domain/brand wearemonk-dot-com and the domain has been squatted by a less than reputable agent (pornography); so we are going through every one of our contributions that have that link somewhere, and replacing it with our real website.