### PR TITLE
[12.0][IMP] website_sale_product_minimal_price: Added fuctionality for take care about the current pricelist items

### DIFF
--- a/website_sale_product_minimal_price/README.rst
+++ b/website_sale_product_minimal_price/README.rst
@@ -34,6 +34,12 @@ price and set order by minimal price in product's view.
 .. contents::
    :local:
 
+Configuration
+=============
+
+#. Go to *Settings > General Settings > Website* and active the option *Multiple Sales
+   Prices per Product* with the second option, for use the pricelists.
+
 Usage
 =====
 
@@ -41,8 +47,35 @@ Usage
    value or define a distinct prices in public price list for this variant.
 #. Go to Website Shop.
 #. You will see that in main products view appears the text "From " with
-   minimal price if the product has a distinct prices by attribute.
-#. Click on product, the price displayed is the minimal variant price.
+   minimal price if the product has a distinct prices by attribute or at least a
+   rate on the current pricelist.
+#. Click on product, the price displayed is the minimal variant price. On the chart
+   under the buy button you can see the different taxes applied to the product.
+
+Changelog
+=========
+
+12.0.1.1.0 (2020-09-30)
+~~~~~~~~~~~~~~~~~~~~~~~
+
+* [IMP] Has been added the functionality that allows to take care about the rates to
+  calculate the minimum price of the product. Furthermore, a dynamic grid was added
+  to the product sheet to see the different prices that his variants take.
+
+  The grid depends on product variant selected and the quantity selected. If more than 3
+  rates are assigned to some product variant the rates on the grid will be the actual
+  and 2 next rates, when we achieve the quantity of the next, the table will be updated
+  to show next values.
+
+12.0.1.0.0 (2019-12-12)
+~~~~~~~~~~~~~~~~~~~~~~~
+
+* [MIG] Initial V12 version. Complete migration from v11.
+
+11.0.1.0.0 (2019-05-28)
+~~~~~~~~~~~~~~~~~~~~~~~
+
+* [NEW] Module added to v11.
 
 Bug Tracker
 ===========
@@ -67,7 +100,8 @@ Contributors
 
 * `Tecnativa <https://www.tecnativa.com>`_:
 
-    * Sergio Teruel <sergio.teruel@tecnativa.com>
+    * Sergio Teruel
+    * Carlos Roca
 
 Maintainers
 ~~~~~~~~~~~

--- a/website_sale_product_minimal_price/__init__.py
+++ b/website_sale_product_minimal_price/__init__.py
@@ -1,2 +1,3 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from . import models
+from . import controllers

