### PR TITLE
[12.0][IMP] website_sale_checkout_country_vat: add is-invalid class

### DIFF
--- a/website_sale_checkout_country_vat/views/templates.xml
+++ b/website_sale_checkout_country_vat/views/templates.xml
@@ -13,6 +13,7 @@
             <t t-set="country_id" t-value="'country_id' in checkout and checkout['country_id'] or False" />
             <t t-set="default_country"
                t-value="countries.search([('code', '=', default_value[:2])]) or countries.search([('id', '=', country_id and int(country_id) or False)])"/>
+            <t t-set="no_country_field_extra_classes" t-value="error.get('vat') and 'is-invalid' or ''"/>
         </t>
     </xpath>
 </template>


### PR DESCRIPTION
This functionality allows the 'is-invalid' class to be added to the input corresponding to the vat field when the website_sale_checkout_country_vat module is installed and this field it's empty and required or if it has an error.
It is necessary for example for the website_sale_vat_required module that is still in PR (https://github.com/OCA/e-commerce/pull/302).

Depends on:

- [x] https://github.com/OCA/website/pull/669

Cc @Tecnativa