### PR TITLE
[12.0][FIX] website_sale_checkout_country_vat: inherit the correct view

### DIFF
--- a/website_sale_checkout_country_vat/views/templates.xml
+++ b/website_sale_checkout_country_vat/views/templates.xml
@@ -5,7 +5,7 @@
      License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl-3). -->
 <odoo>
 
-<template id="address" inherit_id="website_sale.address">
+<template id="address" inherit_id="website_sale.address_b2b">
     <xpath expr="//input[@name='vat']" position="replace">
         <t t-call="website_snippet_country_dropdown.country_dropdown">
             <t t-set="complete_field" t-value="'vat'"/>
@@ -14,6 +14,7 @@
             <t t-set="default_country"
                t-value="countries.search([('code', '=', default_value[:2])]) or countries.search([('id', '=', country_id and int(country_id) or False)])"/>
             <t t-set="no_country_field_extra_classes" t-value="error.get('vat') and 'is-invalid' or ''"/>
+            <t t-set="readonly" t-value="'1' if 'vat' in checkout and checkout['vat'] and not can_edit_vat else None"/>
         </t>
     </xpath>
 </template>


### PR DESCRIPTION
This module happened to be working accidentally because [it was inheriting from a view that had another inheriting view which defined the necessary elements][1]; but that view can be disabled and then this module breaks.

Fixed by inheriting from the correct view.

Also benefits from OCA/website#720 by using readonly mode if that module is updated.

@Tecnativa TT17694

[1]: https://github.com/odoo/odoo/blob/6e99a89574d11811c03fe3cdc61922352a9610ea/addons/website_sale/views/templates.xml#L1296