--- a/website_sale_product_minimal_price/__manifest__.py
+++ b/website_sale_product_minimal_price/__manifest__.py
@@ -13,7 +13,10 @@
     'application': False,
     'installable': True,
     'depends': [
-        'website_sale',
+        'website_sale_stock',
+    ],
+    'demo': [
+        'demo/assets.xml',
     ],
     'data': [
         'views/assets.xml',

--- a/website_sale_product_minimal_price/controllers/__init__.py
+++ b/website_sale_product_minimal_price/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import main

--- a/website_sale_product_minimal_price/controllers/main.py
+++ b/website_sale_product_minimal_price/controllers/main.py
@@ -1,0 +1,82 @@
+# Copyright 2020 Tecnativa - Carlos Roca
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo.addons.website_sale.controllers.main import WebsiteSale
+from odoo import http, tools
+from odoo.http import request
+from odoo import fields
+
+
+class WebsiteSaleProductDetailAttributeImage(WebsiteSale):
+
+    @http.route(['/sale/get_combination_info_pricelist_atributes'],
+                type='json',
+                auth="public",
+                website=True)
+    def get_combination_info_pricelist_atributes(
+            self, product_id, actual_qty, **kwargs):
+        """Special route to use website logic in get_combination_info override.
+        This route is called in JS by appending _website to the base route.
+        """
+        actual_qty = int(actual_qty)
+        product = request.env["product.product"].browse(product_id)
+        current_website = request.env["website"].get_current_website()
+        today = fields.Date.today()
+        res = []
+        pricelist = current_website.get_current_pricelist()
+        pricelist_variant_items = pricelist.item_ids.filtered(
+            lambda i: i.product_id.id == product.id
+            and (not i.date_start or i.date_start <= today)
+            and (not i.date_end or today <= i.date_end)
+            and i.min_quantity > 0)
+        if pricelist_variant_items:
+            item_min_qty = min(pricelist_variant_items, key=lambda i: i.min_quantity)
+            min_qty = item_min_qty.min_quantity
+            pricelist_tmpl_items = pricelist.item_ids.filtered(
+                lambda i: i.product_tmpl_id.id == product.product_tmpl_id.id
+                and i.min_quantity < min_qty
+                and (not i.date_start or i.date_start <= today)
+                and (not i.date_end or today <= i.date_end)
+                and i.min_quantity > 0)
+        else:
+            pricelist_tmpl_items = pricelist.item_ids.filtered(
+                lambda i: i.product_tmpl_id.id == product.product_tmpl_id.id
+                and (not i.date_start or i.date_start <= today)
+                and (not i.date_end or today <= i.date_end)
+                and i.min_quantity > 0)
+        self._prepare_dictionary(pricelist_variant_items, product, res)
+        self._prepare_dictionary(pricelist_tmpl_items, product, res)
+        res.sort(key=lambda i: i.get('min_qty', 0))
+        return res
+
+    def _prepare_dictionary(self, pricelist_items, product, res):
+        for item in pricelist_items:
+            final_price = item.fixed_price
+            if item.compute_price == 'formula':
+                price_limit = product.list_price
+                price = (
+                    product.list_price - (
+                        (product.list_price * item.price_discount) / 100)
+                )
+                if item.price_round:
+                    price = tools.float_round(
+                        price, precision_rounding=item.price_round)
+                if item.price_surcharge:
+                    price += item.price_surcharge
+                if item.price_min_margin:
+                    price = max(price, price_limit + item.price_min_margin)
+                if item.price_max_margin:
+                    price = min(price, price_limit + item.price_max_margin)
+                final_price = price
+            elif item.compute_price == 'percentage':
+                final_price = (
+                    product.list_price - (product.list_price * item.percent_price) / 100
+                )
+            if final_price > 0:
+                res.append({
+                    "min_qty": item.min_quantity,
+                    "price": final_price,
+                    "currency": {
+                        "position": product.currency_id.position,
+                        "symbol": product.currency_id.symbol,
+                    },
+                })

--- a/website_sale_product_minimal_price/demo/assets.xml
+++ b/website_sale_product_minimal_price/demo/assets.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="assets_frontend_demo" inherit_id="website.assets_frontend">
+        <xpath expr=".">
+            <script type="text/javascript"
+                    src="/website_sale_product_minimal_price/static/src/js/website_sale_product_minimal_price_tour.js"/>
+        </xpath>
+    </template>
+</odoo>

--- a/website_sale_product_minimal_price/i18n/es.po
+++ b/website_sale_product_minimal_price/i18n/es.po
@@ -4,18 +4,18 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 11.0\n"
+"Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-12-11 23:22+0000\n"
-"PO-Revision-Date: 2019-12-12 00:24+0100\n"
-"Last-Translator: \n"
+"POT-Creation-Date: 2020-10-26 12:49+0000\n"
+"PO-Revision-Date: 2020-10-26 13:51+0100\n"
 "Language-Team: \n"
-"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 2.0.6\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
+"Language: es\n"
 
 #. module: website_sale_product_minimal_price
 #: model_terms:ir.ui.view,arch_db:website_sale_product_minimal_price.products_item
@@ -23,24 +23,13 @@ msgid "<span>From </span>"
 msgstr "<span>Desde </span>"
 
 #. module: website_sale_product_minimal_price
-#: model:ir.model.fields,field_description:website_sale_product_minimal_price.field_product_product__has_distinct_variant_price
-#: model:ir.model.fields,field_description:website_sale_product_minimal_price.field_product_template__has_distinct_variant_price
-msgid "Has variants with distinct price extra"
-msgstr "Tiene variantes con diferentes precios extra"
+#. openerp-web
+#: code:addons/website_sale_product_minimal_price/static/src/xml/website_sale_product_minimal_price.xml:5
+#, python-format
+msgid "Prices per quantity ("
+msgstr "Precios por cantidad ("
 
 #. module: website_sale_product_minimal_price
 #: model:ir.model,name:website_sale_product_minimal_price.model_product_template
 msgid "Product Template"
 msgstr "Plantilla de producto"
-
-#~ msgid "My product test with various prices"
-#~ msgstr "Mi producto de test con varios precios"
-
-#~ msgid "Test attribute"
-#~ msgstr "Atributo de prueba"
-
-#~ msgid "Test v1"
-#~ msgstr "Valor 1 de test"
-
-#~ msgid "Test v2"
-#~ msgstr "Valor 2 de test"

--- a/website_sale_product_minimal_price/i18n/website_sale_product_minimal_price.pot
+++ b/website_sale_product_minimal_price/i18n/website_sale_product_minimal_price.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-10-26 12:49+0000\n"
+"PO-Revision-Date: 2020-10-26 12:49+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -19,9 +21,10 @@ msgid "<span>From </span>"
 msgstr ""
 
 #. module: website_sale_product_minimal_price
-#: model:ir.model.fields,field_description:website_sale_product_minimal_price.field_product_product__has_distinct_variant_price
-#: model:ir.model.fields,field_description:website_sale_product_minimal_price.field_product_template__has_distinct_variant_price
-msgid "Has variants with distinct price extra"
+#. openerp-web
+#: code:addons/website_sale_product_minimal_price/static/src/xml/website_sale_product_minimal_price.xml:5
+#, python-format
+msgid "Prices per quantity ("
 msgstr ""
 
 #. module: website_sale_product_minimal_price

--- a/website_sale_product_minimal_price/models/product_template.py
+++ b/website_sale_product_minimal_price/models/product_template.py
@@ -1,22 +1,10 @@
 # Copyright 2019 Tecnativa - Sergio Teruel
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-from odoo import fields, models
+from odoo import fields, models, tools
 
 
 class ProductTemplate(models.Model):
     _inherit = 'product.template'
-
-    has_distinct_variant_price = fields.Boolean(
-        compute='_compute_has_distinct_variant_price',
-        string='Has variants with distinct price extra',
-    )
-
-    def _compute_has_distinct_variant_price(self):
-        for template in self:
-            if template.product_variant_count > 1:
-                prices = template.product_variant_ids.mapped('website_price')
-                if len(prices) > 1:
-                    template.has_distinct_variant_price = True
 
     def _get_combination_info(
         self, combination=False, product_id=False, add_qty=1, pricelist=False,
@@ -24,23 +12,81 @@ class ProductTemplate(models.Model):
         """
         Update product template prices for products items view in website shop
         render with cheaper variant prices.
+        Checking the context, we can know if we are on grid view or at the product view.
+        With this comprobation we avoid problems rendering the price at the product
+        view.
         """
+        has_pricelist_items = False
+        quantity = self.env.context.get('quantity', add_qty)
+        context = dict(
+            self.env.context,
+            quantity=quantity,
+            pricelist=pricelist.id if pricelist else False
+        )
+        product_template = self.with_context(context)
+        combination = combination or product_template.env[
+            'product.template.attribute.value']
+        if product_id and not combination:
+            product = product_template.env['product.product'].browse(product_id)
+        else:
+            product = product_template._get_variant_for_combination(combination)
+        if pricelist and "bin_size" in self.env.context:
+            # In this version the categories are not contempled.
+            today = fields.Date.today()
+            pricelist_items = pricelist.item_ids.filtered(
+                lambda i: i.product_tmpl_id.id == self.id
+                or i.product_id.product_tmpl_id.id == self.id
+                and i.min_quantity > add_qty
+                and (not i.date_start or i.date_start <= today)
+                and (not i.date_end or today <= i.date_end))
+            has_pricelist_items = bool(pricelist_items)
+            if product:
+                min_price = product.list_price
+                for item in pricelist_items:
+                    final_price = item.fixed_price
+                    price = product.list_price
+                    price_limit = product.list_price
+                    if item.compute_price == 'formula':
+                        price = (
+                            price_limit - (price_limit * item.price_discount) / 100
+                        )
+                        if item.price_round:
+                            price = tools.float_round(
+                                price, precision_rounding=item.price_round)
+                        if item.price_surcharge:
+                            price += item.price_surcharge
+                        if item.price_min_margin:
+                            price = max(price, price_limit + item.price_min_margin)
+                        if item.price_max_margin:
+                            price = min(price, price_limit + item.price_max_margin)
+                        final_price = price
+                    elif item.compute_price == 'percentage':
+                        final_price = (
+                            product.list_price - (
+                                product.list_price * item.percent_price) / 100
+                        )
+                    if final_price < min_price:
+                        add_qty = item.min_quantity
+                        min_price = final_price
         combination_info = super()._get_combination_info(
             combination=combination, product_id=product_id, add_qty=add_qty,
             pricelist=pricelist, parent_combination=parent_combination,
             only_template=only_template)
-
         if (only_template and self.env.context.get('website_id') and
-                self.product_variant_count > 1):
+                (self.product_variant_count > 1 or has_pricelist_items)):
             cheaper_variant = self.product_variant_ids.sorted(
-                key=lambda p: p.website_price)[:1]
+                key=lambda p: p._get_combination_info_variant(
+                    pricelist=pricelist
+                )['price']
+            )[:1]
 
