### PR TITLE
[FIX] website_sale_hide_price: Hide price from all combination info requests

### DIFF
--- a/website_sale_hide_price/models/__init__.py
+++ b/website_sale_hide_price/models/__init__.py
@@ -1,2 +1,3 @@
 from . import res_partner
 from . import website
+from . import product_template

--- a/website_sale_hide_price/models/product_template.py
+++ b/website_sale_hide_price/models/product_template.py
@@ -1,0 +1,34 @@
+# Copyright 2020 Tecnativa - Alexandre D. Díaz
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class ProductTemplate(models.Model):
+    _inherit = "product.template"
+
+    @api.multi
+    def _get_combination_info(
+        self,
+        combination=False,
+        product_id=False,
+        add_qty=1,
+        pricelist=False,
+        parent_combination=False,
+        only_template=False
+    ):
+        """Avoid show prices in other website places.
+        This will show 0.00 value"""
+        ret = super()._get_combination_info(
+            combination=combination,
+            product_id=product_id,
+            add_qty=add_qty,
+            pricelist=pricelist,
+            parent_combination=parent_combination,
+            only_template=only_template)
+        if not self.env.user.partner_id.website_show_price:
+            ret.update(
+                list_price=0,
+                price=0,
+            )
+        return ret


### PR DESCRIPTION
Avoid show the price in other unexpected places on the website.

Now because we can't know the template where the price is displayed... this change will overwrite it to 0.00 (so, not really hidden)

@chienandalu @sergio-teruel 

cc @tecnativa TT26263