### PR TITLE
[FIX] website_sale_product_attachment: role warning

### DIFF
--- a/website_sale_product_attachment/views/product_template.xml
+++ b/website_sale_product_attachment/views/product_template.xml
@@ -11,7 +11,7 @@
         <field name="arch" type="xml">
             <group name="shop" position="inside">
                 <group name="website_attachments" string="Website Attachments">
-                    <div class="alert alert-info" colspan="4">
+                    <div class="alert alert-info" colspan="4" role="alert">
                         <i class="fa fa-info-circle"/>
                         Only public attachments can be used or created here.
                         Removing one attachment from this list does not delete


### PR DESCRIPTION
As the warning states:

```
WARNING devel odoo.tools.view_validation: Invalid XML: An alert (class alert-*) must have an alert,
alertdialog or status role. Please use alert and alertdialog only for what expects to stop any activity 
to be read immediatly.
```

cc @Tecnativa TT23600