### PR TITLE
[NEW] website_sale_tax_toggle: Test more resilient to CI

### DIFF
--- a/website_sale_tax_toggle/tests/test_website_sale_tax_toggle.py
+++ b/website_sale_tax_toggle/tests/test_website_sale_tax_toggle.py
@@ -1,9 +1,8 @@
 # Copyright 2020 Tecnativa - Sergio Teruel
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-from odoo.tests.common import HttpCase, tagged
+from odoo.tests.common import HttpCase
 
 
-@tagged('post_install', '-at_install')
 class WebsiteSaleTaxesToggleHttpCase(HttpCase):
 
     def setUp(self):


### PR DESCRIPTION
cc @Tecnativa 
Removed post_install, with l10n_es account charts the created tax is removed and test fails.