### PR TITLE
[FIX] website_sale_stock_available: prevent payment blocking

### DIFF
--- a/website_sale_stock_available/__init__.py
+++ b/website_sale_stock_available/__init__.py
@@ -1,3 +1,3 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-
+from . import controllers
 from . import models

--- a/website_sale_stock_available/controllers/__init__.py
+++ b/website_sale_stock_available/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import main

--- a/website_sale_stock_available/controllers/main.py
+++ b/website_sale_stock_available/controllers/main.py
@@ -1,0 +1,14 @@
+# Copyright 2020 Tecnativa - David Vidal
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo.addons.website_sale_stock.controllers.main import WebsiteSale
+from odoo.http import request, route
+
+
+class WebsiteSale(WebsiteSale):
+
+    @route()
+    def payment_transaction(self, *args, **kwargs):
+        """Inject a context when potencial or promised stock is set"""
+        request.website = request.website.with_context(
+            website_sale_stock_available=True)
+        return super().payment_transaction(*args, **kwargs)


### PR DESCRIPTION
When the `virtual_available` is less than the `immediately_usable_qty`,
we'll have a blocking situation when the order is paid if we could add
more quantity to the order than the virtual one.

cc @Tecnativa TT27214