### PR TITLE
[FIX] website_sale_category_description: make website_description properly editable from website

### DIFF
--- a/website_sale_category_description/models/product_public_category.py
+++ b/website_sale_category_description/models/product_public_category.py
@@ -2,9 +2,12 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import models, fields
+from odoo.tools import html_translate
 
 
 class ProductPublicCategory(models.Model):
     _inherit = "product.public.category"
 
-    website_description = fields.Html(translate=True)
+    website_description = fields.Html(
+        sanitize_attributes=False, translate=html_translate
+    )


### PR DESCRIPTION
Before this patch, you had problems to translate this field and to add some snippets such as accordions.

@Tecnativa TT24205