### PR TITLE
[13.0] Add product_variant_multi_link

### DIFF
--- a/product_template_multi_link/models/product_template_link.py
+++ b/product_template_multi_link/models/product_template_link.py
@@ -20,21 +20,18 @@ class ProductTemplateLink(models.Model):
         required=True,
         ondelete="cascade",
     )
-
     right_product_tmpl_id = fields.Many2one(
         string="Linked Product",
         comodel_name="product.template",
         required=True,
         ondelete="cascade",
     )
-
     type_id = fields.Many2one(
         string="Link type",
         comodel_name="product.template.link.type",
         required=True,
         ondelete="restrict",
     )
-
     link_type_name = fields.Char(related="type_id.name")  # left to right
     link_type_inverse_name = fields.Char(
         related="type_id.inverse_name"
@@ -42,14 +39,16 @@ class ProductTemplateLink(models.Model):
 
     @api.constrains("left_product_tmpl_id", "right_product_tmpl_id", "type_id")
     def _check_products(self):
-        """
-        This method checks whether:
+        """Verify links between products.
+
+        Check whether:
             - the two products are different
             - there is only one link between the same two templates for the same type
+
         :raise: ValidationError if not ok
         """
         self.flush()  # flush required since the method uses plain sql
-        if any(rec.left_product_tmpl_id == rec.right_product_tmpl_id for rec in self):
+        if any(rec._check_product_not_different() for rec in self):
             raise ValidationError(
                 _("You can only create a link between 2 different products")
             )
@@ -57,17 +56,34 @@ class ProductTemplateLink(models.Model):
         products = self.mapped("left_product_tmpl_id") + self.mapped(
             "right_product_tmpl_id"
         )
-        self.env.cr.execute(
-            """
+        query, query_args = self._check_products_query(products)
+        self.env.cr.execute(query, query_args)
+        res = self.env.cr.fetchall()
+        is_duplicate_by_link_id = dict(res)
+        if True in is_duplicate_by_link_id.values():
+            ids = [k for k, v in is_duplicate_by_link_id.items() if v]
+            descrs = "\n ".join(
+                [l._duplicate_link_error_msg() for l in self.browse(ids)]
+            )
+            raise ValidationError(
+                _(
+                    "Only one link with the same type is allowed between 2 "
+                    "products. \n %s"
+                )
+                % descrs
+            )
+
+    def _check_product_not_different(self):
+        return self.left_product_tmpl_id == self.right_product_tmpl_id
+
+    def _check_products_query(self, products):
+        query = """
             SELECT
                 id,
                 l2.duplicate or l3.duplicate
             FROM (
                 SELECT
-                    id,
-                    left_product_tmpl_id,
-                    right_product_tmpl_id,
-                    type_id
+                    {main_select_columns}
                 FROM
                     %s
                 WHERE
@@ -80,9 +96,7 @@ class ProductTemplateLink(models.Model):
                 FROM
                     %s
                 WHERE
-                    right_product_tmpl_id = l1.left_product_tmpl_id
-                    AND left_product_tmpl_id = l1.right_product_tmpl_id
-                    AND type_id = l1.type_id
+                    {l2_join_where_clause}
             ) l2 ON TRUE
             LEFT JOIN LATERAL (
                 SELECT
@@ -90,47 +104,55 @@ class ProductTemplateLink(models.Model):
                 FROM
                     %s
                 WHERE
-                    left_product_tmpl_id = l1.left_product_tmpl_id
-                    AND right_product_tmpl_id = l1.right_product_tmpl_id
-                    AND type_id = l1.type_id
-                    AND id != l1.id
+                    {l3_join_where_clause}
             ) l3 ON TRUE
-        """,
-            (
-                AsIs(self._table),
-                tuple(products.ids),
-                tuple(products.ids),
-                AsIs(self._table),
-                AsIs(self._table),
-            ),
+        """.format(
+            **self._check_products_query_params()
         )
-        res = self.env.cr.fetchall()
-        is_duplicate_by_link_id = dict(res)
-        if True in is_duplicate_by_link_id.values():
-            ids = [k for k, v in is_duplicate_by_link_id.items() if v]
-            links = self.browse(ids)
-            descrs = []
-            for l in links:
-                descrs.append(
-                    u"{} <-> {} / {} <-> {}".format(
-                        l.left_product_tmpl_id.name,
-                        l.link_type_name,
-                        l.link_type_inverse_name,
-                        l.right_product_tmpl_id.name,
-                    )
-                )
-            links = "\n ".join(descrs)
-            raise ValidationError(
-                _(
-                    "Only one link with the same type is allowed between 2 "
-                    "products. \n %s"
-                )
-                % links
-            )
+        query_args = (
+            AsIs(self._table),
+            tuple(products.ids),
+            tuple(products.ids),
+            AsIs(self._table),
+            AsIs(self._table),
+        )
+        return query, query_args
+
+    def _check_products_query_params(self):
+        return dict(
+            main_select_columns="""
+                id,
+                left_product_tmpl_id,
+                right_product_tmpl_id,
+                type_id
+            """,
+            l2_join_where_clause="""
+            right_product_tmpl_id = l1.left_product_tmpl_id
+            AND left_product_tmpl_id = l1.right_product_tmpl_id
+            AND type_id = l1.type_id
+        """,
+            l3_join_where_clause="""
+            left_product_tmpl_id = l1.left_product_tmpl_id
+            AND right_product_tmpl_id = l1.right_product_tmpl_id
+            AND type_id = l1.type_id
+            AND id != l1.id
+        """,
+        )
+
+    def _duplicate_link_error_msg(self):
+        return "{} <-> {} / {} <-> {}".format(
+            self.left_product_tmpl_id.name,
+            self.link_type_name,
+            self.link_type_inverse_name,
+            self.right_product_tmpl_id.name,
+        )
 
     @contextmanager
     def _invalidate_links_on_product_template(self):
         yield
+        self._invalidate_links()
+
+    def _invalidate_links(self):
         self.env["product.template"].invalidate_cache(["product_template_link_ids"])
 
     @api.model

--- a/product_template_multi_link/tests/test_product_template_link.py
+++ b/product_template_multi_link/tests/test_product_template_link.py
@@ -9,6 +9,7 @@ class TestProductTemplateLink(SavepointCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
         cls.ProductTemplateLink = cls.env["product.template.link"]
         cls.product_product_1 = cls.env.ref("product.product_product_1")
         cls.product_product_2 = cls.env.ref("product.product_product_2")

--- a/product_template_multi_link/tests/test_product_template_link.py
+++ b/product_template_multi_link/tests/test_product_template_link.py
@@ -9,7 +9,15 @@ class TestProductTemplateLink(SavepointCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.env = cls.env(
+            context=dict(
+                cls.env.context,
+                tracking_disable=True,
+                # compatibility flag when you run tests on a db
+                # where `product_variant_multi_link` is installed.
+                _product_variant_link_bypass_check=True,
+            )
+        )
         cls.ProductTemplateLink = cls.env["product.template.link"]
         cls.product_product_1 = cls.env.ref("product.product_product_1")
         cls.product_product_2 = cls.env.ref("product.product_product_2")

--- a/product_template_multi_link/tests/test_product_template_link_type.py
+++ b/product_template_multi_link/tests/test_product_template_link_type.py
@@ -11,6 +11,7 @@ class TestProductTemplateLinkType(SavepointCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
         cls.LinkType = cls.env["product.template.link.type"]
         cls.link_type_cross_selling = cls.env.ref(
             "product_template_multi_link.product_template_link_type_cross_selling"

--- a/product_variant_multi_link/__init__.py
+++ b/product_variant_multi_link/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/product_variant_multi_link/__manifest__.py
+++ b/product_variant_multi_link/__manifest__.py
@@ -1,0 +1,15 @@
+# Copyright 2020 Camptocamp SA (http://www.camptocamp.com)
+# Simone Orsi <simahawk@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Product Multi Links (Variant)",
+    "version": "13.0.1.0.0",
+    "category": "Generic Modules",
+    "author": "Camptocamp SA, Odoo Community Association (OCA)",
+    "website": "https://github.com/OCA/e-commerce",
+    "license": "AGPL-3",
+    "depends": ["product_template_multi_link"],
+    "data": ["views/product_template_link_view.xml"],
+    "installable": True,
+}

--- a/product_variant_multi_link/models/__init__.py
+++ b/product_variant_multi_link/models/__init__.py
@@ -1,0 +1,2 @@
+from . import product_product
+from . import product_template_link

--- a/product_variant_multi_link/models/product_product.py
+++ b/product_variant_multi_link/models/product_product.py
@@ -1,0 +1,24 @@
+# Copyright 2020 Camptocamp SA (http://www.camptocamp.com)
+# Simone Orsi <simahawk@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ProductProduct(models.Model):
+    _inherit = "product.product"
+
+    product_variant_link_ids = fields.One2many(
+        string="Product Variant Links",
+        comodel_name="product.template.link",
+        compute="_compute_product_link_ids",
+    )
+
+    def _compute_product_link_ids(self):
+        for record in self:
+            record.product_variant_link_ids = record._get_variant_links()
+
+    def _get_variant_links(self):
+        return self.product_template_link_ids.filtered_domain(
+            ["|", ("left_product_id", "=", self.id), ("right_product_id", "=", self.id)]
+        )

--- a/product_variant_multi_link/models/product_template_link.py
+++ b/product_variant_multi_link/models/product_template_link.py
@@ -1,0 +1,66 @@
+# Copyright 2020 Camptocamp SA (http://www.camptocamp.com)
+# Simone Orsi <simahawk@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import _, api, exceptions, fields, models
+
+
+class ProductTemplateLink(models.Model):
+    _inherit = "product.template.link"
+
+    left_product_id = fields.Many2one(
+        string="Source Variant", comodel_name="product.product", ondelete="cascade",
+    )
+    right_product_id = fields.Many2one(
+        string="Linked Variant", comodel_name="product.product", ondelete="cascade",
+    )
+
+    def _product_variant_check_enabled(self):
+        # You might want to turn off the check on variants, here's your chance
+        return not self.env.context.get("_product_variant_link_bypass_check")
+
+    @api.constrains(
+        "left_product_tmpl_id",
+        "right_product_tmpl_id",
+        "type_id",
+        "left_product_id",
+        "right_product_id",
+    )
+    def _check_products(self):
+        if self._product_variant_check_enabled():
+            for rec in self:
+                # make new fields required here
+                # to avoid issues w/ existing table and existing records
+                if not rec.left_product_id or not rec.right_product_id:
+                    raise exceptions.ValidationError(
+                        _("Source and target variants are required!")
+                    )
+        super()._check_products()
+
+    def _check_product_not_different(self):
+        res = super()._check_product_not_different()
+        if self._product_variant_check_enabled():
+            return res and self.left_product_id == self.right_product_id
+        return res
+
+    def _check_products_query_params(self):
+        params = super()._check_products_query_params()
+        if self._product_variant_check_enabled():
+            params["main_select_columns"] += ", right_product_id, left_product_id"
+            params[
+                "l2_join_where_clause"
+            ] += """
+                AND right_product_id = l1.left_product_id
+                AND left_product_id = l1.right_product_id
+            """
+            params[
+                "l3_join_where_clause"
+            ] += """
+                AND left_product_id = l1.left_product_id
+                AND right_product_id = l1.right_product_id
+            """
+        return params
+
+    def _invalidate_links(self):
+        super()._invalidate_links()
+        self.env["product.product"].invalidate_cache(["product_variant_link_ids"])

--- a/product_variant_multi_link/readme/CONTRIBUTORS.rst
+++ b/product_variant_multi_link/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Simone Orsi <simahawk@gmail.com>

--- a/product_variant_multi_link/readme/CREDITS.rst
+++ b/product_variant_multi_link/readme/CREDITS.rst
@@ -1,0 +1,4 @@
+The development of this module has been financially supported by:
+
+* Camptocamp
+* Cosanum

--- a/product_variant_multi_link/readme/DESCRIPTION.rst
+++ b/product_variant_multi_link/readme/DESCRIPTION.rst
@@ -1,0 +1,1 @@
+Extends `product_template_multi_link` to link product variants.

--- a/product_variant_multi_link/readme/USAGE.rst
+++ b/product_variant_multi_link/readme/USAGE.rst
@@ -1,0 +1,2 @@
+Create a link as you would do with `product_template_multi_link`
+and after setting a template, set a variant for that template.

--- a/product_variant_multi_link/tests/__init__.py
+++ b/product_variant_multi_link/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_product_template_link

--- a/product_variant_multi_link/tests/test_product_template_link.py
+++ b/product_variant_multi_link/tests/test_product_template_link.py
@@ -1,0 +1,86 @@
+# Copyright 2020 Camptocamp SA (http://www.camptocamp.com)
+# Simone Orsi <simahawk@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.exceptions import ValidationError
+from odoo.tests.common import SavepointCase
+
+
+class TestProductVariantLink(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.ProductTemplateLink = cls.env["product.template.link"]
+        cls.product_product_1 = cls.env.ref("product.product_product_1")
+        cls.product_product_2 = cls.env.ref("product.product_product_2")
+        cls.link_type = cls.env.ref(
+            "product_template_multi_link.product_template_link_type_cross_selling"
+        )
+
+    def _create_link_default(self):
+        return self.ProductTemplateLink.create(
+            {
+                "left_product_tmpl_id": self.product_product_1.product_tmpl_id.id,
+                "left_product_id": self.product_product_1.id,
+                "right_product_tmpl_id": self.product_product_2.product_tmpl_id.id,
+                "right_product_id": self.product_product_2.id,
+                "type_id": self.link_type.id,
+            }
+        )
+
+    def test_variants_required(self):
+        with self.assertRaises(ValidationError) as err:
+            self.ProductTemplateLink.create(
+                {
+                    "left_product_tmpl_id": self.product_product_1.product_tmpl_id.id,
+                    "right_product_tmpl_id": self.product_product_2.product_tmpl_id.id,
+                    "type_id": self.link_type.id,
+                }
+            )
+        self.assertEqual(err.exception.name, "Source and target variants are required!")
+
+    def test_duplicated_link_different_product(self):
+        link1 = self._create_link_default()
+        with self.assertRaises(ValidationError), self.env.cr.savepoint():
+            link1.copy()
+
+        # create the same link but inverse
+        with self.assertRaises(ValidationError), self.env.cr.savepoint():
+            self.ProductTemplateLink.create(
+                {
+                    "left_product_tmpl_id": self.product_product_2.product_tmpl_id.id,
+                    "left_product_id": self.product_product_2.id,
+                    "right_product_tmpl_id": self.product_product_1.product_tmpl_id.id,
+                    "right_product_id": self.product_product_1.id,
+                    "type_id": self.link_type.id,
+                }
+            )
+
+    def test_duplicated_link_same_product(self):
+        with self.assertRaises(ValidationError), self.env.cr.savepoint():
+            self.ProductTemplateLink.create(
+                {
+                    "left_product_tmpl_id": self.product_product_1.product_tmpl_id.id,
+                    "left_product_id": self.product_product_1.id,
+                    "right_product_tmpl_id": self.product_product_1.product_tmpl_id.id,
+                    "right_product_id": self.product_product_1.id,
+                    "type_id": self.link_type.id,
+                }
+            )
+
+    def test_product_variant_link_ids(self):
+        link1 = self._create_link_default()
+        self.assertIn(link1, self.product_product_1.product_template_link_ids)
+        self.assertIn(link1, self.product_product_2.product_template_link_ids)
+        self.assertIn(link1, self.product_product_1.product_variant_link_ids)
+        self.assertIn(link1, self.product_product_2.product_variant_link_ids)
+
+    def test_cache_invalidation(self):
+        link1 = self._create_link_default()
+        self.assertIn(link1, self.product_product_1.product_variant_link_ids)
+        self.assertIn(link1, self.product_product_2.product_variant_link_ids)
+
+        link1.unlink()
+        self.assertNotIn(link1, self.product_product_1.product_variant_link_ids)
+        self.assertNotIn(link1, self.product_product_2.product_variant_link_ids)

--- a/product_variant_multi_link/views/product_template_link_view.xml
+++ b/product_variant_multi_link/views/product_template_link_view.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id='product_template_link__search' model='ir.ui.view'>
+        <field name="model">product.template.link</field>
+        <field
+            name="inherit_id"
+            ref="product_template_multi_link.product_template_link__search"
+        />
+        <field name="arch" type="xml">
+            <field name="left_product_tmpl_id" position="after">
+                <field
+                    name="left_product_id"
+                    string="Variant"
+                    filter_domain="['|',('left_product_id','ilike',self),('right_product_id','ilike',self)]"
+                />
+            </field>
+        </field>
+    </record>
+    <record id="product_template_link_tree" model="ir.ui.view">
+        <field name="model">product.template.link</field>
+        <field
+            name="inherit_id"
+            ref="product_template_multi_link.product_template_link_tree"
+        />
+        <field name="arch" type="xml">
+            <field name="left_product_tmpl_id" position="after">
+                <field
+                    name="left_product_id"
+                    domain="[('product_tmpl_id','=',left_product_tmpl_id)]"
+                />
+            </field>
+            <field name="right_product_tmpl_id" position="after">
+                <field
+                    name="right_product_id"
+                    domain="[('product_tmpl_id','=',right_product_tmpl_id)]"
+                />
+            </field>
+        </field>
+    </record>
+    <record id="product_template_link_kanban" model="ir.ui.view">
+        <field name="model">product.template.link</field>
+        <field
+            name="inherit_id"
+            ref="product_template_multi_link.product_template_link_kanban"
+        />
+        <field name="arch" type="xml">
+            <field name="left_product_tmpl_id" position="after">
+                <field
+                    name="left_product_id"
+                    domain="[('product_tmpl_id','=',left_product_tmpl_id)]"
+                />
+            </field>
+            <field name="right_product_tmpl_id" position="after">
+                <field
+                    name="right_product_id"
+                    domain="[('product_tmpl_id','=',right_product_tmpl_id)]"
+                />
+            </field>
+        </field>
+    </record>
+    <record id="product_template_link_form" model="ir.ui.view">
+        <field name="model">product.template.link</field>
+        <field
+            name="inherit_id"
+            ref="product_template_multi_link.product_template_link_form"
+        />
+        <field name="arch" type="xml">
+            <field name="left_product_tmpl_id" position="after">
+                <field
+                    name="left_product_id"
+                    domain="[('product_tmpl_id','=',left_product_tmpl_id)]"
+                />
+            </field>
+            <field name="right_product_tmpl_id" position="after">
+                <field
+                    name="right_product_id"
+                    domain="[('product_tmpl_id','=',right_product_tmpl_id)]"
+                />
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/setup/product_variant_multi_link/odoo/addons/product_variant_multi_link
+++ b/setup/product_variant_multi_link/odoo/addons/product_variant_multi_link
@@ -1,0 +1,1 @@
+../../../../product_variant_multi_link

--- a/setup/product_variant_multi_link/setup.py
+++ b/setup/product_variant_multi_link/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
Extends `product_template_multi_link` to link product variants.

NOTE: on v10 there's [product_multi_link](https://github.com/OCA/e-commerce/blob/10.0/product_multi_link) but is not based on `product_template_multi_link` which is more advanced after refactoring by @lmignon 