-            res = cheaper_variant._get_combination_info_variant()
+            res = cheaper_variant._get_combination_info_variant(pricelist=pricelist)
 
             combination_info.update({
                 'price': res.get('price'),
                 'list_price': res.get('list_price'),
                 'has_discounted_price': res.get('has_discounted_price'),
+                'has_distinct_price': True,
             })
         return combination_info
 

--- a/website_sale_product_minimal_price/readme/CONFIGURE.rst
+++ b/website_sale_product_minimal_price/readme/CONFIGURE.rst
@@ -1,0 +1,2 @@
+#. Go to *Settings > General Settings > Website* and active the option *Multiple Sales
+   Prices per Product* with the second option, for use the pricelists.

--- a/website_sale_product_minimal_price/readme/CONTRIBUTORS.rst
+++ b/website_sale_product_minimal_price/readme/CONTRIBUTORS.rst
@@ -1,3 +1,4 @@
 * `Tecnativa <https://www.tecnativa.com>`_:
 
-    * Sergio Teruel <sergio.teruel@tecnativa.com>
+    * Sergio Teruel
+    * Carlos Roca

--- a/website_sale_product_minimal_price/readme/HISTORY.rst
+++ b/website_sale_product_minimal_price/readme/HISTORY.rst
@@ -1,0 +1,21 @@
+12.0.1.1.0 (2020-09-30)
+~~~~~~~~~~~~~~~~~~~~~~~
+
+* [IMP] Has been added the functionality that allows to take care about the rates to
+  calculate the minimum price of the product. Furthermore, a dynamic grid was added
+  to the product sheet to see the different prices that his variants take.
+
+  The grid depends on product variant selected and the quantity selected. If more than 3
+  rates are assigned to some product variant the rates on the grid will be the actual
+  and 2 next rates, when we achieve the quantity of the next, the table will be updated
+  to show next values.
+
+12.0.1.0.0 (2019-12-12)
+~~~~~~~~~~~~~~~~~~~~~~~
+
+* [MIG] Initial V12 version. Complete migration from v11.
+
+11.0.1.0.0 (2019-05-28)
+~~~~~~~~~~~~~~~~~~~~~~~
+
+* [NEW] Module added to v11.

