### PR TITLE
[14.0][ADD] website_sale_product_attribute_filter_collapsed

### DIFF
--- a/setup/website_sale_product_attribute_filter_collapsed/odoo/addons/website_sale_product_attribute_filter_collapsed
+++ b/setup/website_sale_product_attribute_filter_collapsed/odoo/addons/website_sale_product_attribute_filter_collapsed
@@ -1,0 +1,1 @@
+../../../../website_sale_product_attribute_filter_collapsed

--- a/setup/website_sale_product_attribute_filter_collapsed/setup.py
+++ b/setup/website_sale_product_attribute_filter_collapsed/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/website_sale_product_attribute_filter_collapsed/__init__.py
+++ b/website_sale_product_attribute_filter_collapsed/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/website_sale_product_attribute_filter_collapsed/__manifest__.py
+++ b/website_sale_product_attribute_filter_collapsed/__manifest__.py
@@ -1,0 +1,19 @@
+# Copyright 2020 Iván Todorovich
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+{
+    "name": "Website Sale Product Attribute Filter Collapsed",
+    "summary": "Allow to collapse product attributes in shop",
+    "version": "14.0.1.0.0",
+    "development_status": "Production/Stable",
+    "category": "Website",
+    "website": "https://github.com/OCA/e-commerce",
+    "author": "Iván Todorovich, Odoo Community Association (OCA)",
+    "maintainers": ["ivantodorovich"],
+    "license": "AGPL-3",
+    "depends": ["website_sale"],
+    "data": [
+        "views/assets.xml",
+        "views/templates.xml",
+        "views/product_attribute.xml",
+    ],
+}

--- a/website_sale_product_attribute_filter_collapsed/models/__init__.py
+++ b/website_sale_product_attribute_filter_collapsed/models/__init__.py
@@ -1,0 +1,1 @@
+from . import product_attribute

--- a/website_sale_product_attribute_filter_collapsed/models/product_attribute.py
+++ b/website_sale_product_attribute_filter_collapsed/models/product_attribute.py
@@ -1,0 +1,12 @@
+# Copyright 2020 Iván Todorovich
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import fields, models
+
+
+class ProductAttributeCategory(models.Model):
+    _inherit = "product.attribute"
+
+    website_folded = fields.Boolean(
+        string="Website folded",
+        default=True,
+    )

--- a/website_sale_product_attribute_filter_collapsed/readme/CONFIGURE.rst
+++ b/website_sale_product_attribute_filter_collapsed/readme/CONFIGURE.rst
@@ -1,0 +1,2 @@
+You can select if you want to display the attributes folded or unfolded by
+going to 'Website > Configuration > Attributes'

--- a/website_sale_product_attribute_filter_collapsed/readme/CONTRIBUTORS.rst
+++ b/website_sale_product_attribute_filter_collapsed/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Iván Todorovich <ivan.todorovich@gmail.com>

--- a/website_sale_product_attribute_filter_collapsed/readme/DESCRIPTION.rst
+++ b/website_sale_product_attribute_filter_collapsed/readme/DESCRIPTION.rst
@@ -1,0 +1,2 @@
+This module extends the functionality of website sale module to show the
+product attributes filters in a collapsible list.

--- a/website_sale_product_attribute_filter_collapsed/static/src/scss/website_sale_product_attribute_filter_collapsed.scss
+++ b/website_sale_product_attribute_filter_collapsed/static/src/scss/website_sale_product_attribute_filter_collapsed.scss
@@ -1,0 +1,29 @@
+#wsale_products_attributes_collapse {
+    li.attribute-collapse {
+        /* Remove margin on nested ul, they don't play nice here */
+        ul ul {
+            margin-left: 0;
+        }
+
+        /* Remove style="margin" on checkboxes labels, they don't play nice here */
+        ul > li > label {
+            margin-left: 0 !important;
+            margin-right: 0 !important;
+        }
+
+        /* Simulate same styles than eCommerce Categories list */
+        & > a {
+            text-decoration: none !important;
+            padding: 4px 3px;
+        }
+
+        /* Display ">" icon for collapsed elements */
+        [data-toggle="collapse"] .fas:before {
+            content: "\f054";
+        }
+
+        [aria-expanded="true"] .fas:before {
+            content: "\f078";
+        }
+    }
+}

--- a/website_sale_product_attribute_filter_collapsed/views/assets.xml
+++ b/website_sale_product_attribute_filter_collapsed/views/assets.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <template id="assets_frontend" inherit_id="website.assets_frontend">
+        <xpath expr=".">
+            <link
+                type="text/css"
+                rel="stylesheet"
+                href="/website_sale_product_attribute_filter_collapsed/static/src/scss/website_sale_product_attribute_filter_collapsed.scss"
+            />
+        </xpath>
+    </template>
+</odoo>

--- a/website_sale_product_attribute_filter_collapsed/views/product_attribute.xml
+++ b/website_sale_product_attribute_filter_collapsed/views/product_attribute.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="product_attribute_tree_view" model="ir.ui.view">
+        <field name="model">product.attribute</field>
+        <field name="inherit_id" ref="product.attribute_tree_view" />
+        <field name="priority" eval="999" />
+        <field name="arch" type="xml">
+            <tree position="inside">
+                <field name="website_folded" widget="boolean_toggle" />
+            </tree>
+        </field>
+    </record>
+</odoo>

--- a/website_sale_product_attribute_filter_collapsed/views/templates.xml
+++ b/website_sale_product_attribute_filter_collapsed/views/templates.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <template
+        id="products_attributes"
+        inherit_id="website_sale.products_attributes"
+        customize_show="True"
+        name="Collapsible Product Attributes"
+    >
+        <xpath
+            expr="//form/ul/t/li[hasclass('nav-item')]//strong[@t-field='a.name']"
+            position="replace"
+        />
+        <xpath expr="//form/ul/t/li[hasclass('nav-item')]" position="replace">
+            <li
+                t-if="a.value_ids and len(a.value_ids) &gt; 1"
+                class="nav-item attribute-collapse"
+            >
+                <t
+                    t-set="attribute_collapsed"
+                    t-value="a.website_folded and not bool(attrib_set &amp; set(a.value_ids.ids))"
+                />
+                <a
+                    data-toggle="collapse"
+                    t-attf-href="#collapse-attribute-{{a.id}}"
+                    t-attf-aria-expanded="{{'true' if not attribute_collapsed else none}}"
+                >
+                    <i class="fa fas text-primary" />
+                    <span t-field="a.name" />
+                </a>
+                <ul
+                    t-attf-id="collapse-attribute-{{a.id}}"
+                    t-attf-class="nav nav-pills nav-stacked {{'collapse' if attribute_collapsed else 'collapse in show'}}"
+                >
+                    <t>$0</t>
+                </ul>
+            </li>
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
This module displays the attribute filters in a collapsible list.

It plays nicely alone, or with `website_sale_product_attribute_filter_category` (https://github.com/OCA/e-commerce/pull/456) to achieve a nested collapsible list.


![attributes](https://user-images.githubusercontent.com/1914185/97586300-ddd0a180-19d8-11eb-9042-fd585684b0c2.gif)


This is how it looks when installed along with `website_sale_product_attribute_filter_category`:

![compat](https://user-images.githubusercontent.com/1914185/97586932-9a2a6780-19d9-11eb-9b6d-775afecf62ec.gif)
![Uploading attributes.gif…]()
 