### PR TITLE
[12.0][FIX] website_sale_stock_available: immediately_usable_qty in_cart_update

### DIFF
--- a/website_sale_stock_available/models/__init__.py
+++ b/website_sale_stock_available/models/__init__.py
@@ -1,3 +1,5 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
+from . import product_product
 from . import product_template
+from . import sale_order

--- a/website_sale_stock_available/models/product_product.py
+++ b/website_sale_stock_available/models/product_product.py
@@ -1,0 +1,19 @@
+# Copyright 2020 Tecnativa - Ernesto Tejeda
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class Product(models.Model):
+    _inherit = 'product.product'
+
+    def _compute_quantities_dict(self, lot_id, owner_id, package_id,
+                                 from_date=False, to_date=False):
+        res = super()._compute_quantities_dict(
+            lot_id, owner_id, package_id, from_date, to_date)
+        if self.env.context.get('website_sale_stock_available'):
+            for product in self.with_context(
+                    website_sale_stock_available=False):
+                immediately = product.immediately_usable_qty
+                res[product.id]['virtual_available'] = immediately
+        return res

--- a/website_sale_stock_available/models/product_template.py
+++ b/website_sale_stock_available/models/product_template.py
@@ -11,14 +11,7 @@ class ProductTemplate(models.Model):
     def _get_combination_info(self, combination=False, product_id=False,
                               add_qty=1, pricelist=False,
                               parent_combination=False, only_template=False):
-        combination_info = super()._get_combination_info(
+        template = self.with_context(website_sale_stock_available=True)
+        return super(ProductTemplate, template)._get_combination_info(
             combination, product_id, add_qty, pricelist, parent_combination,
             only_template)
-        if self.env.context.get('website_sale_stock_get_quantity'):
-            product_id = combination_info['product_id']
-            if product_id:
-                product_obj = self.env['product.product'].sudo()
-                product = product_obj.browse(product_id)
-                combination_info.update(
-                    virtual_available=product.immediately_usable_qty)
-        return combination_info

--- a/website_sale_stock_available/models/sale_order.py
+++ b/website_sale_stock_available/models/sale_order.py
@@ -1,0 +1,15 @@
+# Copyright 2020 Tecnativa - Ernesto Tejeda
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    @api.multi
+    def _cart_update(self, product_id=None, line_id=None, add_qty=0,
+                     set_qty=0, **kwargs):
+        order = self.with_context(website_sale_stock_available=True)
+        return super(SaleOrder, order)._cart_update(
+            product_id, line_id, add_qty, set_qty, **kwargs)


### PR DESCRIPTION
Fix: take into account here (see image)  'Available to promise' instead of 'Forecast Quantity' To restrict add to cart

![website_fix](https://user-images.githubusercontent.com/38267832/81751190-f2e26400-947c-11ea-9279-c31ade90bfc8.jpg)

Cc @Tecnativa TT21547