### PR TITLE
[FIX] website_tax_toggle: make tour effective

### DIFF
--- a/website_sale_tax_toggle/__manifest__.py
+++ b/website_sale_tax_toggle/__manifest__.py
@@ -18,4 +18,5 @@
         'views/assets.xml',
         'views/templates.xml',
     ],
+    "demo": ["demo/assets.xml"],
 }

--- a/website_sale_tax_toggle/demo/assets.xml
+++ b/website_sale_tax_toggle/demo/assets.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2020 Tecnativa - Jairo Llopis
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<data>
+
+    <template id="assets_frontend_demo" inherit_id="website.assets_frontend">
+        <xpath expr=".">
+            <script type="text/javascript"
+                    src="/website_sale_tax_toggle/static/src/js/website_sale_tax_toggle_tour.js"/>
+        </xpath>
+    </template>
+
+</data>

--- a/website_sale_tax_toggle/static/src/js/website_sale_tax_toggle_tour.js
+++ b/website_sale_tax_toggle/static/src/js/website_sale_tax_toggle_tour.js
@@ -9,42 +9,22 @@ odoo.define("website_sale_tax_toggle.tour", function (require) {
 
     var steps = [
         {
-            trigger: "a[href='/shop']",
-        },
-        {
-            trigger: "a:contains('Product test tax toggle')",
-            extra_trigger: ".product_price:has(span:contains('750.00'))",
-        },
-        {
-            trigger: "a[href='/shop']",
-        },
-        {
-            content: "Toggle tax button click",
+            content: "Toggle tax button click from list page",
             trigger: '.js_tax_toggle_btn',
-            run: function() {
-                    $('.js_tax_toggle_btn').trigger('click');
-            },
+            extra_trigger: ".oe_product_cart:contains('Product test tax toggle') .oe_currency_value:containsExact('750.00')",
         },
         {
-            trigger: "a[href='/shop']",
+            content: "Enter the product page",
+            trigger: ".oe_product_cart:has(.oe_currency_value:containsExact('862.50')) a:contains('Product test tax toggle')",
         },
         {
-            trigger: "a:contains('Product test tax toggle')",
-            extra_trigger: ".product_price:has(span:contains('862.50'))",
-        },
-        {
-            content: "Toggle tax button click",
+            content: "Toggle tax button click from product page",
             trigger: '.js_tax_toggle_btn',
-            run: function() {
-                    $('.js_tax_toggle_btn').trigger('click');
-            },
+            extra_trigger: "#product_details .oe_currency_value:containsExact('862.50')",
         },
         {
-            trigger: "a[href='/shop']",
-        },
-        {
-            trigger: "a:contains('Product test tax toggle')",
-            extra_trigger: ".product_price:has(span:contains('750.00'))",
+            content: "Check the product price is back to what it should",
+            trigger: "#product_details .oe_currency_value:containsExact('750.00')",
         },
     ];
     tour.register("website_sale_tax_toggle",

--- a/website_sale_tax_toggle/views/assets.xml
+++ b/website_sale_tax_toggle/views/assets.xml
@@ -4,8 +4,6 @@
         <xpath expr=".">
             <script type="text/javascript"
                     src="/website_sale_tax_toggle/static/src/js/website_sale_tax_toggle.js"/>
-            <script type="text/javascript"
-                    src="/website_sale_tax_toggle/static/src/js/website_sale_tax_toggle_tour.js"/>
             <link type="text/scss" rel="stylesheet"
                   href="/website_sale_tax_toggle/static/src/scss/website_sale_tax_toggle.scss"/>
         </xpath>

--- a/website_sale_tax_toggle/views/templates.xml
+++ b/website_sale_tax_toggle/views/templates.xml
@@ -6,8 +6,8 @@
     <template id="tax_toggle_template">
         <t t-set="taxed" t-value="request.session.get('tax_toggle_taxed', request.env.user.with_context(skip_tax_toggle_check=True).has_group('account.group_show_line_subtotals_tax_included'))"/>
         <div class="js_tax_toggle_management" data-controller="/website/tax_toggle">
-            <label class="o_switch o_switch_danger js_tax_toggle_btn" for="id">
-                <input type="checkbox" t-att-checked="taxed" id="id"/>
+            <label class="o_switch o_switch_danger js_tax_toggle_btn">
+                <input type="checkbox" t-att-checked="taxed"/>
                 <span/>
                 <span>Show prices with taxes included</span>
             </label>


### PR DESCRIPTION
This tour was not effective because:

- Steps did not have proper wait conditions.
- That made them run fast without actually testing the desired effect.
- That left many remaining requests that could made tests to fail randomly, as you can see in https://github.com/OCA/e-commerce/pull/420#issuecomment-672026443.

Now it's shorter but more effective:

- It skips going to `/shop` at the start because it starts already there.
- It moves tour code to demo data.
- It adds proper checks to each trigger, to make sure it doesn't run before checking the result is OK.

@Tecnativa TT24410