### PR TITLE
[FIX] website_sale_qty: Product page permissions

### DIFF
--- a/website_sale_price_tier/__manifest__.py
+++ b/website_sale_price_tier/__manifest__.py
@@ -5,7 +5,7 @@
 {
     'name': 'Website Sale - Price Tiers',
     'summary': 'Add price tier radio buttons to product pages in website shop',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.0.1',
     'category': 'E-commerce',
     'website': 'https://laslabs.com/',
     'author': 'LasLabs, Odoo Community Association (OCA)',
@@ -16,6 +16,7 @@
         'website_sale',
     ],
     'data': [
+        'security/ir.model.access.csv',
         'static/src/xml/website_sale_price_tier.xml',
         'templates/assets.xml',
         'wizards/website_config_settings.xml',

--- a/website_sale_price_tier/__manifest__.py
+++ b/website_sale_price_tier/__manifest__.py
@@ -5,7 +5,7 @@
 {
     'name': 'Website Sale - Price Tiers',
     'summary': 'Add price tier radio buttons to product pages in website shop',
-    'version': '10.0.1.0.1',
+    'version': '10.0.1.1.0',
     'category': 'E-commerce',
     'website': 'https://laslabs.com/',
     'author': 'LasLabs, Odoo Community Association (OCA)',

--- a/website_sale_price_tier/demo/product_product.xml
+++ b/website_sale_price_tier/demo/product_product.xml
@@ -9,5 +9,6 @@
         <field name="type">consu</field>
         <field name="uom_id" ref="product.product_uom_unit"/>
         <field name="uom_po_id" ref="product.product_uom_unit"/>
+        <field name="website_published" eval="True"/>
     </record>
 </odoo>

--- a/website_sale_price_tier/security/ir.model.access.csv
+++ b/website_sale_price_tier/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+product_uom_portal_read_access,Product UoM - Portal Read Access,product.model_product_uom,base.group_portal,1,0,0,0
+product_uom_public_read_access,Product UoM - Public Read Access,product.model_product_uom,base.group_public,1,0,0,0

--- a/website_sale_price_tier/tests/test_ui.py
+++ b/website_sale_price_tier/tests/test_ui.py
@@ -14,5 +14,4 @@ class TestUi(HttpCase):
                  '.run("website_sale_price_tier")',
             ready='odoo.__DEBUG__.services["web_tour.tour"]'
                   '.tours.website_sale_price_tier.ready',
-            login='admin',
         )


### PR DESCRIPTION
* Fix permission errors on website shop product pages by granting portal and public users read access to the ``product.uom`` model