### PR TITLE
[12.0][IMP] website_snippet_carousel_product: Initialize animations

### DIFF
--- a/website_snippet_carousel_product/README.rst
+++ b/website_snippet_carousel_product/README.rst
@@ -45,6 +45,9 @@ Usage
 Known issues / Roadmap
 ======================
 
+Odoo doesn't load "pyjs" on the frontend by default. For this reason this
+snippet only allows use javascript syntax to write the domain.
+
 * Use/Implement a user-friendly domain selector
 
 Bug Tracker

--- a/website_snippet_carousel_product/readme/CONFIGURATION.rst
+++ b/website_snippet_carousel_product/readme/CONFIGURATION.rst
@@ -2,7 +2,7 @@
 #. Press 'Edit'
 #. Select the snippet that you want configure
 #. Press 'Customize' dropdown > Here You can see the implemented options for the widget:
-    * ``Set Domain`` > Sets a new domain to use
+    * ``Set Domain`` > Sets a new domain to use (Example: [["field", "=", "value"]])
     * ``Limit`` > Sets how many products will be fetched at maximum following default product order
     * ``Show`` > Sets how many products can be shown per slide
 

--- a/website_snippet_carousel_product/readme/ROADMAP.rst
+++ b/website_snippet_carousel_product/readme/ROADMAP.rst
@@ -1,1 +1,4 @@
+Odoo doesn't load "pyjs" on the frontend by default. For this reason this
+snippet only allows use javascript syntax to write the domain.
+
 * Use/Implement a user-friendly domain selector

--- a/website_snippet_carousel_product/static/description/index.html
+++ b/website_snippet_carousel_product/static/description/index.html
@@ -396,6 +396,8 @@ ul.auto-toc {
 </div>
 <div class="section" id="known-issues-roadmap">
 <h1><a class="toc-backref" href="#id2">Known issues / Roadmap</a></h1>
+<p>Odoo doesn’t load “pyjs” on the frontend by default. For this reason this
+snippet only allows use javascript syntax to write the domain.</p>
 <ul class="simple">
 <li>Use/Implement a user-friendly domain selector</li>
 </ul>

--- a/website_snippet_carousel_product/static/src/js/s_product_carousel_frontend.js
+++ b/website_snippet_carousel_product/static/src/js/s_product_carousel_frontend.js
@@ -72,6 +72,12 @@ odoo.define("website_snippet_carousel_product.s_product_carousel", function (req
                         self.$target.find('.carousel').carousel({
                             interval: interval,
                         });
+                        // Initialize 'animations' for the product card.
+                        // This is necessary because the snippet is asynchonously
+                        // rendered on the server.
+                        self.trigger_up('animation_start_demand', {
+                            $target: self.$target.find('.oe_website_sale'),
+                        });
                     },
                     function () {
                         if (self.editableMode) {


### PR DESCRIPTION
Because the qweb is rendered asynchronously on the server side, we need force animations initialization to get the product card buttons worked (basically this PR ensure that animations that works over "oe_website_sale" class are initialized).
Improved the README too. Now offers an a domain example and an explanation that why we need use javascript syntax to define the domains.

cc @tecnativa