### PR TITLE
[FIX] website_sale_charge_payment_fee: Do not blow up when there is no acquirer

### DIFF
--- a/website_sale_charge_payment_fee/__manifest__.py
+++ b/website_sale_charge_payment_fee/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "eCommerce: charge payment fee",
     "summary": "Payment fee charged to customer",
-    "version": "10.0.1.0.0",
+    "version": "10.0.1.0.1",
     "development_status": "Beta",
     "category": "Website",
     "website": "https://github.com/OCA/e-commerce",

--- a/website_sale_charge_payment_fee/templates/website_sale.xml
+++ b/website_sale_charge_payment_fee/templates/website_sale.xml
@@ -23,7 +23,7 @@
             <attribute name="t-att-checked">acquirer == selected_acquirer if selected_acquirer else acquirers[0] == acquirer</attribute>
         </xpath>
         <xpath expr="//div[@t-if='not website_sale_order.amount_total']" position="after">
-            <input type="hidden" t-att-value="selected_acquirer.id if selected_acquirer else acquirers and acquirers[0].id"
+            <input type="hidden" t-att-value="selected_acquirer.id if selected_acquirer else acquirers and acquirers[0].id or False"
                    name="selected_acquirer_id"/>
         </xpath>
         <xpath expr="//a[@t-attf-href='/shop/product/#{ slug(line.product_id.product_tmpl_id) }']" position="attributes">

--- a/website_sale_charge_payment_fee/templates/website_sale.xml
+++ b/website_sale_charge_payment_fee/templates/website_sale.xml
@@ -23,7 +23,7 @@
             <attribute name="t-att-checked">acquirer == selected_acquirer if selected_acquirer else acquirers[0] == acquirer</attribute>
         </xpath>
         <xpath expr="//div[@t-if='not website_sale_order.amount_total']" position="after">
-            <input type="hidden" t-att-value="selected_acquirer.id if selected_acquirer else acquirers[0].id"
+            <input type="hidden" t-att-value="selected_acquirer.id if selected_acquirer else acquirers and acquirers[0].id"
                    name="selected_acquirer_id"/>
         </xpath>
         <xpath expr="//a[@t-attf-href='/shop/product/#{ slug(line.product_id.product_tmpl_id) }']" position="attributes">


### PR DESCRIPTION
If there are no acquirers, gets
```
Error to render compiling AST
TypeError: 'NoneType' object has no attribute '__getitem__'
Template: 929
Path: /templates/t/t/div/div[1]/div/div[2]/input
Node: <input type="hidden" t-att-value="selected_acquirer.id if selected_acquirer else acquirers[0].id" name="selected_acquirer_id" data-oe-id="1278" data-oe-xpath="/data/xpath[3]/input" data-oe-model="ir.ui.view" data-oe-field="arch"/>
```