### PR TITLE
 [MIG] website_sale_hide_empty_category: Migration to 11.0 

### DIFF
--- a/website_sale_hide_empty_category/README.rst
+++ b/website_sale_hide_empty_category/README.rst
@@ -1,0 +1,56 @@
+.. image:: https://img.shields.io/badge/license-LGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/lgpl-3.0-standalone.html
+   :alt: License: LGPL-3
+
+====================================
+Website Sale - Hide Empty Categories
+====================================
+
+Removes any category links from the Shop which have no products associated
+to them.
+
+Usage
+=====
+
+Simply install the module and refresh your view. You will see the empty
+categories disappear
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/186/10.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/website/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smash it by providing detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Ted Salmon <tsalmon@laslabs.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/website_sale_hide_empty_category/README.rst
+++ b/website_sale_hide_empty_category/README.rst
@@ -1,4 +1,4 @@
-.. image:: https://img.shields.io/badge/license-LGPL--3-blue.svg
+.. image:: https://img.shields.io/badge/license-LGPL--3-blue.png
    :target: http://www.gnu.org/licenses/lgpl-3.0-standalone.html
    :alt: License: LGPL-3
 
@@ -17,7 +17,7 @@ categories disappear
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot
-   :target: https://runbot.odoo-community.org/runbot/186/10.0
+   :target: https://runbot.odoo-community.org/runbot/186/11.0
 
 Bug Tracker
 ===========

--- a/website_sale_hide_empty_category/__init__.py
+++ b/website_sale_hide_empty_category/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 LasLabs Inc.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+
+from . import models

--- a/website_sale_hide_empty_category/__init__.py
+++ b/website_sale_hide_empty_category/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2017 LasLabs Inc.
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 

--- a/website_sale_hide_empty_category/__manifest__.py
+++ b/website_sale_hide_empty_category/__manifest__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 LasLabs Inc.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+{
+    "name": "Website Sale - Hide Empty Categories",
+    "summary": "Hide any Product Categories that are empty",
+    "version": "10.0.1.0.0",
+    "category": "Website",
+    "website": "https://laslabs.com/",
+    "author": "LasLabs, Odoo Community Association (OCA)",
+    "license": "LGPL-3",
+    "application": False,
+    "installable": True,
+    "depends": [
+        "website_sale",
+    ],
+    "data": [
+        "views/website_sale_templates.xml",
+    ],
+}

--- a/website_sale_hide_empty_category/__manifest__.py
+++ b/website_sale_hide_empty_category/__manifest__.py
@@ -1,12 +1,11 @@
-# -*- coding: utf-8 -*-
-# Copyright 2017 LasLabs Inc.
+# Copyright 2017 LasLabs Inc. <https://laslabs.com/>
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 {
     "name": "Website Sale - Hide Empty Categories",
     "summary": "Hide any Product Categories that are empty",
-    "version": "10.0.1.0.0",
+    "version": "11.0.1.0.0",
     "category": "Website",
-    "website": "https://laslabs.com/",
+    "website": "https://github.com/OCA/e-commerce/",
     "author": "LasLabs, Odoo Community Association (OCA)",
     "license": "LGPL-3",
     "application": False,

--- a/website_sale_hide_empty_category/i18n/website_sale_hide_empty_category.pot
+++ b/website_sale_hide_empty_category/i18n/website_sale_hide_empty_category.pot
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 10.0\n"
+"Project-Id-Version: Odoo Server 11.0\n"
 "Report-Msgid-Bugs-To: \n"
 "Last-Translator: <>\n"
 "Language-Team: \n"

--- a/website_sale_hide_empty_category/i18n/website_sale_hide_empty_category.pot
+++ b/website_sale_hide_empty_category/i18n/website_sale_hide_empty_category.pot
@@ -1,0 +1,25 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* website_sale_hide_empty_category
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 10.0\n"
+"Report-Msgid-Bugs-To: \n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: website_sale_hide_empty_category
+#: model:ir.model.fields,field_description:website_sale_hide_empty_category.field_product_public_category_product_ids
+msgid "Products"
+msgstr ""
+
+#. module: website_sale_hide_empty_category
+#: model:ir.model,name:website_sale_hide_empty_category.model_product_public_category
+msgid "Website Product Category"
+msgstr ""
+

--- a/website_sale_hide_empty_category/models/__init__.py
+++ b/website_sale_hide_empty_category/models/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2017 LasLabs Inc.
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 

--- a/website_sale_hide_empty_category/models/__init__.py
+++ b/website_sale_hide_empty_category/models/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 LasLabs Inc.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+
+from . import product_public_category

--- a/website_sale_hide_empty_category/models/product_public_category.py
+++ b/website_sale_hide_empty_category/models/product_public_category.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2017 LasLabs Inc.
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 

--- a/website_sale_hide_empty_category/models/product_public_category.py
+++ b/website_sale_hide_empty_category/models/product_public_category.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 LasLabs Inc.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+
+from odoo import fields, models
+
+
+class ProductPublicCategory(models.Model):
+    _inherit = 'product.public.category'
+
+    # This module relies on the M2M relation built from `product.template` to
+    # `product.public.category` named `public_categ_ids`
+    product_ids = fields.Many2many(
+        comodel_name='product.template',
+        string='Products',
+        relation='product_public_category_product_template_rel',
+        column1='product_public_category_id',
+        column2='product_template_id',
+    )

--- a/website_sale_hide_empty_category/views/website_sale_templates.xml
+++ b/website_sale_hide_empty_category/views/website_sale_templates.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2017 LasLabs Inc.
+     License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+-->
+
+<odoo>
+
+    <template inherit_id="website_sale.categories_recursive"
+              id="hide_categories_recursive"
+              active="True"
+              customize_show="True"
+              name="Hide Empty Category list">
+        <xpath expr="//t[@t-name='website_sale.categories_recursive']"
+               position="attributes">
+            <attribute name="t-if">c.product_ids</attribute>
+        </xpath>
+    </template>
+
+</odoo>


### PR DESCRIPTION
This PR upgrade the `website_sale_hide_empty_category` from 10.0 to 11.0 and move it from `website` to `e-commerce`.