### PR TITLE
[13.0][IMP] website_sale_hide_empty_categry - allow for recursive evaluation of empty

### DIFF
--- a/website_sale_hide_empty_category/models/__init__.py
+++ b/website_sale_hide_empty_category/models/__init__.py
@@ -1,3 +1,4 @@
 # Copyright 2017 LasLabs Inc.
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
-from . import models
+
+from . import product_public_category

--- a/website_sale_hide_empty_category/models/product_public_category.py
+++ b/website_sale_hide_empty_category/models/product_public_category.py
@@ -1,0 +1,21 @@
+# Copyright 2017 LasLabs Inc.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+
+from odoo import api, fields, models
+
+
+class ProductPublicCategory(models.Model):
+    _inherit = "product.public.category"
+
+    has_product_recursive = fields.Boolean(
+        string="This category or one of its children has products",
+        compute="_compute_has_product_recursive",
+    )
+
+    @api.depends("product_tmpl_ids", "child_id.has_product_recursive")
+    def _compute_has_product_recursive(self):
+        for category in self:
+            category.has_product_recursive = bool(
+                category.product_tmpl_ids
+                or any(child.has_product_recursive for child in category.child_id)
+            )

--- a/website_sale_hide_empty_category/readme/CONTRIBUTORS.rst
+++ b/website_sale_hide_empty_category/readme/CONTRIBUTORS.rst
@@ -2,3 +2,4 @@
 * `Tecnativa <https://www.tecnativa.com>`_:
 
   * Carlos Roca
+* Radovan Skolnik <radovan@skolnik.info>

--- a/website_sale_hide_empty_category/tests/__init__.py
+++ b/website_sale_hide_empty_category/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_ui
+from . import test_has_product_recursive

--- a/website_sale_hide_empty_category/tests/test_has_product_recursive.py
+++ b/website_sale_hide_empty_category/tests/test_has_product_recursive.py
@@ -1,0 +1,22 @@
+from odoo.tests import common
+
+
+class TestPublicCategory(common.TransactionCase):
+    def test_has_product_recursive(self):
+
+        category_1 = self.env["product.public.category"].create({"name": "Category 1"})
+
+        self.assertFalse(category_1.has_product_recursive)
+
+        category_2 = self.env["product.public.category"].create(
+            {"name": "Category 2", "parent_id": category_1.id}
+        )
+
+        self.assertFalse(category_2.has_product_recursive)
+
+        self.env["product.template"].create(
+            {"name": "Product Test", "public_categ_ids": [(4, category_2.id, None)]}
+        )
+
+        self.assertTrue(category_1.has_product_recursive)
+        self.assertTrue(category_2.has_product_recursive)

--- a/website_sale_hide_empty_category/views/website_sale_templates.xml
+++ b/website_sale_hide_empty_category/views/website_sale_templates.xml
@@ -1,20 +1,46 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!-- Copyright 2017 LasLabs Inc.
+     Copyright 2020 Radovan Skolnik <radovan@skolnik.info>
      License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 -->
 <odoo>
     <template
         inherit_id="website_sale.categories_recursive"
         id="hide_categories_recursive"
-        active="True"
-        customize_show="True"
         name="Hide Empty Category list"
     >
         <xpath
             expr="//t[@t-name='website_sale.categories_recursive']"
             position="attributes"
         >
-            <attribute name="t-if">c.product_tmpl_ids</attribute>
+            <attribute
+                name="t-if"
+            >not hide_empty_category or c.has_product_recursive</attribute>
+        </xpath>
+    </template>
+    <template
+        inherit_id="website_sale.option_collapse_categories_recursive"
+        id="hide_categories_collapse_recursive"
+        name="Hide Empty Category Collapsible list"
+    >
+        <xpath
+            expr="//t[@t-name='website_sale.option_collapse_categories_recursive']"
+            position="attributes"
+        >
+            <attribute
+                name="t-if"
+            >not hide_empty_category or c.has_product_recursive</attribute>
+        </xpath>
+    </template>
+    <template
+        inherit_id="website_sale.products_categories"
+        id="hide_categories_recursive_helper"
+        name="Hide Empty Category list"
+        customize_show="True"
+        active="True"
+    >
+        <xpath expr="//t[@t-foreach='categories']" position="before">
+            <t t-set="hide_empty_category" t-value="True" />
         </xpath>
     </template>
 </odoo>


### PR DESCRIPTION
This is based on unfinished PR #260 It allows for recursive evaluation of "empty". In current version hiding is not working in collapsed categories. @pedrobaeza please review and possibly nominate more reviewers please. Thank you.