### PR TITLE
[12.0][FIX] website_sale_attribute_filter_price: shop 'keep' values

### DIFF
--- a/website_sale_attribute_filter_price/controllers/website_sale.py
+++ b/website_sale_attribute_filter_price/controllers/website_sale.py
@@ -67,11 +67,12 @@ class WebsiteSale(WebsiteSale):
             order='list_price DESC', limit=1)
         max_price = product_id.list_price
         # Price Filter QWeb Values
+        attrib_list = request.httprequest.args.getlist('attrib')
         keep = QueryURL(
             '/shop',
             category=category and int(category),
-            search=post.get('search'),
-            attrib=post.get('atrib'),
+            search=search,
+            attrib=attrib_list,
             order=post.get('order'),
             min_price=custom_min_price,
             max_price=custom_max_price)


### PR DESCRIPTION
Before this PR, wrong values are passed to 'keep' method.

cc @tecnativa TT28228