### PR TITLE
[13.0][FIX] website_sale_checkout_skip_payment: CacheMiss error when session is not authenticated

### DIFF
--- a/website_sale_checkout_skip_payment/models/website.py
+++ b/website_sale_checkout_skip_payment/models/website.py
@@ -21,3 +21,5 @@ class Website(models.Model):
                 rec.checkout_skip_payment = (
                     request.env.user.partner_id.skip_website_checkout_payment
                 )
+            else:
+                rec.checkout_skip_payment = False

--- a/website_sale_checkout_skip_payment/tests/test_checkout_skip_payment.py
+++ b/website_sale_checkout_skip_payment/tests/test_checkout_skip_payment.py
@@ -1,5 +1,7 @@
 # Copyright 2018 Tecnativa - Sergio Teruel
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+import mock
+
 from odoo.tests.common import HttpCase
 
 
@@ -14,6 +16,14 @@ class WebsiteSaleHttpCase(HttpCase):
         # Delete optional products for avoid popup window
         product = self.env.ref("product.product_product_4_product_template")
         product.optional_product_ids = [(6, 0, [])]
+
+    def test_checkout_skip_payment(self):
+        website = self.env.ref("website.website2")
+        with mock.patch(
+            "odoo.addons.website_sale_checkout_skip_payment.models.website.request"
+        ) as request:
+            request.session.uid = False
+            self.assertFalse(website.checkout_skip_payment)
 
     def test_ui_website(self):
         """Test frontend tour."""


### PR DESCRIPTION
Without this fix you'll get an error:
`odoo.exceptions.CacheMiss: ('website(1,).checkout_skip_payment', None)`
when the user / customer is not signed in.

