### PR TITLE
[12.0] [MIG] website_sale_hide_price

### DIFF
--- a/website_sale_hide_price/README.rst
+++ b/website_sale_hide_price/README.rst
@@ -1,0 +1,61 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+=======================
+Website Sale Hide Price
+=======================
+
+This module allows to have hidden product prices on the website store.
+
+Configuration
+=============
+
+#. Go to *Customers* and choose one.
+#. Go to *Sales and Purchases* tab.
+#. In *Sales* group set *Show prices on website* on or off so this customer can
+   see them or not. The default value is `True`, so every partner website user
+   can see the prices.
+#. If you wanted to have the prices hidden by default when no user is logged
+   in you should go to Public User's partner and set *Show prices on website*
+   off.
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/113/10.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/e-commerce/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smash it by providing detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* David Vidal <david.vidal@tecnativa.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/website_sale_hide_price/README.rst
+++ b/website_sale_hide_price/README.rst
@@ -44,6 +44,7 @@ Contributors
 ------------
 
 * David Vidal <david.vidal@tecnativa.com>
+* Abraham González <abraham@trey.es>
 
 Maintainer
 ----------

--- a/website_sale_hide_price/README.rst
+++ b/website_sale_hide_price/README.rst
@@ -45,6 +45,7 @@ Contributors
 
 * David Vidal <david.vidal@tecnativa.com>
 * Abraham González <abraham@trey.es>
+* Juanjo Algaz  <jalgaz@gmail.com>
 
 Maintainer
 ----------

--- a/website_sale_hide_price/README.rst
+++ b/website_sale_hide_price/README.rst
@@ -22,7 +22,7 @@ Configuration
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot
-   :target: https://runbot.odoo-community.org/runbot/113/10.0
+   :target: https://runbot.odoo-community.org/runbot/113/12.0
 
 Bug Tracker
 ===========

--- a/website_sale_hide_price/__init__.py
+++ b/website_sale_hide_price/__init__.py
@@ -1,3 +1,2 @@
 # -*- coding: utf-8 -*-
-
 from . import models

--- a/website_sale_hide_price/__init__.py
+++ b/website_sale_hide_price/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import models

--- a/website_sale_hide_price/__manifest__.py
+++ b/website_sale_hide_price/__manifest__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Tecnativa - David Vidal
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+{
+    'name': 'Website Sale Hide Price',
+    'version': '10.0.1.0.0',
+    'category': 'Website',
+    'author': 'Tecnativa, '
+              'Odoo Community Association (OCA)',
+    'website': 'https://www.tecnativa.com',
+    'license': 'AGPL-3',
+    'summary': 'Hide product prices on the shop',
+    'depends': [
+        'website_sale',
+    ],
+    'data': [
+        'views/partner_view.xml',
+        'views/website_sale_template.xml'
+    ],
+    'installable': True,
+}

--- a/website_sale_hide_price/__manifest__.py
+++ b/website_sale_hide_price/__manifest__.py
@@ -3,11 +3,11 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     'name': 'Website Sale Hide Price',
-    'version': '10.0.1.0.0',
+    'version': '11.0.1.0.0',
     'category': 'Website',
     'author': 'Tecnativa, '
               'Odoo Community Association (OCA)',