--- a/website_sale_product_minimal_price/readme/USAGE.rst
+++ b/website_sale_product_minimal_price/readme/USAGE.rst
@@ -2,5 +2,7 @@
    value or define a distinct prices in public price list for this variant.
 #. Go to Website Shop.
 #. You will see that in main products view appears the text "From " with
-   minimal price if the product has a distinct prices by attribute.
-#. Click on product, the price displayed is the minimal variant price.
+   minimal price if the product has a distinct prices by attribute or at least a
+   rate on the current pricelist.
+#. Click on product, the price displayed is the minimal variant price. On the chart
+   under the buy button you can see the different taxes applied to the product.

--- a/website_sale_product_minimal_price/static/description/index.html
+++ b/website_sale_product_minimal_price/static/description/index.html
@@ -374,29 +374,73 @@ price and set order by minimal price in product’s view.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
-<li><a class="reference internal" href="#usage" id="id1">Usage</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="id2">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="id3">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="id4">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="id5">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="id6">Maintainers</a></li>
+<li><a class="reference internal" href="#configuration" id="id4">Configuration</a></li>
+<li><a class="reference internal" href="#usage" id="id5">Usage</a></li>
+<li><a class="reference internal" href="#changelog" id="id6">Changelog</a><ul>
+<li><a class="reference internal" href="#id1" id="id7">12.0.1.1.0 (2020-09-30)</a></li>
+<li><a class="reference internal" href="#id2" id="id8">12.0.1.0.0 (2019-12-12)</a></li>
+<li><a class="reference internal" href="#id3" id="id9">11.0.1.0.0 (2019-05-28)</a></li>
+</ul>
+</li>
+<li><a class="reference internal" href="#bug-tracker" id="id10">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="id11">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="id12">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="id13">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="id14">Maintainers</a></li>
 </ul>
 </li>
 </ul>
 </div>
