### PR TITLE
[FIX] web_sale_hide_price: fix error with product comparison tool

### DIFF
--- a/website_sale_hide_price/views/website_sale_template.xml
+++ b/website_sale_hide_price/views/website_sale_template.xml
@@ -10,7 +10,7 @@
         <template id="products_item" inherit_id="website_sale.products_item">
             <xpath expr="//div[@itemprop='offers']" position="attributes">
                 <attribute name="t-if">
-                    website.website_show_price
+                    product.product_variant_ids and website.website_show_price
                 </attribute>
             </xpath>
         </template>


### PR DESCRIPTION
add original validation of the view https://github.com/odoo/odoo/blob/11.0/addons/website_sale/views/templates.xml#L109

FIXED https://github.com/OCA/e-commerce/issues/273