### PR TITLE
[FIX] website_sale_product_attachment: sort attachments, support long names

### DIFF
--- a/website_sale_product_attachment/controllers/main.py
+++ b/website_sale_product_attachment/controllers/main.py
@@ -20,7 +20,8 @@ class WebsiteSale(main.WebsiteSale):
         )["website_attachment_ids"]["domain"]
         attachments = request.env["ir.attachment"].search(
             [("id", "in", result.qcontext["product"].website_attachment_ids.ids)]
-            + attachments_domain
+            + attachments_domain,
+            order="name"
         )
         result.qcontext["product_attachments"] = attachments
         return result

--- a/website_sale_product_attachment/templates/product_template.xml
+++ b/website_sale_product_attachment/templates/product_template.xml
@@ -40,7 +40,7 @@
 
     <template id="download_icons" inherit_id="product_attachments" name="Download icons" customize_show="True">
         <xpath expr="//*[@t-field='attachment.name']" position="before">
-            <span class="o_image mr8" t-att-data-mimetype="attachment.mimetype" />
+            <span class="o_image mr8 flex-shrink-0" t-att-data-mimetype="attachment.mimetype" />
         </xpath>
     </template>
 


### PR DESCRIPTION
Without this fix, the order in which attachments were displayed couldn't be predictable. Now, it's as expected by user: by name.

Also the thumbnails got stretched when the attachment had a long name:

![Captura de pantalla de 2020-06-22 09-44-28](https://user-images.githubusercontent.com/973709/85267301-ff3ee100-b46c-11ea-94be-61932f7b75b4.png)


@Tecnativa TT24437