### PR TITLE
[FIX] website_sale_require_login: Fix public user test

### DIFF
--- a/website_sale_require_login/tests/test_checkout.py
+++ b/website_sale_require_login/tests/test_checkout.py
@@ -2,8 +2,6 @@
 import odoo.tests
 
 
-@odoo.tests.common.at_install(False)
-@odoo.tests.common.post_install(True)
 class TestUi(odoo.tests.HttpCase):
     def run_tour(self, login=None):
         self.phantom_js(
@@ -27,4 +25,7 @@ class TestUi(odoo.tests.HttpCase):
         self.run_tour("demo")
 
     def test_04_public_checkout(self):
+        # Disable sign up, in case auth_signup is installed
+        self.env["ir.config_parameter"].set_param(
+            "auth_signup.invitation_scope", "b2b")
         self.run_tour()


### PR DESCRIPTION
This PR should render the 12.0 branch :heavy_check_mark: in Travis again.

This test was expecting sign up to be disabled because `auth_signup` is not in its module graph, but since that addon is autoinstallable, it could be installed without our knowledge.

Just make sure signup is disabled before running the public user test, to make it unitary.

Also, moved to at-install mode, since the post-install one adds no value.

@Tecnativa