### PR TITLE
[13.0][FIX] website_sale_checkout_skip_payment: CacheMiss error when session is not authenticated

### DIFF
--- a/website_sale_checkout_skip_payment/models/website.py
+++ b/website_sale_checkout_skip_payment/models/website.py
@@ -21,3 +21,5 @@ class Website(models.Model):
                 rec.checkout_skip_payment = (
                     request.env.user.partner_id.skip_website_checkout_payment
                 )
+            else:
+                rec.checkout_skip_payment = False

--- a/website_sale_checkout_skip_payment/tests/test_checkout_skip_payment.py
+++ b/website_sale_checkout_skip_payment/tests/test_checkout_skip_payment.py
@@ -1,5 +1,7 @@
 # Copyright 2018 Tecnativa - Sergio Teruel
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+import mock
+
 from odoo.tests.common import HttpCase
 
 
@@ -14,6 +16,14 @@ class WebsiteSaleHttpCase(HttpCase):
         # Delete optional products for avoid popup window
         product = self.env.ref("product.product_product_4_product_template")
         product.optional_product_ids = [(6, 0, [])]
+
+    def test_checkout_skip_payment(self):
+        website = self.env.ref("website.website2")
+        with mock.patch(
+            "odoo.addons.website_sale_checkout_skip_payment.models.website.request"
+        ) as request:
+            request.session.uid = False
+            self.assertFalse(website.checkout_skip_payment)
 
     def test_ui_website(self):
         """Test frontend tour."""

--- a/website_sale_product_minimal_price/__manifest__.py
+++ b/website_sale_product_minimal_price/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Website Sale Product Minimal Price",
     "summary": "Display minimal price for products that has variants",
-    "version": "13.0.1.0.0",
+    "version": "13.0.1.0.1",
     "development_status": "Production/Stable",
     "maintainers": ["sergio-teruel"],
     "category": "Website",

--- a/website_sale_product_minimal_price/static/src/js/website_sale_product_minimal_price.js
+++ b/website_sale_product_minimal_price/static/src/js/website_sale_product_minimal_price.js
@@ -17,45 +17,45 @@ odoo.define("website_sale_product_minimal_price.shop_min_price", function(requir
                 this.render_price(),
             ]);
         },
-        render_price: async function() {
+        render_price: function() {
             const $products = $(".o_wsale_product_grid_wrapper");
             const product_dic = {};
             $products.each(function() {
                 product_dic[this.querySelector("a img").src.split("/")[6]] = this;
             });
             const product_ids = Object.keys(product_dic).map(Number);
-            const products_min_price = await this._rpc({
+            return this._rpc({
                 route: "/sale/get_combination_info_minimal_price/",
                 params: {product_template_ids: product_ids},
-            });
-
-            for (const product of products_min_price) {
-                if (!product.distinct_prices) {
-                    continue;
+            }).then(products_min_price => {
+                for (const product of products_min_price) {
+                    if (!product.distinct_prices) {
+                        continue;
+                    }
+                    $(product_dic[product.id])
+                        .find(".product_price")
+                        .prepend(
+                            $(
+                                core.qweb.render(
+                                    "website_sale_product_minimal_price.from_view"
+                                )
+                            ).get(0)
+                        );
+                    $(product_dic[product.id])
+                        .find(".product_price .oe_currency_value")
+                        .replaceWith(
+                            $(
+                                core.qweb.render(
+                                    "website_sale_product_minimal_price.product_minimal_price",
+                                    {
+                                        price: this.widgetMonetary(product.price),
+                                    }
+                                )
+                            ).get(0)
+                        );
                 }
-                $(product_dic[product.id])
-                    .find(".product_price")
-                    .prepend(
-                        $(
-                            core.qweb.render(
-                                "website_sale_product_minimal_price.from_view"
-                            )
-                        ).get(0)
-                    );
-                $(product_dic[product.id])
-                    .find(".product_price .oe_currency_value")
-                    .replaceWith(
-                        $(
-                            core.qweb.render(
-                                "website_sale_product_minimal_price.product_minimal_price",
-                                {
-                                    price: this.widgetMonetary(product.price),
-                                }
-                            )
-                        ).get(0)
-                    );
-            }
-            return products_min_price;
+                return products_min_price;
+            });
         },
         widgetMonetary: function(value) {
             return field_utils.format.monetary(value);


### PR DESCRIPTION
Without this fix you'll get an error:
`odoo.exceptions.CacheMiss: ('website(1,).checkout_skip_payment', None)`
when the user / customer is not signed in.