### PR TITLE
[12.0][FIX] website_sale_checkout_skip_payment: Change error template reference

### DIFF
--- a/website_sale_checkout_skip_payment/controllers/main.py
+++ b/website_sale_checkout_skip_payment/controllers/main.py
@@ -31,6 +31,6 @@ class CheckoutSkipPayment(WebsiteSale):
         order.action_confirm()
         if not order.force_quotation_send():
             return request.render(
-                'website_sale_skip_payment.confirmation_order_error')
+                'website_sale_checkout_skip_payment.confirmation_order_error')
         request.website.sale_reset()
         return request.render("website_sale.confirmation", {'order': order})

--- a/website_sale_checkout_skip_payment/views/website_sale_skip_payment.xml
+++ b/website_sale_checkout_skip_payment/views/website_sale_skip_payment.xml
@@ -8,9 +8,11 @@
             <t t-set="additional_title">Shop - Confirmation - Error</t>
             <div id="wrap">
                 <div class="container oe_website_sale">
-                    <div class="alert alert-danger" role="alert">
-                        <strong>Error!</strong> An error occurred trying to
-                        confirm the sale order.
+                    <div class="row">
+                        <div class="alert alert-danger" role="alert">
+                            <strong>Error!</strong> An error occurred trying to
+                            confirm the sale order.
+                        </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
In some point the module was changed their name, but the reference to the error template not. This commit improves the error template (adding a padding) and fixes the reference problem.

cc @tecnativa