+<div class="section" id="configuration">
+<h1><a class="toc-backref" href="#id4">Configuration</a></h1>
+<ol class="arabic simple">
+<li>Go to <em>Settings &gt; General Settings &gt; Website</em> and active the option <em>Multiple Sales
+Prices per Product</em> with the second option, for use the pricelists.</li>
+</ol>
+</div>
 <div class="section" id="usage">
-<h1><a class="toc-backref" href="#id1">Usage</a></h1>
+<h1><a class="toc-backref" href="#id5">Usage</a></h1>
 <ol class="arabic simple">
 <li>Go to backend and set a product with variants and extra price by attribute
 value or define a distinct prices in public price list for this variant.</li>
 <li>Go to Website Shop.</li>
 <li>You will see that in main products view appears the text “From ” with
-minimal price if the product has a distinct prices by attribute.</li>
-<li>Click on product, the price displayed is the minimal variant price.</li>
+minimal price if the product has a distinct prices by attribute or at least a
+rate on the current pricelist.</li>
+<li>Click on product, the price displayed is the minimal variant price. On the chart
+under the buy button you can see the different taxes applied to the product.</li>
 </ol>
 </div>
+<div class="section" id="changelog">
+<h1><a class="toc-backref" href="#id6">Changelog</a></h1>
+<div class="section" id="id1">
+<h2><a class="toc-backref" href="#id7">12.0.1.1.0 (2020-09-30)</a></h2>
+<ul>
+<li><p class="first">[IMP] Has been added the functionality that allows to take care about the rates to
+calculate the minimum price of the product. Furthermore, a dynamic grid was added
+to the product sheet to see the different prices that his variants take.</p>
+<p>The grid depends on product variant selected and the quantity selected. If more than 3
+rates are assigned to some product variant the rates on the grid will be the actual
+and 2 next rates, when we achieve the quantity of the next, the table will be updated
+to show next values.</p>
+</li>
+</ul>
+</div>
+<div class="section" id="id2">
+<h2><a class="toc-backref" href="#id8">12.0.1.0.0 (2019-12-12)</a></h2>
+<ul class="simple">
+<li>[MIG] Initial V12 version. Complete migration from v11.</li>
+</ul>
+</div>
+<div class="section" id="id3">
+<h2><a class="toc-backref" href="#id9">11.0.1.0.0 (2019-05-28)</a></h2>
+<ul class="simple">
+<li>[NEW] Module added to v11.</li>
+</ul>
+</div>
+</div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#id2">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#id10">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/e-commerce/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us smashing it by providing a detailed and welcomed
@@ -404,27 +448,28 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#id3">Credits</a></h1>
+<h1><a class="toc-backref" href="#id11">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#id4">Authors</a></h2>
+<h2><a class="toc-backref" href="#id12">Authors</a></h2>
 <ul class="simple">
 <li>Tecnativa</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#id5">Contributors</a></h2>
