### PR TITLE
[11.0][ADD] website_sale_ecommerce_description: Add a description only for the e-commerce

### DIFF
--- a/website_sale_ecommerce_description/README.rst
+++ b/website_sale_ecommerce_description/README.rst
@@ -1,0 +1,62 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+=========================
+e-Commerce description
+=========================
+
+The sale description is used in the e-commerce and also in other reports likes
+invoices, sale orders, ....
+In some case, we only need a description on the e-commerce.
+This module will add a field description only for the e-commerce.
+
+Configuration
+=============
+
+No configuration required
+
+Usage
+=====
+
+On any product you can add a description on the tab "Notes"
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/113/11.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/e-commerce/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Sylvain Van Hoof <sylvain@okia.be>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/website_sale_ecommerce_description/__init__.py
+++ b/website_sale_ecommerce_description/__init__.py
@@ -1,0 +1,2 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from . import models

--- a/website_sale_ecommerce_description/__manifest__.py
+++ b/website_sale_ecommerce_description/__manifest__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 Sylvain Van Hoof <sylvain@okia.be>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+{
+    'name': 'Website Sale e-Commerce Description',
+    'category': 'Website',
+    'summary': 'Add a e-Commerce description',
+    'version': '11.0.1.0.1',
+    'description': """
+The sale description is used in the e-commerce and also in other reports likes
+invoices, sale orders, ....
+In some case, we only need a description on the e-commerce. This module
+will add a field description only for the e-commerce.
+    """,
+    'author': 'Okia SPRL, Odoo Community Association (OCA)',
+    'depends': ['website_sale', 'product'],
+    'data': [
+        'views/website_sale_template.xml',
+        'views/product_template.xml',
+    ],
+    'installable': True,
+    'application': False,
+}

--- a/website_sale_ecommerce_description/__manifest__.py
+++ b/website_sale_ecommerce_description/__manifest__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2019 Sylvain Van Hoof <sylvain@okia.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
@@ -6,14 +5,9 @@
     'category': 'Website',
     'summary': 'Add a e-Commerce description',
     'version': '11.0.1.0.1',
-    'description': """
-The sale description is used in the e-commerce and also in other reports likes
-invoices, sale orders, ....
-In some case, we only need a description on the e-commerce. This module
-will add a field description only for the e-commerce.
-    """,
     'author': 'Okia SPRL, Odoo Community Association (OCA)',
     'depends': ['website_sale', 'product'],
