### PR TITLE
Explain where attributes are shown

### DIFF
--- a/website_sale_product_detail_attribute_image/readme/USAGE.rst
+++ b/website_sale_product_detail_attribute_image/readme/USAGE.rst
@@ -1,7 +1,8 @@
 * Go to Website > Configuration > Products > Attributes.
 * Set an image in 'Website image' field to display this attribute in shop
-  product detail.
+  product page.
 * You can set alternative name for attribute in field "Website name".
 * You can set alternative name for attribute value in field "Website name".
 * Active 'Publish in website' field to display this attribute in
-  shop product detail.
+  shop product page.
+* By default, the attribute is shown under the product images. If website's Product Comparison Tool is activated, the "Product attributes table" will not use values from this module, but default ones.


### PR DESCRIPTION
Add explanation about attributes displayed, explain that the product attribute table will not use values from this module.
Change "product detail" to "product page".