-    'website': 'https://www.tecnativa.com',
+    'website': 'https://github.com/OCA/e-commerce',
     'license': 'AGPL-3',
     'summary': 'Hide product prices on the shop',
     'depends': [

--- a/website_sale_hide_price/__manifest__.py
+++ b/website_sale_hide_price/__manifest__.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     'name': 'Website Sale Hide Price',
-    'version': '11.0.1.0.0',
+    'version': '11.0.1.0.1',
     'category': 'Website',
     'author': 'Tecnativa, '
               'Odoo Community Association (OCA)',

--- a/website_sale_hide_price/__manifest__.py
+++ b/website_sale_hide_price/__manifest__.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     'name': 'Website Sale Hide Price',
-    'version': '11.0.1.0.1',
+    'version': '12.0.1.0.1',
     'category': 'Website',
     'author': 'Tecnativa, '
               'Odoo Community Association (OCA)',

--- a/website_sale_hide_price/i18n/ar.po
+++ b/website_sale_hide_price/i18n/ar.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * website_sale_hide_price
-# 
+#
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
@@ -12,15 +12,16 @@ msgstr ""
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
 "Language-Team: Arabic (https://www.transifex.com/oca/teams/23907/ar/)\n"
+"Language: ar\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: ar\n"
-"Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5;\n"
+"Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 "
+"&& n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5;\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
-msgid "Partner"
+msgid "Contact"
 msgstr ""
 
 #. module: website_sale_hide_price
@@ -36,5 +37,5 @@ msgstr "الموقع"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price
-msgid "Website show price"
+msgid "Website Show Price"
 msgstr ""

--- a/website_sale_hide_price/i18n/ar.po
+++ b/website_sale_hide_price/i18n/ar.po
@@ -11,12 +11,12 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"Language-Team: Arabic (https://www.transifex.com/oca/teams/23907/ar/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: ar\n"
+"Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5;\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
@@ -32,7 +32,7 @@ msgstr ""
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_website
 msgid "Website"
-msgstr "Sitio web"
+msgstr "الموقع"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price

--- a/website_sale_hide_price/i18n/bg.po
+++ b/website_sale_hide_price/i18n/bg.po
@@ -11,11 +11,11 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"Language-Team: Bulgarian (https://www.transifex.com/oca/teams/23907/bg/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
+"Language: bg\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: website_sale_hide_price
@@ -32,7 +32,7 @@ msgstr ""
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_website
 msgid "Website"
-msgstr "Sitio web"
+msgstr "Уеб-страница"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price

--- a/website_sale_hide_price/i18n/bg.po
+++ b/website_sale_hide_price/i18n/bg.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * website_sale_hide_price
-# 
+#
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
@@ -12,15 +12,15 @@ msgstr ""
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
 "Language-Team: Bulgarian (https://www.transifex.com/oca/teams/23907/bg/)\n"
+"Language: bg\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: bg\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
-msgid "Partner"
+msgid "Contact"
 msgstr ""
 
 #. module: website_sale_hide_price
@@ -36,5 +36,5 @@ msgstr "Уеб-страница"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price
-msgid "Website show price"
+msgid "Website Show Price"
 msgstr ""

--- a/website_sale_hide_price/i18n/bs.po
+++ b/website_sale_hide_price/i18n/bs.po
@@ -11,12 +11,12 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"Language-Team: Bosnian (https://www.transifex.com/oca/teams/23907/bs/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: bs\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
@@ -32,7 +32,7 @@ msgstr ""
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_website
 msgid "Website"
-msgstr "Sitio web"
+msgstr "Web stranica"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price

--- a/website_sale_hide_price/i18n/bs.po
+++ b/website_sale_hide_price/i18n/bs.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * website_sale_hide_price
-# 
+#
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
@@ -12,15 +12,16 @@ msgstr ""
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
 "Language-Team: Bosnian (https://www.transifex.com/oca/teams/23907/bs/)\n"
+"Language: bs\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: bs\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
-msgid "Partner"
+msgid "Contact"
 msgstr ""
 
 #. module: website_sale_hide_price
@@ -36,5 +37,5 @@ msgstr "Web stranica"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price
-msgid "Website show price"
+msgid "Website Show Price"
 msgstr ""

--- a/website_sale_hide_price/i18n/ca.po
+++ b/website_sale_hide_price/i18n/ca.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * website_sale_hide_price
-# 
+#
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
@@ -12,15 +12,15 @@ msgstr ""
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
 "Language-Team: Catalan (https://www.transifex.com/oca/teams/23907/ca/)\n"
+"Language: ca\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: ca\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
-msgid "Partner"
+msgid "Contact"
 msgstr ""
 
 #. module: website_sale_hide_price
@@ -36,5 +36,5 @@ msgstr "Lloc web"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price
-msgid "Website show price"
+msgid "Website Show Price"
 msgstr ""

--- a/website_sale_hide_price/i18n/ca.po
+++ b/website_sale_hide_price/i18n/ca.po
@@ -11,11 +11,11 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"Language-Team: Catalan (https://www.transifex.com/oca/teams/23907/ca/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
+"Language: ca\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: website_sale_hide_price
@@ -32,7 +32,7 @@ msgstr ""
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_website
 msgid "Website"
-msgstr "Sitio web"
+msgstr "Lloc web"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price

--- a/website_sale_hide_price/i18n/cs.po
+++ b/website_sale_hide_price/i18n/cs.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * website_sale_hide_price
-# 
+#
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
@@ -12,15 +12,15 @@ msgstr ""
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
 "Language-Team: Czech (https://www.transifex.com/oca/teams/23907/cs/)\n"
+"Language: cs\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: cs\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
-msgid "Partner"
+msgid "Contact"
 msgstr ""
 
 #. module: website_sale_hide_price
@@ -36,5 +36,5 @@ msgstr "Webová stránka"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price
-msgid "Website show price"
+msgid "Website Show Price"
 msgstr ""

--- a/website_sale_hide_price/i18n/cs.po
+++ b/website_sale_hide_price/i18n/cs.po
@@ -11,12 +11,12 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"Language-Team: Czech (https://www.transifex.com/oca/teams/23907/cs/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: cs\n"
+"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
@@ -32,7 +32,7 @@ msgstr ""
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_website
 msgid "Website"
-msgstr "Sitio web"
+msgstr "Webová stránka"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price

--- a/website_sale_hide_price/i18n/da.po
+++ b/website_sale_hide_price/i18n/da.po
@@ -11,11 +11,11 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"Language-Team: Danish (https://www.transifex.com/oca/teams/23907/da/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
+"Language: da\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: website_sale_hide_price
@@ -32,7 +32,7 @@ msgstr ""
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_website
 msgid "Website"
-msgstr "Sitio web"
+msgstr "Hjemmeside"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price

--- a/website_sale_hide_price/i18n/da.po
+++ b/website_sale_hide_price/i18n/da.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * website_sale_hide_price
-# 
+#
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
@@ -12,15 +12,15 @@ msgstr ""
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
 "Language-Team: Danish (https://www.transifex.com/oca/teams/23907/da/)\n"
+"Language: da\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: da\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
-msgid "Partner"
+msgid "Contact"
 msgstr ""
 
 #. module: website_sale_hide_price
@@ -36,5 +36,5 @@ msgstr "Hjemmeside"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price
-msgid "Website show price"
+msgid "Website Show Price"
 msgstr ""

--- a/website_sale_hide_price/i18n/de.po
+++ b/website_sale_hide_price/i18n/de.po
@@ -9,30 +9,31 @@ msgstr ""
 "Project-Id-Version: Odoo Server 10.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
-"PO-Revision-Date: 2017-12-16 01:57+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"PO-Revision-Date: 2018-08-28 20:23+0000\n"
+"Last-Translator: Axel-G <git@r5d.de>\n"
 "Language-Team: German (https://www.transifex.com/oca/teams/23907/de/)\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 3.1.1\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
 msgid "Contact"
-msgstr ""
+msgstr "Kontakt"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_res_partner_website_show_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_res_users_website_show_price
 msgid "Show prices on website"
-msgstr ""
+msgstr "Preise auf Website anzeigen"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_website
 msgid "Website"
-msgstr "Webseite"
+msgstr "Website"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price

--- a/website_sale_hide_price/i18n/de.po
+++ b/website_sale_hide_price/i18n/de.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * website_sale_hide_price
-# 
+#
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
@@ -12,15 +12,15 @@ msgstr ""
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
 "Language-Team: German (https://www.transifex.com/oca/teams/23907/de/)\n"
+"Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
-msgid "Partner"
+msgid "Contact"
 msgstr ""
 
 #. module: website_sale_hide_price
@@ -36,5 +36,5 @@ msgstr "Webseite"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price
-msgid "Website show price"
+msgid "Website Show Price"
 msgstr ""

--- a/website_sale_hide_price/i18n/de.po
+++ b/website_sale_hide_price/i18n/de.po
@@ -11,11 +11,11 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"Language-Team: German (https://www.transifex.com/oca/teams/23907/de/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
+"Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: website_sale_hide_price
@@ -32,7 +32,7 @@ msgstr ""
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_website
 msgid "Website"
-msgstr "Sitio web"
+msgstr "Webseite"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price

--- a/website_sale_hide_price/i18n/el_GR.po
+++ b/website_sale_hide_price/i18n/el_GR.po
@@ -11,11 +11,11 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"Language-Team: Greek (Greece) (https://www.transifex.com/oca/teams/23907/el_GR/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
+"Language: el_GR\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: website_sale_hide_price
@@ -32,7 +32,7 @@ msgstr ""
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_website
 msgid "Website"
-msgstr "Sitio web"
+msgstr "Ιστότοπος"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price

--- a/website_sale_hide_price/i18n/el_GR.po
+++ b/website_sale_hide_price/i18n/el_GR.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * website_sale_hide_price
-# 
+#
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
@@ -11,16 +11,17 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Greek (Greece) (https://www.transifex.com/oca/teams/23907/el_GR/)\n"
+"Language-Team: Greek (Greece) (https://www.transifex.com/oca/teams/23907/"
+"el_GR/)\n"
+"Language: el_GR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: el_GR\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
-msgid "Partner"
+msgid "Contact"
 msgstr ""
 
 #. module: website_sale_hide_price
@@ -36,5 +37,5 @@ msgstr "Ιστότοπος"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price
-msgid "Website show price"
+msgid "Website Show Price"
 msgstr ""

--- a/website_sale_hide_price/i18n/en_GB.po
+++ b/website_sale_hide_price/i18n/en_GB.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * website_sale_hide_price
-# 
+#
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
@@ -11,16 +11,17 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: English (United Kingdom) (https://www.transifex.com/oca/teams/23907/en_GB/)\n"
+"Language-Team: English (United Kingdom) (https://www.transifex.com/oca/"
+"teams/23907/en_GB/)\n"
+"Language: en_GB\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: en_GB\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
-msgid "Partner"
+msgid "Contact"
 msgstr ""
 
 #. module: website_sale_hide_price
@@ -36,5 +37,5 @@ msgstr "Website"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price
-msgid "Website show price"
+msgid "Website Show Price"
 msgstr ""

--- a/website_sale_hide_price/i18n/en_GB.po
+++ b/website_sale_hide_price/i18n/en_GB.po
@@ -11,11 +11,11 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"Language-Team: English (United Kingdom) (https://www.transifex.com/oca/teams/23907/en_GB/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
+"Language: en_GB\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: website_sale_hide_price
@@ -32,7 +32,7 @@ msgstr ""
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_website
 msgid "Website"
-msgstr "Sitio web"
+msgstr "Website"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price

--- a/website_sale_hide_price/i18n/es.po
+++ b/website_sale_hide_price/i18n/es.po
@@ -1,0 +1,39 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* website_sale_hide_price
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 10.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-08-08 10:10+0000\n"
+"PO-Revision-Date: 2017-08-08 12:11+0200\n"
+"Last-Translator: David <david.vidal@tecnativa.com>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: es\n"
+"X-Generator: Poedit 1.8.7.1\n"
+
+#. module: website_sale_hide_price
+#: model:ir.model,name:website_sale_hide_price.model_res_partner
+msgid "Partner"
+msgstr "Empresa"
+
+#. module: website_sale_hide_price
+#: model:ir.model.fields,field_description:website_sale_hide_price.field_res_partner_website_show_price
+#: model:ir.model.fields,field_description:website_sale_hide_price.field_res_users_website_show_price
+msgid "Show prices on website"
+msgstr "Mostrar precios en el sitio web"
+
+#. module: website_sale_hide_price
+#: model:ir.model,name:website_sale_hide_price.model_website
+msgid "Website"
+msgstr "Sitio web"
+
+#. module: website_sale_hide_price
+#: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price
+msgid "Website show prices"
+msgstr "Mostrar precios en el sitio web"

--- a/website_sale_hide_price/i18n/es.po
+++ b/website_sale_hide_price/i18n/es.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * website_sale_hide_price
-# 
+#
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
@@ -12,15 +12,15 @@ msgstr ""
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
 "Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
-msgid "Partner"
+msgid "Contact"
 msgstr ""
 
 #. module: website_sale_hide_price
@@ -36,5 +36,5 @@ msgstr "Sitio web"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price
-msgid "Website show price"
+msgid "Website Show Price"
 msgstr ""

--- a/website_sale_hide_price/i18n/es_AR.po
+++ b/website_sale_hide_price/i18n/es_AR.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * website_sale_hide_price
-# 
+#
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
@@ -11,16 +11,17 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Spanish (Argentina) (https://www.transifex.com/oca/teams/23907/es_AR/)\n"
+"Language-Team: Spanish (Argentina) (https://www.transifex.com/oca/"
+"teams/23907/es_AR/)\n"
+"Language: es_AR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es_AR\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
-msgid "Partner"
+msgid "Contact"
 msgstr ""
 
 #. module: website_sale_hide_price
@@ -36,5 +37,5 @@ msgstr "Sitio web"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price
-msgid "Website show price"
+msgid "Website Show Price"
 msgstr ""

--- a/website_sale_hide_price/i18n/es_AR.po
+++ b/website_sale_hide_price/i18n/es_AR.po
@@ -11,11 +11,11 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"Language-Team: Spanish (Argentina) (https://www.transifex.com/oca/teams/23907/es_AR/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
+"Language: es_AR\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: website_sale_hide_price

--- a/website_sale_hide_price/i18n/es_CL.po
+++ b/website_sale_hide_price/i18n/es_CL.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * website_sale_hide_price
-# 
+#
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
@@ -11,16 +11,17 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Spanish (Chile) (https://www.transifex.com/oca/teams/23907/es_CL/)\n"
+"Language-Team: Spanish (Chile) (https://www.transifex.com/oca/teams/23907/"
+"es_CL/)\n"
+"Language: es_CL\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es_CL\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
-msgid "Partner"
+msgid "Contact"
 msgstr ""
 
 #. module: website_sale_hide_price
@@ -36,5 +37,5 @@ msgstr "Sitio Web"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price
-msgid "Website show price"
+msgid "Website Show Price"
 msgstr ""

--- a/website_sale_hide_price/i18n/es_CL.po
+++ b/website_sale_hide_price/i18n/es_CL.po
@@ -11,11 +11,11 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"Language-Team: Spanish (Chile) (https://www.transifex.com/oca/teams/23907/es_CL/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
+"Language: es_CL\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: website_sale_hide_price
@@ -32,7 +32,7 @@ msgstr ""
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_website
 msgid "Website"
-msgstr "Sitio web"
+msgstr "Sitio Web"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price

--- a/website_sale_hide_price/i18n/es_CO.po
+++ b/website_sale_hide_price/i18n/es_CO.po
@@ -11,11 +11,11 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"Language-Team: Spanish (Colombia) (https://www.transifex.com/oca/teams/23907/es_CO/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
+"Language: es_CO\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: website_sale_hide_price
@@ -32,7 +32,7 @@ msgstr ""
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_website
 msgid "Website"
-msgstr "Sitio web"
+msgstr "Sitio Web"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price

--- a/website_sale_hide_price/i18n/es_CO.po
+++ b/website_sale_hide_price/i18n/es_CO.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * website_sale_hide_price
-# 
+#
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
@@ -11,16 +11,17 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Spanish (Colombia) (https://www.transifex.com/oca/teams/23907/es_CO/)\n"
+"Language-Team: Spanish (Colombia) (https://www.transifex.com/oca/teams/23907/"
+"es_CO/)\n"
+"Language: es_CO\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es_CO\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
-msgid "Partner"
+msgid "Contact"
 msgstr ""
 
 #. module: website_sale_hide_price
@@ -36,5 +37,5 @@ msgstr "Sitio Web"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price
-msgid "Website show price"
+msgid "Website Show Price"
 msgstr ""

--- a/website_sale_hide_price/i18n/es_CR.po
+++ b/website_sale_hide_price/i18n/es_CR.po
@@ -11,11 +11,11 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"Language-Team: Spanish (Costa Rica) (https://www.transifex.com/oca/teams/23907/es_CR/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
+"Language: es_CR\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: website_sale_hide_price

--- a/website_sale_hide_price/i18n/es_CR.po
+++ b/website_sale_hide_price/i18n/es_CR.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * website_sale_hide_price
-# 
+#
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
@@ -11,16 +11,17 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Spanish (Costa Rica) (https://www.transifex.com/oca/teams/23907/es_CR/)\n"
+"Language-Team: Spanish (Costa Rica) (https://www.transifex.com/oca/"
+"teams/23907/es_CR/)\n"
+"Language: es_CR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es_CR\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
-msgid "Partner"
+msgid "Contact"
 msgstr ""
 
 #. module: website_sale_hide_price
@@ -36,5 +37,5 @@ msgstr "Sitio web"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price
-msgid "Website show price"
+msgid "Website Show Price"
 msgstr ""

--- a/website_sale_hide_price/i18n/es_DO.po
+++ b/website_sale_hide_price/i18n/es_DO.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * website_sale_hide_price
-# 
+#
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
@@ -11,16 +11,17 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Spanish (Dominican Republic) (https://www.transifex.com/oca/teams/23907/es_DO/)\n"
+"Language-Team: Spanish (Dominican Republic) (https://www.transifex.com/oca/"
+"teams/23907/es_DO/)\n"
+"Language: es_DO\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es_DO\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
-msgid "Partner"
+msgid "Contact"
 msgstr ""
 
 #. module: website_sale_hide_price
@@ -36,5 +37,5 @@ msgstr "Sitio web"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price
-msgid "Website show price"
+msgid "Website Show Price"
 msgstr ""

--- a/website_sale_hide_price/i18n/es_DO.po
+++ b/website_sale_hide_price/i18n/es_DO.po
@@ -11,11 +11,11 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"Language-Team: Spanish (Dominican Republic) (https://www.transifex.com/oca/teams/23907/es_DO/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
+"Language: es_DO\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: website_sale_hide_price

--- a/website_sale_hide_price/i18n/es_EC.po
+++ b/website_sale_hide_price/i18n/es_EC.po
@@ -11,11 +11,11 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"Language-Team: Spanish (Ecuador) (https://www.transifex.com/oca/teams/23907/es_EC/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
+"Language: es_EC\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: website_sale_hide_price

--- a/website_sale_hide_price/i18n/es_EC.po
+++ b/website_sale_hide_price/i18n/es_EC.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * website_sale_hide_price
-# 
+#
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
@@ -11,16 +11,17 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Spanish (Ecuador) (https://www.transifex.com/oca/teams/23907/es_EC/)\n"
+"Language-Team: Spanish (Ecuador) (https://www.transifex.com/oca/teams/23907/"
+"es_EC/)\n"
+"Language: es_EC\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es_EC\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
-msgid "Partner"
+msgid "Contact"
 msgstr ""
 
 #. module: website_sale_hide_price
@@ -36,5 +37,5 @@ msgstr "Sitio web"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price
-msgid "Website show price"
+msgid "Website Show Price"
 msgstr ""

--- a/website_sale_hide_price/i18n/es_MX.po
+++ b/website_sale_hide_price/i18n/es_MX.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * website_sale_hide_price
-# 
+#
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
@@ -11,16 +11,17 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Spanish (Mexico) (https://www.transifex.com/oca/teams/23907/es_MX/)\n"
+"Language-Team: Spanish (Mexico) (https://www.transifex.com/oca/teams/23907/"
+"es_MX/)\n"
+"Language: es_MX\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es_MX\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
-msgid "Partner"
+msgid "Contact"
 msgstr ""
 
 #. module: website_sale_hide_price
@@ -36,5 +37,5 @@ msgstr "Sitio Web"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price
-msgid "Website show price"
+msgid "Website Show Price"
 msgstr ""

--- a/website_sale_hide_price/i18n/es_MX.po
+++ b/website_sale_hide_price/i18n/es_MX.po
@@ -11,11 +11,11 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"Language-Team: Spanish (Mexico) (https://www.transifex.com/oca/teams/23907/es_MX/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
+"Language: es_MX\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: website_sale_hide_price
@@ -32,7 +32,7 @@ msgstr ""
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_website
 msgid "Website"
-msgstr "Sitio web"
+msgstr "Sitio Web"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price

--- a/website_sale_hide_price/i18n/es_PE.po
+++ b/website_sale_hide_price/i18n/es_PE.po
@@ -11,11 +11,11 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"Language-Team: Spanish (Peru) (https://www.transifex.com/oca/teams/23907/es_PE/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
+"Language: es_PE\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: website_sale_hide_price
@@ -32,7 +32,7 @@ msgstr ""
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_website
 msgid "Website"
-msgstr "Sitio web"
+msgstr "Sitio Web"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price

--- a/website_sale_hide_price/i18n/es_PE.po
+++ b/website_sale_hide_price/i18n/es_PE.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * website_sale_hide_price
-# 
+#
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
@@ -11,16 +11,17 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Spanish (Peru) (https://www.transifex.com/oca/teams/23907/es_PE/)\n"
+"Language-Team: Spanish (Peru) (https://www.transifex.com/oca/teams/23907/"
+"es_PE/)\n"
+"Language: es_PE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es_PE\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
-msgid "Partner"
+msgid "Contact"
 msgstr ""
 
 #. module: website_sale_hide_price
@@ -36,5 +37,5 @@ msgstr "Sitio Web"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price
-msgid "Website show price"
+msgid "Website Show Price"
 msgstr ""

--- a/website_sale_hide_price/i18n/et.po
+++ b/website_sale_hide_price/i18n/et.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * website_sale_hide_price
-# 
+#
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
@@ -12,15 +12,15 @@ msgstr ""
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
 "Language-Team: Estonian (https://www.transifex.com/oca/teams/23907/et/)\n"
+"Language: et\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: et\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
-msgid "Partner"
+msgid "Contact"
 msgstr ""
 
 #. module: website_sale_hide_price
@@ -36,5 +36,5 @@ msgstr "Veebileht"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price
-msgid "Website show price"
+msgid "Website Show Price"
 msgstr ""

--- a/website_sale_hide_price/i18n/et.po
+++ b/website_sale_hide_price/i18n/et.po
@@ -11,11 +11,11 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"Language-Team: Estonian (https://www.transifex.com/oca/teams/23907/et/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
+"Language: et\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: website_sale_hide_price
@@ -32,7 +32,7 @@ msgstr ""
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_website
 msgid "Website"
-msgstr "Sitio web"
+msgstr "Veebileht"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price

--- a/website_sale_hide_price/i18n/eu.po
+++ b/website_sale_hide_price/i18n/eu.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * website_sale_hide_price
-# 
+#
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
@@ -12,15 +12,15 @@ msgstr ""
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
 "Language-Team: Basque (https://www.transifex.com/oca/teams/23907/eu/)\n"
+"Language: eu\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: eu\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
-msgid "Partner"
+msgid "Contact"
 msgstr ""
 
 #. module: website_sale_hide_price
@@ -36,5 +36,5 @@ msgstr "Webgunea"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price
-msgid "Website show price"
+msgid "Website Show Price"
 msgstr ""

--- a/website_sale_hide_price/i18n/eu.po
+++ b/website_sale_hide_price/i18n/eu.po
@@ -11,11 +11,11 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"Language-Team: Basque (https://www.transifex.com/oca/teams/23907/eu/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
+"Language: eu\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: website_sale_hide_price
@@ -32,7 +32,7 @@ msgstr ""
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_website
 msgid "Website"
-msgstr "Sitio web"
+msgstr "Webgunea"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price

--- a/website_sale_hide_price/i18n/fa.po
+++ b/website_sale_hide_price/i18n/fa.po
@@ -9,25 +9,26 @@ msgstr ""
 "Project-Id-Version: Odoo Server 10.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
-"PO-Revision-Date: 2017-12-16 01:57+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"PO-Revision-Date: 2018-07-21 10:13+0000\n"
+"Last-Translator: derKonig <fshahy@gmail.com>\n"
 "Language-Team: Persian (https://www.transifex.com/oca/teams/23907/fa/)\n"
 "Language: fa\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Weblate 3.0.1\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
 msgid "Contact"
-msgstr ""
+msgstr "تماس"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_res_partner_website_show_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_res_users_website_show_price
 msgid "Show prices on website"
-msgstr ""
+msgstr "نمایش قیمت ها در سایت"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_website
@@ -37,4 +38,4 @@ msgstr "تارنما"
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price
 msgid "Website Show Price"
-msgstr ""
+msgstr "نمایش قیمت در سایت"

--- a/website_sale_hide_price/i18n/fa.po
+++ b/website_sale_hide_price/i18n/fa.po
@@ -11,12 +11,12 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"Language-Team: Persian (https://www.transifex.com/oca/teams/23907/fa/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: fa\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
@@ -32,7 +32,7 @@ msgstr ""
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_website
 msgid "Website"
-msgstr "Sitio web"
+msgstr "تارنما"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price

--- a/website_sale_hide_price/i18n/fa.po
+++ b/website_sale_hide_price/i18n/fa.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * website_sale_hide_price
-# 
+#
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
@@ -12,15 +12,15 @@ msgstr ""
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
 "Language-Team: Persian (https://www.transifex.com/oca/teams/23907/fa/)\n"
+"Language: fa\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: fa\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
-msgid "Partner"
+msgid "Contact"
 msgstr ""
 
 #. module: website_sale_hide_price
@@ -36,5 +36,5 @@ msgstr "تارنما"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price
-msgid "Website show price"
+msgid "Website Show Price"
 msgstr ""

--- a/website_sale_hide_price/i18n/fi.po
+++ b/website_sale_hide_price/i18n/fi.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * website_sale_hide_price
-# 
+#
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
@@ -12,15 +12,15 @@ msgstr ""
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
 "Language-Team: Finnish (https://www.transifex.com/oca/teams/23907/fi/)\n"
+"Language: fi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: fi\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
-msgid "Partner"
+msgid "Contact"
 msgstr ""
 
 #. module: website_sale_hide_price
@@ -36,5 +36,5 @@ msgstr "Verkkosivut"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price
-msgid "Website show price"
+msgid "Website Show Price"
 msgstr ""

--- a/website_sale_hide_price/i18n/fi.po
+++ b/website_sale_hide_price/i18n/fi.po
@@ -11,11 +11,11 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"Language-Team: Finnish (https://www.transifex.com/oca/teams/23907/fi/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
+"Language: fi\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: website_sale_hide_price
@@ -32,7 +32,7 @@ msgstr ""
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_website
 msgid "Website"
-msgstr "Sitio web"
+msgstr "Verkkosivut"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price

--- a/website_sale_hide_price/i18n/fr.po
+++ b/website_sale_hide_price/i18n/fr.po
@@ -11,12 +11,12 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"Language-Team: French (https://www.transifex.com/oca/teams/23907/fr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: fr\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
@@ -32,7 +32,7 @@ msgstr ""
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_website
 msgid "Website"
-msgstr "Sitio web"
+msgstr "Site Internet"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price

--- a/website_sale_hide_price/i18n/fr.po
+++ b/website_sale_hide_price/i18n/fr.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * website_sale_hide_price
-# 
+#
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
@@ -12,15 +12,15 @@ msgstr ""
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
 "Language-Team: French (https://www.transifex.com/oca/teams/23907/fr/)\n"
+"Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: fr\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
-msgid "Partner"
+msgid "Contact"
 msgstr ""
 
 #. module: website_sale_hide_price
@@ -36,5 +36,5 @@ msgstr "Site Internet"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price
-msgid "Website show price"
+msgid "Website Show Price"
 msgstr ""

--- a/website_sale_hide_price/i18n/gl.po
+++ b/website_sale_hide_price/i18n/gl.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * website_sale_hide_price
-# 
+#
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
@@ -12,15 +12,15 @@ msgstr ""
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
 "Language-Team: Galician (https://www.transifex.com/oca/teams/23907/gl/)\n"
+"Language: gl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: gl\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
-msgid "Partner"
+msgid "Contact"
 msgstr ""
 
 #. module: website_sale_hide_price
@@ -36,5 +36,5 @@ msgstr "Sitio web"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price
-msgid "Website show price"
+msgid "Website Show Price"
 msgstr ""

--- a/website_sale_hide_price/i18n/gl.po
+++ b/website_sale_hide_price/i18n/gl.po
@@ -11,11 +11,11 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"Language-Team: Galician (https://www.transifex.com/oca/teams/23907/gl/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
+"Language: gl\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: website_sale_hide_price

--- a/website_sale_hide_price/i18n/he.po
+++ b/website_sale_hide_price/i18n/he.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * website_sale_hide_price
-# 
+#
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
@@ -12,15 +12,15 @@ msgstr ""
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
 "Language-Team: Hebrew (https://www.transifex.com/oca/teams/23907/he/)\n"
+"Language: he\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: he\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
-msgid "Partner"
+msgid "Contact"
 msgstr ""
 
 #. module: website_sale_hide_price
@@ -36,5 +36,5 @@ msgstr "אתר"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price
-msgid "Website show price"
+msgid "Website Show Price"
 msgstr ""

--- a/website_sale_hide_price/i18n/he.po
+++ b/website_sale_hide_price/i18n/he.po
@@ -11,11 +11,11 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"Language-Team: Hebrew (https://www.transifex.com/oca/teams/23907/he/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
+"Language: he\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: website_sale_hide_price
@@ -32,7 +32,7 @@ msgstr ""
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_website
 msgid "Website"
-msgstr "Sitio web"
+msgstr "אתר"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price

--- a/website_sale_hide_price/i18n/hr.po
+++ b/website_sale_hide_price/i18n/hr.po
@@ -11,12 +11,12 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"Language-Team: Croatian (https://www.transifex.com/oca/teams/23907/hr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: hr\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
@@ -32,7 +32,7 @@ msgstr ""
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_website
 msgid "Website"
-msgstr "Sitio web"
+msgstr "Web stranice"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price

--- a/website_sale_hide_price/i18n/hr.po
+++ b/website_sale_hide_price/i18n/hr.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * website_sale_hide_price
-# 
+#
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
@@ -12,15 +12,16 @@ msgstr ""
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
 "Language-Team: Croatian (https://www.transifex.com/oca/teams/23907/hr/)\n"
+"Language: hr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: hr\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
-msgid "Partner"
+msgid "Contact"
 msgstr ""
 
 #. module: website_sale_hide_price
@@ -36,5 +37,5 @@ msgstr "Web stranice"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price
-msgid "Website show price"
+msgid "Website Show Price"
 msgstr ""

--- a/website_sale_hide_price/i18n/hr_HR.po
+++ b/website_sale_hide_price/i18n/hr_HR.po
@@ -11,12 +11,12 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"Language-Team: Croatian (Croatia) (https://www.transifex.com/oca/teams/23907/hr_HR/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: hr_HR\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
@@ -32,7 +32,7 @@ msgstr ""
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_website
 msgid "Website"
-msgstr "Sitio web"
+msgstr "Webstranice"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price

--- a/website_sale_hide_price/i18n/hr_HR.po
+++ b/website_sale_hide_price/i18n/hr_HR.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * website_sale_hide_price
-# 
+#
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
@@ -11,16 +11,18 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Croatian (Croatia) (https://www.transifex.com/oca/teams/23907/hr_HR/)\n"
+"Language-Team: Croatian (Croatia) (https://www.transifex.com/oca/teams/23907/"
+"hr_HR/)\n"
+"Language: hr_HR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: hr_HR\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
-msgid "Partner"
+msgid "Contact"
 msgstr ""
 
 #. module: website_sale_hide_price
@@ -36,5 +38,5 @@ msgstr "Webstranice"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price
-msgid "Website show price"
+msgid "Website Show Price"
 msgstr ""

--- a/website_sale_hide_price/i18n/hu.po
+++ b/website_sale_hide_price/i18n/hu.po
@@ -11,11 +11,11 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"Language-Team: Hungarian (https://www.transifex.com/oca/teams/23907/hu/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
+"Language: hu\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: website_sale_hide_price
@@ -32,7 +32,7 @@ msgstr ""
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_website
 msgid "Website"
-msgstr "Sitio web"
+msgstr "Honlap"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price

--- a/website_sale_hide_price/i18n/hu.po
+++ b/website_sale_hide_price/i18n/hu.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * website_sale_hide_price
-# 
+#
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
@@ -12,15 +12,15 @@ msgstr ""
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
 "Language-Team: Hungarian (https://www.transifex.com/oca/teams/23907/hu/)\n"
+"Language: hu\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: hu\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
-msgid "Partner"
+msgid "Contact"
 msgstr ""
 
 #. module: website_sale_hide_price
@@ -36,5 +36,5 @@ msgstr "Honlap"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price
-msgid "Website show price"
+msgid "Website Show Price"
 msgstr ""

--- a/website_sale_hide_price/i18n/id.po
+++ b/website_sale_hide_price/i18n/id.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * website_sale_hide_price
-# 
+#
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
@@ -12,15 +12,15 @@ msgstr ""
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
 "Language-Team: Indonesian (https://www.transifex.com/oca/teams/23907/id/)\n"
+"Language: id\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: id\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
-msgid "Partner"
+msgid "Contact"
 msgstr ""
 
 #. module: website_sale_hide_price
@@ -36,5 +36,5 @@ msgstr "Situs Web"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price
-msgid "Website show price"
+msgid "Website Show Price"
 msgstr ""

--- a/website_sale_hide_price/i18n/id.po
+++ b/website_sale_hide_price/i18n/id.po
@@ -11,12 +11,12 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"Language-Team: Indonesian (https://www.transifex.com/oca/teams/23907/id/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: id\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
@@ -32,7 +32,7 @@ msgstr ""
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_website
 msgid "Website"
-msgstr "Sitio web"
+msgstr "Situs Web"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price

--- a/website_sale_hide_price/i18n/it.po
+++ b/website_sale_hide_price/i18n/it.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * website_sale_hide_price
-# 
+#
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
@@ -12,15 +12,15 @@ msgstr ""
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
 "Language-Team: Italian (https://www.transifex.com/oca/teams/23907/it/)\n"
+"Language: it\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: it\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
-msgid "Partner"
+msgid "Contact"
 msgstr ""
 
 #. module: website_sale_hide_price
@@ -36,5 +36,5 @@ msgstr "Sito"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price
-msgid "Website show price"
+msgid "Website Show Price"
 msgstr ""

--- a/website_sale_hide_price/i18n/it.po
+++ b/website_sale_hide_price/i18n/it.po
@@ -11,11 +11,11 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"Language-Team: Italian (https://www.transifex.com/oca/teams/23907/it/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
+"Language: it\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: website_sale_hide_price
@@ -32,7 +32,7 @@ msgstr ""
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_website
 msgid "Website"
-msgstr "Sitio web"
+msgstr "Sito"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price

--- a/website_sale_hide_price/i18n/ja.po
+++ b/website_sale_hide_price/i18n/ja.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * website_sale_hide_price
-# 
+#
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
@@ -12,15 +12,15 @@ msgstr ""
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
 "Language-Team: Japanese (https://www.transifex.com/oca/teams/23907/ja/)\n"
+"Language: ja\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: ja\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
-msgid "Partner"
+msgid "Contact"
 msgstr ""
 
 #. module: website_sale_hide_price
@@ -36,5 +36,5 @@ msgstr "ウェブサイト"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price
-msgid "Website show price"
+msgid "Website Show Price"
 msgstr ""

--- a/website_sale_hide_price/i18n/ja.po
+++ b/website_sale_hide_price/i18n/ja.po
@@ -11,12 +11,12 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"Language-Team: Japanese (https://www.transifex.com/oca/teams/23907/ja/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: ja\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
@@ -32,7 +32,7 @@ msgstr ""
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_website
 msgid "Website"
-msgstr "Sitio web"
+msgstr "ウェブサイト"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price

--- a/website_sale_hide_price/i18n/ko.po
+++ b/website_sale_hide_price/i18n/ko.po
@@ -11,12 +11,12 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"Language-Team: Korean (https://www.transifex.com/oca/teams/23907/ko/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: ko\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
@@ -32,7 +32,7 @@ msgstr ""
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_website
 msgid "Website"
-msgstr "Sitio web"
+msgstr "웹사이트"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price

--- a/website_sale_hide_price/i18n/ko.po
+++ b/website_sale_hide_price/i18n/ko.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * website_sale_hide_price
-# 
+#
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
@@ -12,15 +12,15 @@ msgstr ""
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
 "Language-Team: Korean (https://www.transifex.com/oca/teams/23907/ko/)\n"
+"Language: ko\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: ko\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
-msgid "Partner"
+msgid "Contact"
 msgstr ""
 
 #. module: website_sale_hide_price
@@ -36,5 +36,5 @@ msgstr "웹사이트"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price
-msgid "Website show price"
+msgid "Website Show Price"
 msgstr ""

--- a/website_sale_hide_price/i18n/lt.po
+++ b/website_sale_hide_price/i18n/lt.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * website_sale_hide_price
-# 
+#
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
@@ -12,15 +12,16 @@ msgstr ""
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
 "Language-Team: Lithuanian (https://www.transifex.com/oca/teams/23907/lt/)\n"
+"Language: lt\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: lt\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n"
+"%100<10 || n%100>=20) ? 1 : 2);\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
-msgid "Partner"
+msgid "Contact"
 msgstr ""
 
 #. module: website_sale_hide_price
@@ -36,5 +37,5 @@ msgstr "Tinklapis"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price
-msgid "Website show price"
+msgid "Website Show Price"
 msgstr ""

--- a/website_sale_hide_price/i18n/lt.po
+++ b/website_sale_hide_price/i18n/lt.po
@@ -11,12 +11,12 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"Language-Team: Lithuanian (https://www.transifex.com/oca/teams/23907/lt/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: lt\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
@@ -32,7 +32,7 @@ msgstr ""
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_website
 msgid "Website"
-msgstr "Sitio web"
+msgstr "Tinklapis"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price

--- a/website_sale_hide_price/i18n/lv.po
+++ b/website_sale_hide_price/i18n/lv.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * website_sale_hide_price
-# 
+#
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
@@ -12,15 +12,16 @@ msgstr ""
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
 "Language-Team: Latvian (https://www.transifex.com/oca/teams/23907/lv/)\n"
+"Language: lv\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: lv\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n != 0 ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n != 0 ? 1 : "
+"2);\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
-msgid "Partner"
+msgid "Contact"
 msgstr ""
 
 #. module: website_sale_hide_price
@@ -36,5 +37,5 @@ msgstr "Tīkla vietne"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price
-msgid "Website show price"
+msgid "Website Show Price"
 msgstr ""

--- a/website_sale_hide_price/i18n/lv.po
+++ b/website_sale_hide_price/i18n/lv.po
@@ -11,12 +11,12 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"Language-Team: Latvian (https://www.transifex.com/oca/teams/23907/lv/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: lv\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n != 0 ? 1 : 2);\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
@@ -32,7 +32,7 @@ msgstr ""
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_website
 msgid "Website"
-msgstr "Sitio web"
+msgstr "Tīkla vietne"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price

--- a/website_sale_hide_price/i18n/mk.po
+++ b/website_sale_hide_price/i18n/mk.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * website_sale_hide_price
-# 
+#
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
@@ -12,15 +12,15 @@ msgstr ""
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
 "Language-Team: Macedonian (https://www.transifex.com/oca/teams/23907/mk/)\n"
+"Language: mk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: mk\n"
 "Plural-Forms: nplurals=2; plural=(n % 10 == 1 && n % 100 != 11) ? 0 : 1;\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
-msgid "Partner"
+msgid "Contact"
 msgstr ""
 
 #. module: website_sale_hide_price
@@ -36,5 +36,5 @@ msgstr "Вебсајт"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price
-msgid "Website show price"
+msgid "Website Show Price"
 msgstr ""

--- a/website_sale_hide_price/i18n/mk.po
+++ b/website_sale_hide_price/i18n/mk.po
@@ -11,12 +11,12 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"Language-Team: Macedonian (https://www.transifex.com/oca/teams/23907/mk/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: mk\n"
+"Plural-Forms: nplurals=2; plural=(n % 10 == 1 && n % 100 != 11) ? 0 : 1;\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
@@ -32,7 +32,7 @@ msgstr ""
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_website
 msgid "Website"
-msgstr "Sitio web"
+msgstr "Вебсајт"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price

--- a/website_sale_hide_price/i18n/mn.po
+++ b/website_sale_hide_price/i18n/mn.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * website_sale_hide_price
-# 
+#
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
@@ -12,15 +12,15 @@ msgstr ""
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
 "Language-Team: Mongolian (https://www.transifex.com/oca/teams/23907/mn/)\n"
+"Language: mn\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: mn\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
-msgid "Partner"
+msgid "Contact"
 msgstr ""
 
 #. module: website_sale_hide_price
@@ -36,5 +36,5 @@ msgstr "Вэбсайт"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price
-msgid "Website show price"
+msgid "Website Show Price"
 msgstr ""

--- a/website_sale_hide_price/i18n/mn.po
+++ b/website_sale_hide_price/i18n/mn.po
@@ -11,11 +11,11 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"Language-Team: Mongolian (https://www.transifex.com/oca/teams/23907/mn/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
+"Language: mn\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: website_sale_hide_price
@@ -32,7 +32,7 @@ msgstr ""
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_website
 msgid "Website"
-msgstr "Sitio web"
+msgstr "Вэбсайт"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price

--- a/website_sale_hide_price/i18n/nb.po
+++ b/website_sale_hide_price/i18n/nb.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * website_sale_hide_price
-# 
+#
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
@@ -11,16 +11,17 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Norwegian Bokmål (https://www.transifex.com/oca/teams/23907/nb/)\n"
+"Language-Team: Norwegian Bokmål (https://www.transifex.com/oca/teams/23907/"
+"nb/)\n"
+"Language: nb\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: nb\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
-msgid "Partner"
+msgid "Contact"
 msgstr ""
 
 #. module: website_sale_hide_price
@@ -36,5 +37,5 @@ msgstr "Nettsted"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price
-msgid "Website show price"
+msgid "Website Show Price"
 msgstr ""

--- a/website_sale_hide_price/i18n/nb.po
+++ b/website_sale_hide_price/i18n/nb.po
@@ -11,11 +11,11 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"Language-Team: Norwegian Bokmål (https://www.transifex.com/oca/teams/23907/nb/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
+"Language: nb\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: website_sale_hide_price
@@ -32,7 +32,7 @@ msgstr ""
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_website
 msgid "Website"
-msgstr "Sitio web"
+msgstr "Nettsted"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price

--- a/website_sale_hide_price/i18n/nl.po
+++ b/website_sale_hide_price/i18n/nl.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * website_sale_hide_price
-# 
+#
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
@@ -12,15 +12,15 @@ msgstr ""
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
 "Language-Team: Dutch (https://www.transifex.com/oca/teams/23907/nl/)\n"
+"Language: nl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: nl\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
-msgid "Partner"
+msgid "Contact"
 msgstr ""
 
 #. module: website_sale_hide_price
@@ -36,5 +36,5 @@ msgstr "Website"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price
-msgid "Website show price"
+msgid "Website Show Price"
 msgstr ""

--- a/website_sale_hide_price/i18n/nl.po
+++ b/website_sale_hide_price/i18n/nl.po
@@ -11,11 +11,11 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"Language-Team: Dutch (https://www.transifex.com/oca/teams/23907/nl/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
+"Language: nl\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: website_sale_hide_price
@@ -32,7 +32,7 @@ msgstr ""
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_website
 msgid "Website"
-msgstr "Sitio web"
+msgstr "Website"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price

--- a/website_sale_hide_price/i18n/nl_NL.po
+++ b/website_sale_hide_price/i18n/nl_NL.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * website_sale_hide_price
-# 
+#
 # Translators:
 # Peter Hageman <hageman.p@gmail.com>, 2017
 msgid ""
@@ -11,16 +11,17 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: Peter Hageman <hageman.p@gmail.com>, 2017\n"
-"Language-Team: Dutch (Netherlands) (https://www.transifex.com/oca/teams/23907/nl_NL/)\n"
+"Language-Team: Dutch (Netherlands) (https://www.transifex.com/oca/"
+"teams/23907/nl_NL/)\n"
+"Language: nl_NL\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: nl_NL\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
-msgid "Partner"
+msgid "Contact"
 msgstr ""
 
 #. module: website_sale_hide_price
@@ -36,5 +37,5 @@ msgstr "Website"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price
-msgid "Website show price"
+msgid "Website Show Price"
 msgstr ""

--- a/website_sale_hide_price/i18n/nl_NL.po
+++ b/website_sale_hide_price/i18n/nl_NL.po
@@ -3,19 +3,19 @@
 # * website_sale_hide_price
 # 
 # Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2017
+# Peter Hageman <hageman.p@gmail.com>, 2017
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 10.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"Last-Translator: Peter Hageman <hageman.p@gmail.com>, 2017\n"
+"Language-Team: Dutch (Netherlands) (https://www.transifex.com/oca/teams/23907/nl_NL/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
+"Language: nl_NL\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: website_sale_hide_price
@@ -32,7 +32,7 @@ msgstr ""
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_website
 msgid "Website"
-msgstr "Sitio web"
+msgstr "Website"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price

--- a/website_sale_hide_price/i18n/pl.po
+++ b/website_sale_hide_price/i18n/pl.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * website_sale_hide_price
-# 
+#
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
@@ -12,15 +12,17 @@ msgstr ""
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
 "Language-Team: Polish (https://www.transifex.com/oca/teams/23907/pl/)\n"
+"Language: pl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: pl\n"
-"Plural-Forms: nplurals=4; plural=(n==1 ? 0 : (n%10>=2 && n%10<=4) && (n%100<12 || n%100>14) ? 1 : n!=1 && (n%10>=0 && n%10<=1) || (n%10>=5 && n%10<=9) || (n%100>=12 && n%100<=14) ? 2 : 3);\n"
+"Plural-Forms: nplurals=4; plural=(n==1 ? 0 : (n%10>=2 && n%10<=4) && (n"
+"%100<12 || n%100>14) ? 1 : n!=1 && (n%10>=0 && n%10<=1) || (n%10>=5 && n"
+"%10<=9) || (n%100>=12 && n%100<=14) ? 2 : 3);\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
-msgid "Partner"
+msgid "Contact"
 msgstr ""
 
 #. module: website_sale_hide_price
@@ -36,5 +38,5 @@ msgstr "Strona WWW"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price
-msgid "Website show price"
+msgid "Website Show Price"
 msgstr ""

--- a/website_sale_hide_price/i18n/pl.po
+++ b/website_sale_hide_price/i18n/pl.po
@@ -11,12 +11,12 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"Language-Team: Polish (https://www.transifex.com/oca/teams/23907/pl/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: pl\n"
+"Plural-Forms: nplurals=4; plural=(n==1 ? 0 : (n%10>=2 && n%10<=4) && (n%100<12 || n%100>14) ? 1 : n!=1 && (n%10>=0 && n%10<=1) || (n%10>=5 && n%10<=9) || (n%100>=12 && n%100<=14) ? 2 : 3);\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
@@ -32,7 +32,7 @@ msgstr ""
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_website
 msgid "Website"
-msgstr "Sitio web"
+msgstr "Strona WWW"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price

--- a/website_sale_hide_price/i18n/pt_BR.po
+++ b/website_sale_hide_price/i18n/pt_BR.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * website_sale_hide_price
-# 
+#
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
@@ -11,16 +11,17 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Portuguese (Brazil) (https://www.transifex.com/oca/teams/23907/pt_BR/)\n"
+"Language-Team: Portuguese (Brazil) (https://www.transifex.com/oca/"
+"teams/23907/pt_BR/)\n"
+"Language: pt_BR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: pt_BR\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
-msgid "Partner"
+msgid "Contact"
 msgstr ""
 
 #. module: website_sale_hide_price
@@ -36,5 +37,5 @@ msgstr "Website"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price
-msgid "Website show price"
+msgid "Website Show Price"
 msgstr ""

--- a/website_sale_hide_price/i18n/pt_BR.po
+++ b/website_sale_hide_price/i18n/pt_BR.po
@@ -11,12 +11,12 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"Language-Team: Portuguese (Brazil) (https://www.transifex.com/oca/teams/23907/pt_BR/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: pt_BR\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
@@ -32,7 +32,7 @@ msgstr ""
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_website
 msgid "Website"
-msgstr "Sitio web"
+msgstr "Website"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price

--- a/website_sale_hide_price/i18n/ru.po
+++ b/website_sale_hide_price/i18n/ru.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * website_sale_hide_price
-# 
+#
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
@@ -12,15 +12,17 @@ msgstr ""
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
 "Language-Team: Russian (https://www.transifex.com/oca/teams/23907/ru/)\n"
+"Language: ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: ru\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n"
+"%100>=11 && n%100<=14)? 2 : 3);\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
-msgid "Partner"
+msgid "Contact"
 msgstr ""
 
 #. module: website_sale_hide_price
@@ -36,5 +38,5 @@ msgstr "Сайт"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price
-msgid "Website show price"
+msgid "Website Show Price"
 msgstr ""

--- a/website_sale_hide_price/i18n/ru.po
+++ b/website_sale_hide_price/i18n/ru.po
@@ -11,12 +11,12 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"Language-Team: Russian (https://www.transifex.com/oca/teams/23907/ru/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: ru\n"
+"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
@@ -32,7 +32,7 @@ msgstr ""
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_website
 msgid "Website"
-msgstr "Sitio web"
+msgstr "Сайт"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price

--- a/website_sale_hide_price/i18n/sk.po
+++ b/website_sale_hide_price/i18n/sk.po
@@ -11,12 +11,12 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"Language-Team: Slovak (https://www.transifex.com/oca/teams/23907/sk/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: sk\n"
+"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
@@ -32,7 +32,7 @@ msgstr ""
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_website
 msgid "Website"
-msgstr "Sitio web"
+msgstr "Webová stránka"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price

--- a/website_sale_hide_price/i18n/sk.po
+++ b/website_sale_hide_price/i18n/sk.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * website_sale_hide_price
-# 
+#
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
@@ -12,15 +12,15 @@ msgstr ""
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
 "Language-Team: Slovak (https://www.transifex.com/oca/teams/23907/sk/)\n"
+"Language: sk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: sk\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
-msgid "Partner"
+msgid "Contact"
 msgstr ""
 
 #. module: website_sale_hide_price
@@ -36,5 +36,5 @@ msgstr "Webová stránka"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price
-msgid "Website show price"
+msgid "Website Show Price"
 msgstr ""

--- a/website_sale_hide_price/i18n/sl.po
+++ b/website_sale_hide_price/i18n/sl.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * website_sale_hide_price
-# 
+#
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
@@ -12,15 +12,16 @@ msgstr ""
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
 "Language-Team: Slovenian (https://www.transifex.com/oca/teams/23907/sl/)\n"
+"Language: sl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: sl\n"
-"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3);\n"
+"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n"
+"%100==4 ? 2 : 3);\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
-msgid "Partner"
+msgid "Contact"
 msgstr ""
 
 #. module: website_sale_hide_price
@@ -36,5 +37,5 @@ msgstr "Spletna stran"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price
-msgid "Website show price"
+msgid "Website Show Price"
 msgstr ""

--- a/website_sale_hide_price/i18n/sl.po
+++ b/website_sale_hide_price/i18n/sl.po
@@ -11,12 +11,12 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"Language-Team: Slovenian (https://www.transifex.com/oca/teams/23907/sl/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: sl\n"
+"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3);\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
@@ -32,7 +32,7 @@ msgstr ""
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_website
 msgid "Website"
-msgstr "Sitio web"
+msgstr "Spletna stran"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price

--- a/website_sale_hide_price/i18n/sr.po
+++ b/website_sale_hide_price/i18n/sr.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * website_sale_hide_price
-# 
+#
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
@@ -12,15 +12,16 @@ msgstr ""
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
 "Language-Team: Serbian (https://www.transifex.com/oca/teams/23907/sr/)\n"
+"Language: sr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: sr\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
-msgid "Partner"
+msgid "Contact"
 msgstr ""
 
 #. module: website_sale_hide_price
@@ -36,5 +37,5 @@ msgstr "Web stranica"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price
-msgid "Website show price"
+msgid "Website Show Price"
 msgstr ""

--- a/website_sale_hide_price/i18n/sr.po
+++ b/website_sale_hide_price/i18n/sr.po
@@ -11,12 +11,12 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"Language-Team: Serbian (https://www.transifex.com/oca/teams/23907/sr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: sr\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
@@ -32,7 +32,7 @@ msgstr ""
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_website
 msgid "Website"
-msgstr "Sitio web"
+msgstr "Web stranica"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price

--- a/website_sale_hide_price/i18n/sr@latin.po
+++ b/website_sale_hide_price/i18n/sr@latin.po
@@ -11,12 +11,12 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"Language-Team: Serbian (Latin) (https://www.transifex.com/oca/teams/23907/sr%40latin/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: sr@latin\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
@@ -32,7 +32,7 @@ msgstr ""
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_website
 msgid "Website"
-msgstr "Sitio web"
+msgstr "Internet stranica"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price

--- a/website_sale_hide_price/i18n/sr@latin.po
+++ b/website_sale_hide_price/i18n/sr@latin.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * website_sale_hide_price
-# 
+#
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
@@ -11,16 +11,18 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Serbian (Latin) (https://www.transifex.com/oca/teams/23907/sr%40latin/)\n"
+"Language-Team: Serbian (Latin) (https://www.transifex.com/oca/teams/23907/sr"
+"%40latin/)\n"
+"Language: sr@latin\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: sr@latin\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
-msgid "Partner"
+msgid "Contact"
 msgstr ""
 
 #. module: website_sale_hide_price
@@ -36,5 +38,5 @@ msgstr "Internet stranica"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price
-msgid "Website show price"
+msgid "Website Show Price"
 msgstr ""

--- a/website_sale_hide_price/i18n/sv.po
+++ b/website_sale_hide_price/i18n/sv.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * website_sale_hide_price
-# 
+#
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
@@ -12,15 +12,15 @@ msgstr ""
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
 "Language-Team: Swedish (https://www.transifex.com/oca/teams/23907/sv/)\n"
+"Language: sv\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: sv\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
-msgid "Partner"
+msgid "Contact"
 msgstr ""
 
 #. module: website_sale_hide_price
@@ -36,5 +36,5 @@ msgstr "Webbplats"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price
-msgid "Website show price"
+msgid "Website Show Price"
 msgstr ""

--- a/website_sale_hide_price/i18n/sv.po
+++ b/website_sale_hide_price/i18n/sv.po
@@ -11,11 +11,11 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"Language-Team: Swedish (https://www.transifex.com/oca/teams/23907/sv/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
+"Language: sv\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: website_sale_hide_price
@@ -32,7 +32,7 @@ msgstr ""
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_website
 msgid "Website"
-msgstr "Sitio web"
+msgstr "Webbplats"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price

--- a/website_sale_hide_price/i18n/th.po
+++ b/website_sale_hide_price/i18n/th.po
@@ -11,12 +11,12 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"Language-Team: Thai (https://www.transifex.com/oca/teams/23907/th/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: th\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
@@ -32,7 +32,7 @@ msgstr ""
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_website
 msgid "Website"
-msgstr "Sitio web"
+msgstr "เว็บไซต์"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price

--- a/website_sale_hide_price/i18n/th.po
+++ b/website_sale_hide_price/i18n/th.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * website_sale_hide_price
-# 
+#
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
@@ -12,15 +12,15 @@ msgstr ""
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
 "Language-Team: Thai (https://www.transifex.com/oca/teams/23907/th/)\n"
+"Language: th\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: th\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
-msgid "Partner"
+msgid "Contact"
 msgstr ""
 
 #. module: website_sale_hide_price
@@ -36,5 +36,5 @@ msgstr "เว็บไซต์"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price
-msgid "Website show price"
+msgid "Website Show Price"
 msgstr ""

--- a/website_sale_hide_price/i18n/tr.po
+++ b/website_sale_hide_price/i18n/tr.po
@@ -11,12 +11,12 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"Language-Team: Turkish (https://www.transifex.com/oca/teams/23907/tr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: tr\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
@@ -32,7 +32,7 @@ msgstr ""
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_website
 msgid "Website"
-msgstr "Sitio web"
+msgstr "Web Sitesi"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price

--- a/website_sale_hide_price/i18n/tr.po
+++ b/website_sale_hide_price/i18n/tr.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * website_sale_hide_price
-# 
+#
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
@@ -12,15 +12,15 @@ msgstr ""
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
 "Language-Team: Turkish (https://www.transifex.com/oca/teams/23907/tr/)\n"
+"Language: tr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: tr\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
-msgid "Partner"
+msgid "Contact"
 msgstr ""
 
 #. module: website_sale_hide_price
@@ -36,5 +36,5 @@ msgstr "Web Sitesi"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price
-msgid "Website show price"
+msgid "Website Show Price"
 msgstr ""

--- a/website_sale_hide_price/i18n/uk.po
+++ b/website_sale_hide_price/i18n/uk.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * website_sale_hide_price
-# 
+#
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
@@ -12,15 +12,16 @@ msgstr ""
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
 "Language-Team: Ukrainian (https://www.transifex.com/oca/teams/23907/uk/)\n"
+"Language: uk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: uk\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
-msgid "Partner"
+msgid "Contact"
 msgstr ""
 
 #. module: website_sale_hide_price
@@ -36,5 +37,5 @@ msgstr "Веб-сайт"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price
-msgid "Website show price"
+msgid "Website Show Price"
 msgstr ""

--- a/website_sale_hide_price/i18n/uk.po
+++ b/website_sale_hide_price/i18n/uk.po
@@ -11,12 +11,12 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"Language-Team: Ukrainian (https://www.transifex.com/oca/teams/23907/uk/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: uk\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
@@ -32,7 +32,7 @@ msgstr ""
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_website
 msgid "Website"
-msgstr "Sitio web"
+msgstr "Веб-сайт"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price

--- a/website_sale_hide_price/i18n/vi.po
+++ b/website_sale_hide_price/i18n/vi.po
@@ -11,12 +11,12 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"Language-Team: Vietnamese (https://www.transifex.com/oca/teams/23907/vi/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: vi\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
@@ -32,7 +32,7 @@ msgstr ""
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_website
 msgid "Website"
-msgstr "Sitio web"
+msgstr "Trang web"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price

--- a/website_sale_hide_price/i18n/vi.po
+++ b/website_sale_hide_price/i18n/vi.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * website_sale_hide_price
-# 
+#
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
@@ -12,15 +12,15 @@ msgstr ""
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
 "Language-Team: Vietnamese (https://www.transifex.com/oca/teams/23907/vi/)\n"
+"Language: vi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: vi\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
-msgid "Partner"
+msgid "Contact"
 msgstr ""
 
 #. module: website_sale_hide_price
@@ -36,5 +36,5 @@ msgstr "Trang web"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price
-msgid "Website show price"
+msgid "Website Show Price"
 msgstr ""

--- a/website_sale_hide_price/i18n/website_sale_hide_price.pot
+++ b/website_sale_hide_price/i18n/website_sale_hide_price.pot
@@ -1,23 +1,17 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * website_sale_hide_price
+#	* website_sale_hide_price
 #
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 10.0\n"
+"Project-Id-Version: Odoo Server 11.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-12-16 01:57+0000\n"
-"PO-Revision-Date: 2017-12-16 01:57+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Chinese (China) (https://www.transifex.com/oca/teams/23907/"
-"zh_CN/)\n"
-"Language: zh_CN\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=1; plural=0;\n"
+"Plural-Forms: \n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
@@ -33,9 +27,10 @@ msgstr ""
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_website
 msgid "Website"
-msgstr "网站"
+msgstr ""
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price
 msgid "Website Show Price"
 msgstr ""
+

--- a/website_sale_hide_price/i18n/zh_CN.po
+++ b/website_sale_hide_price/i18n/zh_CN.po
@@ -11,12 +11,12 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"Language-Team: Chinese (China) (https://www.transifex.com/oca/teams/23907/zh_CN/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: zh_CN\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
@@ -32,7 +32,7 @@ msgstr ""
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_website
 msgid "Website"
-msgstr "Sitio web"
+msgstr "网站"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price

--- a/website_sale_hide_price/i18n/zh_TW.po
+++ b/website_sale_hide_price/i18n/zh_TW.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * website_sale_hide_price
-# 
+#
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
@@ -11,16 +11,17 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Chinese (Taiwan) (https://www.transifex.com/oca/teams/23907/zh_TW/)\n"
+"Language-Team: Chinese (Taiwan) (https://www.transifex.com/oca/teams/23907/"
+"zh_TW/)\n"
+"Language: zh_TW\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: zh_TW\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
-msgid "Partner"
+msgid "Contact"
 msgstr ""
 
 #. module: website_sale_hide_price
@@ -36,5 +37,5 @@ msgstr "網站"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price
-msgid "Website show price"
+msgid "Website Show Price"
 msgstr ""

--- a/website_sale_hide_price/i18n/zh_TW.po
+++ b/website_sale_hide_price/i18n/zh_TW.po
@@ -11,12 +11,12 @@ msgstr ""
 "POT-Creation-Date: 2017-12-16 01:57+0000\n"
 "PO-Revision-Date: 2017-12-16 01:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"Language-Team: Chinese (Taiwan) (https://www.transifex.com/oca/teams/23907/zh_TW/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: zh_TW\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_res_partner
@@ -32,7 +32,7 @@ msgstr ""
 #. module: website_sale_hide_price
 #: model:ir.model,name:website_sale_hide_price.model_website
 msgid "Website"
-msgstr "Sitio web"
+msgstr "網站"
 
 #. module: website_sale_hide_price
 #: model:ir.model.fields,field_description:website_sale_hide_price.field_website_website_show_price

--- a/website_sale_hide_price/models/__init__.py
+++ b/website_sale_hide_price/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+
+from . import res_partner
+from . import website

--- a/website_sale_hide_price/models/__init__.py
+++ b/website_sale_hide_price/models/__init__.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
 from . import res_partner
 from . import website

--- a/website_sale_hide_price/models/res_partner.py
+++ b/website_sale_hide_price/models/res_partner.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Tecnativa - David Vidal
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ResPartner(models.Model):
+    _inherit = "res.partner"
+
+    website_show_price = fields.Boolean(
+        string='Show prices on website',
+        default=True,
+    )

--- a/website_sale_hide_price/models/res_partner.py
+++ b/website_sale_hide_price/models/res_partner.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2017 Tecnativa - David Vidal
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-
 from odoo import fields, models
 
 
@@ -10,5 +9,5 @@ class ResPartner(models.Model):
 
     website_show_price = fields.Boolean(
         string='Show prices on website',
-        default=True,
+        default=True
     )

--- a/website_sale_hide_price/models/website.py
+++ b/website_sale_hide_price/models/website.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2017 Tecnativa - David Vidal
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 

--- a/website_sale_hide_price/models/website.py
+++ b/website_sale_hide_price/models/website.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Tecnativa - David Vidal
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+from odoo.http import request
+
+
+class Website(models.Model):
+    _inherit = "website"
+
+    website_show_price = fields.Boolean(
+        compute='_compute_website_show_price')
+
+    def _compute_website_show_price(self):
+        for rec in self:
+            rec.website_show_price = (
+                request.env.user.partner_id.website_show_price)

--- a/website_sale_hide_price/views/partner_view.xml
+++ b/website_sale_hide_price/views/partner_view.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_partner_form" model="ir.ui.view">
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='sale']" position="inside">
+                <field name="website_show_price"/>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/website_sale_hide_price/views/partner_view.xml
+++ b/website_sale_hide_price/views/partner_view.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-
     <record id="view_partner_form" model="ir.ui.view">
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="base.view_partner_form"/>
@@ -10,5 +9,4 @@
             </xpath>
         </field>
     </record>
-
 </odoo>

--- a/website_sale_hide_price/views/website_sale_template.xml
+++ b/website_sale_hide_price/views/website_sale_template.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+        <template id="product_price" inherit_id="website_sale.product_price">
+            <xpath expr="//div[@itemprop='offers']" position="attributes">
+                <attribute name="t-if">
+                    website.website_show_price
+                </attribute>
+            </xpath>
+        </template>
+
+        <template id="products_item" inherit_id="website_sale.products_item">
+            <xpath expr="//div[@itemprop='offers']" position="attributes">
+                <attribute name="t-if">
+                    website.website_show_price
+                </attribute>
+            </xpath>
+        </template>
+
+</odoo>

--- a/website_sale_hide_price/views/website_sale_template.xml
+++ b/website_sale_hide_price/views/website_sale_template.xml
@@ -14,4 +14,17 @@
                 </attribute>
             </xpath>
         </template>
+        <!-- Hide Add To Cart Button and quantity selector if not website_show_price -->
+        <template id="product" inherit_id="website_sale.product">
+            <xpath expr="//a[@id='add_to_cart']" position="attributes">
+                <attribute name="t-if">
+                    website.website_show_price
+                </attribute>
+            </xpath>
+            <xpath expr="//div[hasclass('css_quantity')]" position="attributes">
+                <attribute name="t-if">
+                    website.website_show_price
+                </attribute>
+            </xpath>
+        </template>
 </odoo>

--- a/website_sale_hide_price/views/website_sale_template.xml
+++ b/website_sale_hide_price/views/website_sale_template.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-
         <template id="product_price" inherit_id="website_sale.product_price">
             <xpath expr="//div[@itemprop='offers']" position="attributes">
                 <attribute name="t-if">
@@ -8,7 +7,6 @@
                 </attribute>
             </xpath>
         </template>
-
         <template id="products_item" inherit_id="website_sale.products_item">
             <xpath expr="//div[@itemprop='offers']" position="attributes">
                 <attribute name="t-if">
@@ -16,5 +14,4 @@
                 </attribute>
             </xpath>
         </template>
-
 </odoo>


### PR DESCRIPTION
Migrated as-is.

Note that a discussion could be opened regarding the 'multi-website' feature that was added in Odoo 12.0.

It might make sense to modify the boolean field on the partner to a many2many relation between `res_partner` and `website_website`, so that this price-hiding feature might be made website-dependant.

I don't know if this makes sense or not, and if this kind of behavioural change if often added in a migration. In any case, the module seems to work fine in 12.0, albeit for all websites at once.