### PR TITLE
[12.0] FIX website_sale_product_brand tanslation error on update with --i18n-overwrite

### DIFF
--- a/website_sale_product_brand/i18n/it.po
+++ b/website_sale_product_brand/i18n/it.po
@@ -1,42 +1,37 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * website_sale_product_brand
+#	* website_sale_product_brand
 #
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2016
-# Paolo Valier <paolo.valier@hotmail.it>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-03-28 02:55+0000\n"
-"PO-Revision-Date: 2020-03-25 11:13+0000\n"
-"Last-Translator: Lorenzo Battistini <lb@takobi.online>\n"
-"Language-Team: Italian (https://www.transifex.com/oca/teams/23907/it/)\n"
-"Language: it\n"
+"POT-Creation-Date: 2020-04-05 07:42+0000\n"
+"PO-Revision-Date: 2020-04-05 07:42+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 3.10\n"
+"Plural-Forms: \n"
 
 #. module: website_sale_product_brand
-#: model:ir.ui.view,arch_db:website_sale_product_brand.product_brands
+#: model_terms:ir.ui.view,arch_db:website_sale_product_brand.product_brands
 msgid "No Brands Found."
 msgstr "Nessuna marca trovata."
 
 #. module: website_sale_product_brand
-#: model:ir.ui.view,arch_db:website_sale_product_brand.product_brands
+#: model_terms:ir.ui.view,arch_db:website_sale_product_brand.product_brands
 msgid "Product Brands"
 msgstr "Marche prodotto"
 
 #. module: website_sale_product_brand
-#: model:ir.ui.view,arch_db:website_sale_product_brand.product_brands
+#: model_terms:ir.ui.view,arch_db:website_sale_product_brand.product_brands
 msgid "Search"
 msgstr "Cerca"
 
 #. module: website_sale_product_brand
-#: model:ir.ui.view,arch_db:website_sale_product_brand.product_brands
+#: model_terms:ir.ui.view,arch_db:website_sale_product_brand.product_brands
 msgid "Search..."
 msgstr "Cerca..."
 
@@ -45,5 +40,3 @@ msgstr "Cerca..."
 msgid "Shop by Brand"
 msgstr ""
 
-#~ msgid "Website"
-#~ msgstr "Sito"


### PR DESCRIPTION
Steps:

 - Install website_sale_product_brand
 - Install Italian language
 - Update with `-u  website_sale_product_brand  --i18n-overwrite`

Get

```
bad query:  INSERT INTO ir_translation(name, lang, res_id, src, type, value, module, state, comments)
                           SELECT name, lang, res_id, src, type, value, module, state, comments
                           FROM tmp_ir_translation_import
                           WHERE type = 'model'
                           AND noupdate IS NOT TRUE
                           ON CONFLICT (type, lang, name, res_id) WHERE type = 'model'
                            DO UPDATE SET (name, lang, res_id, src, type, value, module, state, comments) = (EXCLUDED.name, EXCLUDED.lang, EXCLUDED.res_id, EXCLUDED.src, EXCLUDED.type, EXCLUDED.value, EXCLUDED.module, EXCLUDED.state, EXCLUDED.comments)
                            WHERE EXCLUDED.value IS NOT NULL AND EXCLUDED.value != '';
                       
ERROR: ON CONFLICT DO UPDATE command cannot affect row a second time
HINT:  Ensure that no rows proposed for insertion within the same command have duplicate constrained values
```