### PR TITLE
[10.0][REF]  website_sale_require_login,  website_sale_suggest_create_account

### DIFF
--- a/website_sale_require_login/__manifest__.py
+++ b/website_sale_require_login/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Require login to checkout",
     "summary": "Force users to login for buying",
-    "version": "10.0.1.0.0",
+    "version": "10.0.1.1.0",
     "category": "Website",
     "website": "http://www.antiun.com",
     "author": "Tecnativa, "

--- a/website_sale_require_login/views/website_sale.xml
+++ b/website_sale_require_login/views/website_sale.xml
@@ -10,13 +10,11 @@
     </template>
     
     <template id="cart" inherit_id="website_sale.cart" priority="20">
+        <xpath expr="//div[@id='wrap']" position="before">
+            <t t-set="hide_checkout_button" t-value="not (user_authenticated and can_checkout)" />
+        </xpath>
         <xpath expr="//a[@href='/shop/checkout']" position="attributes">
-            <attribute name="t-if">(
-                user_id != website.user_id and
-                not optional_products and
-                website_sale_order and
-                website_sale_order.website_order_line
-            )</attribute>
+            <attribute name="t-if">not hide_checkout_button</attribute>
         </xpath>
     </template>
 

--- a/website_sale_suggest_create_account/__manifest__.py
+++ b/website_sale_suggest_create_account/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Suggest to create user account when buying",
     "summary": "Suggest users to create an account when buying in the website",
-    "version": "10.0.1.0.0",
+    "version": "10.0.1.1.0",
     "category": "Website",
     "website": "https://www.tecnativa.com",
     "author": "Tecnativa, "

--- a/website_sale_suggest_create_account/views/website_sale.xml
+++ b/website_sale_suggest_create_account/views/website_sale.xml
@@ -2,31 +2,32 @@
 <odoo>
     
     <template id="cart" inherit_id="website_sale.cart">
+        <xpath expr="//div[@id='wrap']" position="before">
+            <t t-set="user_authenticated" t-value="user_id != website.user_id"/>
+            <t t-set="signup_allowed" t-value="env['ir.config_parameter'].get_param('auth_signup.allow_uninvited') == 'True' "/>
+            <!-- TODO: optional_products has to be removed since odoo 12.0 at least. See https://github.com/odoo/odoo/pull/21461 -->
+            <t t-set="can_checkout" t-value="not optional_products 
+                                             and website_sale_order and
+                                             website_sale_order.website_order_line"/>
+
+            <t t-set="suggest_create_account" t-value="not user_authenticated and signup_allowed and can_checkout" />
+        </xpath>
+
         <!-- Show normal "Checkout" button if user is logged in or external login
              is disabled -->
         <xpath expr="//a[@href='/shop/checkout']" position="attributes">
-            <attribute name="t-if">(
-                user_id != website.user_id or
-                env['ir.config_parameter'].get_param(
-                    'auth_signup.allow_uninvited') != 'True' and
-                not optional_products and website_sale_order and
-                website_sale_order.website_order_line
-            )</attribute>
+            <attribute name="t-if">(user_authenticated or not signup_allowed) and can_checkout</attribute>
         </xpath>
     
         <!-- Show choice in other cases -->
         <xpath expr="//a[@href='/shop/checkout']" position="after">
-            <a t-if="user_id == website.user_id"
+            <a t-if="not user_authenticated"
                class="btn btn-primary pull-right mb32"
                href="/web/login?redirect=/shop/checkout">
                 <span>Log in and checkout</span>
                 <span class="fa fa-long-arrow-right"/>
             </a>
-            <t t-if="(user_id == website.user_id and
-                      env['ir.config_parameter'].get_param(
-                          'auth_signup.allow_uninvited') == 'True' and
-                      not optional_products and website_sale_order and
-                      website_sale_order.website_order_line)">
+            <t t-if="suggest_create_account">
                 <a class="btn btn-primary pull-right mb32"
                    href="/web/signup?redirect=/shop/checkout">
                     <span>Sign up and checkout</span>


### PR DESCRIPTION
This refactoring makes the modules compatible with other modules, that replace Checkout button.

E.g. we have a [module](https://github.com/it-projects-llc/website-addons/tree/10.0/website_sale_checkout_store) that makes following buttons:
> > > ![default](https://user-images.githubusercontent.com/186131/33869770-7a875f4a-df2c-11e7-9e88-f997c387a188.png)


-- with the refactoring we are able to hide or  modify those buttons depending on new variables ``suggest_create_account``, ``hide_checkout_button``