### PR TITLE
[13.0][IMP] website_sale_suggest_create_account: unit test compatibility

### DIFF
--- a/website_sale_suggest_create_account/tests/test_shop_buy.py
+++ b/website_sale_suggest_create_account/tests/test_shop_buy.py
@@ -6,6 +6,11 @@ import odoo.tests
 @odoo.tests.tagged("post_install", "-at_install")
 class TestUi(odoo.tests.HttpCase):
     def test_01_shop_buy(self):
+        # Ensure that 'vat' is not empty for compatibility with
+        # website_sale_vat_required module
+        portal_user = self.env.ref("base.demo_user0")
+        if not portal_user.partner_id.vat:
+            portal_user.partner_id.vat = "BE1234567"
         current_website = self.env["website"].get_current_website()
         current_website.auth_signup_uninvited = "b2b"
         self.env.ref("website_sale_suggest_create_account.cart").active = True


### PR DESCRIPTION
Ensure that 'vat' is not empty for compatibility with website_sale_vat_required module

cc @Tecnativa TT25964

Needed for https://github.com/OCA/e-commerce/pull/440