### PR TITLE
[FIX] website_sale_qty: Product page permissions

### DIFF
--- a/website_sale_qty/__openerp__.py
+++ b/website_sale_qty/__openerp__.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
-# Copyright 2016 LasLabs Inc.
+# Copyright 2016-2017 LasLabs Inc.
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
 {
     'name': 'Website Sale - Price Tiers',
     'summary': 'Add price tier radio buttons to product pages in website shop',
-    'version': '9.0.1.0.0',
+    'version': '9.0.1.0.1',
     'category': 'E-commerce',
     'website': 'https://laslabs.com/',
     'author': 'LasLabs, Odoo Community Association (OCA)',
@@ -16,6 +16,7 @@
         'website_sale',
     ],
     'data': [
+        'security/ir.model.access.csv',
         'views/website_sale_qty.xml',
     ],
     'demo': [

--- a/website_sale_qty/security/ir.model.access.csv
+++ b/website_sale_qty/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+product_uom_portal_read_access,Product UoM - Portal Read Access,product.model_product_uom,base.group_portal,1,0,0,0
+product_uom_public_read_access,Product UoM - Public Read Access,product.model_product_uom,base.group_public,1,0,0,0

--- a/website_sale_qty/tests/test_js.py
+++ b/website_sale_qty/tests/test_js.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2016 LasLabs Inc.
+# Copyright 2016-2017 LasLabs Inc.
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
 from openerp.tests import HttpCase
@@ -14,5 +14,4 @@ class TestJS(HttpCase):
                  '.run("test_website_sale_qty", "test")',
             ready='odoo.__DEBUG__.services["web.Tour"]'
                   '.tours.test_website_sale_qty',
-            login='admin',
         )


### PR DESCRIPTION
* Fix permission errors on website shop product pages by granting portal and public users read access to the ``product.uom`` model