+<h2><a class="toc-backref" href="#id13">Contributors</a></h2>
 <ul>
 <li><p class="first"><a class="reference external" href="https://www.tecnativa.com">Tecnativa</a>:</p>
 <blockquote>
 <ul class="simple">
-<li>Sergio Teruel &lt;<a class="reference external" href="mailto:sergio.teruel&#64;tecnativa.com">sergio.teruel&#64;tecnativa.com</a>&gt;</li>
+<li>Sergio Teruel</li>
+<li>Carlos Roca</li>
 </ul>
 </blockquote>
 </li>
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#id6">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#id14">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose

--- a/website_sale_product_minimal_price/static/src/js/website_sale_product_minimal_price.js
+++ b/website_sale_product_minimal_price/static/src/js/website_sale_product_minimal_price.js
@@ -1,0 +1,84 @@
+odoo.define("website_sale_product_minimal_price.load", function (require) {
+    "use strict";
+    var ajax = require("web.ajax");
+    var core = require("web.core");
+    var field_utils = require("web.field_utils");
+    var ProductConfiguratorMixin = require(
+        "website_sale_stock.ProductConfiguratorMixin");
+    var QWeb = core.qweb;
+    var load_xml = ajax.loadXML(
+        "/website_sale_product_minimal_price/static/src/xml/" +
+            "website_sale_product_minimal_price.xml",
+        QWeb
+    );
+
+    // Save original method
+    var _onChangeCombinationStock =
+        ProductConfiguratorMixin._onChangeCombinationStock;
+    ProductConfiguratorMixin._onChangeCombinationStock = function (
+        ev,
+        $parent,
+        combination
+    ) {
+        var self = this;
+        var args = arguments;
+        if (!this.isWebsite) {
+            return;
+        }
+        ajax.jsonRpc("/sale/get_combination_info_pricelist_atributes", "call", {
+            product_id: combination.product_id,
+            actual_qty: $(".quantity").val(),
+        }).then(function (unit_prices) {
+            $(".temporal").remove();
+            if (unit_prices.length > 0) {
+                load_xml.then(function () {
+                    var $form = $('form[action*="/shop/cart/update"]');
+                    $form.append('<hr class="temporal"/>');
+                    $form.append(
+                        QWeb.render(
+                            "website_sale_product_minimal_price.title",
+                            {
+                                uom: combination.uom_name,
+                            }
+                        )
+                    );
+                    // We define a limit of displayed columns as 4
+                    const limit_col = 4;
+                    var $div = undefined;
+                    for (var i in unit_prices) {
+                        if (unit_prices[i].price === 0) {
+                            continue;
+                        }
+                        if (i % limit_col === 0) {
+                            var id = i/limit_col;
+                            $form.append('<div id="row_'+ id +'" class="row temporal"></div>');
+                            $div = $('#row_' + id);
+                        }
+                        var monetary_u = field_utils.format.monetary(
+                            unit_prices[i].price,
+                            {},
+                            {currency: unit_prices[i].currency}
+                        );
+                        monetary_u = monetary_u.replace("&nbsp;", " ");
+                        $div.append(
+                            QWeb.render(
+                                "website_sale_product_minimal_price.pricelist",
+                                {
+                                    quantity: unit_prices[i].min_qty,
+                                    price: monetary_u,
+                                }
+                            )
+                        );
+                    }
+                    $div = $('div[id*="row_"]');
+                    for (var i = 0; i < $div.length - 1; i++) {
+                        $($div[i]).addClass('border-bottom');
+                    }
+                });
+            } else {
+                _onChangeCombinationStock.apply(self, args);
+            }
+        });
+    };
+    return ProductConfiguratorMixin;
+});

