### PR TITLE
[FIX] website_sale_b2x_alt_price: l10n resilient tests

### DIFF
--- a/website_sale_b2x_alt_price/static/tours/b2b.js
+++ b/website_sale_b2x_alt_price/static/tours/b2b.js
@@ -62,16 +62,16 @@ odoo.define("website_sale_b2x_alt_price.tour_b2b", function (require) {
                     "#product_details:has(.js_alt_price :containsExact(6.10)):has(.oe_currency_value:containsExact(5.00)):contains('Pen')",
                 run: goSearch,
             },
-            // Switch to discounted pricelist
+            // Switch to "website_sale_b2x_alt_price discounted" pricelist
             {
                 content: "open pricelist selector",
                 extra_trigger:
                     ".oe_product_cart:not(:has(.js_alt_list_price:visible, .text-danger:visible)) a:contains('Pen')",
-                trigger: ".btn:containsExact('Public Pricelist')",
+                trigger: ".btn:containsExact('website_sale_b2x_alt_price public')",
             },
             {
-                content: "select discounted pricelist",
-                trigger: ".switcher_pricelist:containsExact('Discounted Pricelist')",
+                content: "select website_sale_b2x_alt_price discounted",
+                trigger: ".switcher_pricelist:containsExact('website_sale_b2x_alt_price discounted')",
             },
             // Pen now has 10% discount
             {
@@ -102,12 +102,12 @@ odoo.define("website_sale_b2x_alt_price.tour_b2b", function (require) {
                 content: "open pricelist selector",
                 extra_trigger:
                     "#product_details:has(.js_alt_list_price:visible :containsExact(4.27)):has(.js_alt_price :containsExact(3.84)):has(.text-danger :containsExact(3.50)):has(.oe_currency_value:containsExact(3.15)):contains('Notebook')",
-                trigger: ".btn:containsExact('Discounted Pricelist')",
+                trigger: ".btn:containsExact('website_sale_b2x_alt_price discounted')",
             },
-            // Change to public pricelist; 10% discount disappears
+            // Change to "website_sale_b2x_alt_price public" pricelist; 10% discount disappears
             {
-                content: "select public pricelist",
-                trigger: ".switcher_pricelist:containsExact('Public Pricelist')",
+                content: "select website_sale_b2x_alt_price public",
+                trigger: ".switcher_pricelist:containsExact('website_sale_b2x_alt_price public')",
             },
             {
                 content: "select variant: a4 size",

--- a/website_sale_b2x_alt_price/static/tours/b2c.js
+++ b/website_sale_b2x_alt_price/static/tours/b2c.js
@@ -50,16 +50,16 @@ odoo.define("website_sale_b2x_alt_price.tour_b2c", function (require) {
                     "#product_details:has(.js_alt_price :containsExact(5.00)):has(.oe_currency_value:containsExact(6.10)):contains('Pen')",
                 run: tour_b2b.goSearch,
             },
-            // Switch to discounted pricelist
+            // Switch to "website_sale_b2x_alt_price discounted" pricelist
             {
                 content: "open pricelist selector",
                 extra_trigger:
                     ".oe_product_cart:not(:has(.js_alt_list_price:visible, .text-danger:visible)) a:contains('Pen')",
-                trigger: ".btn:containsExact('Public Pricelist')",
+                trigger: ".btn:containsExact('website_sale_b2x_alt_price public')",
             },
             {
-                content: "select discounted pricelist",
-                trigger: ".switcher_pricelist:containsExact('Discounted Pricelist')",
+                content: "select website_sale_b2x_alt_price discounted",
+                trigger: ".switcher_pricelist:containsExact('website_sale_b2x_alt_price discounted')",
             },
             // Pen now has 10% discount
             {
@@ -90,12 +90,12 @@ odoo.define("website_sale_b2x_alt_price.tour_b2c", function (require) {
                 content: "open pricelist selector",
                 extra_trigger:
                     "#product_details:has(.js_alt_list_price:visible :containsExact(3.50)):has(.js_alt_price :containsExact(3.15)):has(.text-danger :containsExact(4.27)):has(.oe_currency_value:containsExact(3.15)):contains('Notebook')",
-                trigger: ".btn:containsExact('Discounted Pricelist')",
+                trigger: ".btn:containsExact('website_sale_b2x_alt_price discounted')",
             },
-            // Change to public pricelist; 10% discount disappears
+            // Change to "website_sale_b2x_alt_price public" pricelist; 10% discount disappears
             {
-                content: "select public pricelist",
-                trigger: ".switcher_pricelist:containsExact('Public Pricelist')",
+                content: "select website_sale_b2x_alt_price public",
+                trigger: ".switcher_pricelist:containsExact('website_sale_b2x_alt_price public')",
             },
             {
                 content: "select variant: a4 size",

--- a/website_sale_b2x_alt_price/tests/test_ui.py
+++ b/website_sale_b2x_alt_price/tests/test_ui.py
@@ -7,6 +7,15 @@ from odoo.tests.common import HttpCase, Form
 class UICase(HttpCase):
     def setUp(self):
         super().setUp()
+        # Create and select a pricelist
+        # to make tests pass no matter what l10n package is enabled
+        website = self.env["website"].get_current_website()
+        pricelist = self.env["product.pricelist"].create({
+            "name": "website_sale_b2x_alt_price public",
+            "currency_id": website.user_id.company_id.currency_id.id,
+            "selectable": True,
+        })
+        website.user_id.property_product_pricelist = pricelist
         # Create some demo taxes
         self.tax_group_22 = self.env["account.tax.group"].create(
             {"name": "Tax group 22%"}
@@ -110,7 +119,7 @@ class UICase(HttpCase):
         # Create a pricelist selectable from website with 10% discount
         self.discount_pricelist = self.env["product.pricelist"].create(
             {
-                "name": "Discounted Pricelist",
+                "name": "website_sale_b2x_alt_price discounted",
                 "discount_policy": "without_discount",
                 "selectable": True,
                 "item_ids": [


### PR DESCRIPTION
When testing on an integration environment which had a different l10n package enabled, the tours failed due to currency rate conversion.

Create instead a test-specific pricelist and reset currency conversions before testing, to avoid false negative tests. That's not the feature being tested here.

@Tecnativa TT24410