+    'license': 'AGPL-3',
     'data': [
         'views/website_sale_template.xml',
         'views/product_template.xml',

--- a/website_sale_ecommerce_description/i18n/fr_BE.po
+++ b/website_sale_ecommerce_description/i18n/fr_BE.po
@@ -1,0 +1,44 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* website_sale_ecommerce_description
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 11.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-02-19 14:10+0000\n"
+"PO-Revision-Date: 2019-02-19 14:10+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: website_sale_ecommerce_description
+#: model:ir.model.fields,help:website_sale_ecommerce_description.field_product_product_description_ecommerce
+#: model:ir.model.fields,help:website_sale_ecommerce_description.field_product_template_description_ecommerce
+msgid "A description of the Product. This description will be displayed only on your e-Commerce."
+msgstr "Une description de votre produit. Cette description sera affichée uniquement sur votre e-Commerce"
+
+#. module: website_sale_ecommerce_description
+#: model:ir.ui.view,arch_db:website_sale_ecommerce_description.product_template_form_view
+msgid "Description for e-Commerce"
+msgstr "Description pour le e-Commerce"
+
+#. module: website_sale_ecommerce_description
+#: model:ir.model,name:website_sale_ecommerce_description.model_product_template
+msgid "Product Template"
+msgstr "Modèle d'article"
+
+#. module: website_sale_ecommerce_description
+#: model:ir.ui.view,arch_db:website_sale_ecommerce_description.product_template_form_view
+msgid "This note will show up on e-Commerce."
+msgstr "Cette note sera affichée sur le e-Commerce"
+
+#. module: website_sale_ecommerce_description
+#: model:ir.model.fields,field_description:website_sale_ecommerce_description.field_product_product_description_ecommerce
+#: model:ir.model.fields,field_description:website_sale_ecommerce_description.field_product_template_description_ecommerce
+msgid "e-Commerce description"
+msgstr "description e-Commerce"
+

--- a/website_sale_ecommerce_description/i18n/website_sale_ecommerce_description.pot
+++ b/website_sale_ecommerce_description/i18n/website_sale_ecommerce_description.pot
@@ -1,0 +1,44 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* website_sale_ecommerce_description
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 11.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-02-19 14:09+0000\n"
+"PO-Revision-Date: 2019-02-19 14:09+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: website_sale_ecommerce_description
+#: model:ir.model.fields,help:website_sale_ecommerce_description.field_product_product_description_ecommerce
+#: model:ir.model.fields,help:website_sale_ecommerce_description.field_product_template_description_ecommerce
+msgid "A description of the Product. This description will be displayed only on your e-Commerce."
+msgstr ""
+
+#. module: website_sale_ecommerce_description
+#: model:ir.ui.view,arch_db:website_sale_ecommerce_description.product_template_form_view
+msgid "Description for e-Commerce"
+msgstr ""
+
+#. module: website_sale_ecommerce_description
+#: model:ir.model,name:website_sale_ecommerce_description.model_product_template
+msgid "Product Template"
+msgstr ""
+
+#. module: website_sale_ecommerce_description
+#: model:ir.ui.view,arch_db:website_sale_ecommerce_description.product_template_form_view
+msgid "This note will show up on e-Commerce."
+msgstr ""
+
+#. module: website_sale_ecommerce_description
+#: model:ir.model.fields,field_description:website_sale_ecommerce_description.field_product_product_description_ecommerce
+#: model:ir.model.fields,field_description:website_sale_ecommerce_description.field_product_template_description_ecommerce
+msgid "e-Commerce description"
+msgstr ""
+

--- a/website_sale_ecommerce_description/models/__init__.py
+++ b/website_sale_ecommerce_description/models/__init__.py
@@ -1,0 +1,2 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from . import product_template

--- a/website_sale_ecommerce_description/models/product_template.py
+++ b/website_sale_ecommerce_description/models/product_template.py
@@ -1,0 +1,14 @@
+# Copyright 2019 Sylvain Van Hoof <sylvain@okia.be>
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from odoo import fields, models
+
+
+class ProductTemplate(models.Model):
+    _inherit = 'product.template'
+
+    description_ecommerce = fields.Text(
+        'e-Commerce description',
+        help='A description of the Product. This description will be displayed'
+             ' only on your e-Commerce.'
+    )

--- a/website_sale_ecommerce_description/views/product_template.xml
+++ b/website_sale_ecommerce_description/views/product_template.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="product_template_form_view" model="ir.ui.view">
+        <field name="name">product.template.form.view.inherit</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_form_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='description']" position="after">
+                <group name="description_ecommerce">
+                    <group string="Description for e-Commerce" attrs="{'invisible': [('sale_ok','=',False)]}">
+                        <field name="description_ecommerce" nolabel="1" placeholder="This note will show up on e-Commerce."/>
+                    </group>
+                </group>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/website_sale_ecommerce_description/views/website_sale_template.xml
+++ b/website_sale_ecommerce_description/views/website_sale_template.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="products_description" inherit_id="website_sale.products_description">
+        <xpath expr="//div[@t-field='product.description_sale']" position="after">
+            <div itemprop="description" t-field="product.description_ecommerce"/>
+        </xpath>
+    </template>
+
+    <template id="product" inherit_id="website_sale.product">
+        <xpath expr="//div[p[@t-field='product.description_sale']]" position="after">
+            <hr t-if="product.description_ecommerce" />
+            <div class="o_not_editable">
+                <p t-field="product.description_ecommerce" class="text-muted" />
+            </div>
+        </xpath>
+    </template>
+
+    <template id="suggested_products_list" inherit_id="website_sale.suggested_products_list">
+        <xpath expr="//div[@t-field='product.description_sale']" position="after">
+            <div class="text-muted hidden-xs" t-field="product.description_ecommerce" />
+        </xpath>
+    </template>
+
+</odoo>


### PR DESCRIPTION
The field sale description on the product is displayed on the ecommerce but also on other reports (invoice, sale order ...). This module will allow to add a description only for the ecommerce.