--- a/website_sale_product_minimal_price/static/src/js/website_sale_product_minimal_price_tour.js
+++ b/website_sale_product_minimal_price/static/src/js/website_sale_product_minimal_price_tour.js
@@ -14,7 +14,8 @@ odoo.define("website_sale_product_minimal_price.tour", function (require) {
         },
         {
             trigger: "a[href='/shop']",
-            extra_trigger: ".js_attribute_value:eq(0):has(span:contains('Test v2'))",
+            extra_trigger:
+                ".js_attribute_value:eq(0):has(span:contains('Test v2'))",
         },
         {
             trigger: "a:contains('My product test')",

--- a/website_sale_product_minimal_price/static/src/xml/website_sale_product_minimal_price.xml
+++ b/website_sale_product_minimal_price/static/src/xml/website_sale_product_minimal_price.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates>
+
+    <t t-name="website_sale_product_minimal_price.title">
+        <h5 class="temporal"><strong>Prices per quantity ( <span t-esc="uom"/> )</strong></h5>
+    </t>
+
+    <t t-name="website_sale_product_minimal_price.pricelist">
+        <div class="col-3 text-center">
+            <div><strong>≥<span t-esc="quantity"/></strong></div>
+            <div><span t-esc="price"/></div>
+        </div>
+    </t>
+
+</templates>

--- a/website_sale_product_minimal_price/tests/test_website_sale_product_minimal_price.py
+++ b/website_sale_product_minimal_price/tests/test_website_sale_product_minimal_price.py
@@ -9,20 +9,15 @@ class WebsiteSaleProductMinimalPriceHttpCase(HttpCase):
         super().setUp()
 
         # Models
-        AttributeCategory = self.env['product.attribute.category']
         ProductAttribute = self.env['product.attribute']
         ProductAttributeValue = self.env['product.attribute.value']
         ProductTmplAttributeValue = self.env[
             'product.template.attribute.value']
 
-        self.attribute_category = AttributeCategory.create({
-            'name': 'Test category',
-        })
         self.product_attribute = ProductAttribute.create({
             'name': 'Test',
             'website_published': True,
             'create_variant': 'always',
-            'category_id': self.attribute_category.id,
         })
         self.product_attribute_value_test_1 = ProductAttributeValue.create({
             'name': 'Test v1',

--- a/website_sale_product_minimal_price/views/assets.xml
+++ b/website_sale_product_minimal_price/views/assets.xml
@@ -3,7 +3,9 @@
     <template id="assets_frontend" inherit_id="website.assets_frontend">
         <xpath expr=".">
             <script type="text/javascript"
-                    src="/website_sale_product_minimal_price/static/src/js/website_sale_product_minimal_price_tour.js"/>
+                    src="/web/static/src/js/fields/field_utils.js"/>
+            <script type="text/javascript"
+                    src="/website_sale_product_minimal_price/static/src/js/website_sale_product_minimal_price.js"/>
         </xpath>
     </template>
 </odoo>

--- a/website_sale_product_minimal_price/views/templates.xml
+++ b/website_sale_product_minimal_price/views/templates.xml
@@ -22,7 +22,7 @@
     <template id="products_item" inherit_id="website_sale.products_item">
         <!-- Display "From" if variants have distinct extra prices -->
         <xpath expr="//span[@t-if=&quot;combination_info[&apos;price&apos;]&quot;]" position="before">
-            <t t-if="product.has_distinct_variant_price">
+            <t t-if="combination_info.get('has_distinct_price')">
                 <span>From </span>
             </t>
         </xpath>


### PR DESCRIPTION
cc @Tecnativa TT24954

Please @sergio-teruel @Tardo, can you review this PR. You can see how it work at next GIF.
![1](https://user-images.githubusercontent.com/35952655/93489009-4d963b80-f907-11ea-8b62-aaf6252b0c3b.gif)

With this improvement, we achieve to set the minimal price of the different products on the grid view taking care about the selected pricelist. Furthermore, I add a table with the different offers for the product variant selected on the product sheet.