### PR TITLE
[13.0][IMP] website_sale_tax_toggle: Making test more resilient

### DIFF
--- a/website_sale_tax_toggle/static/src/js/website_sale_tax_toggle_tour.js
+++ b/website_sale_tax_toggle/static/src/js/website_sale_tax_toggle_tour.js
@@ -21,6 +21,7 @@ odoo.define("website_sale_tax_toggle.tour", function(require) {
             content: "Enter the product page",
             trigger:
                 ".oe_product_cart:has(span .oe_currency_value:containsExact('862.50')) a:contains('Product test tax toggle')",
+            extra_trigger: ".o_switch_danger:has(input:checked)",
         },
         {
             content: "Toggle tax button click from product page",
@@ -32,6 +33,7 @@ odoo.define("website_sale_tax_toggle.tour", function(require) {
             content: "Check the product price is back to what it should",
             trigger:
                 "#product_details .oe_price .oe_currency_value:containsExact('750.00')",
+            extra_trigger: ".o_switch_danger:has(input:not(:checked))",
         },
     ];
     tour.register(


### PR DESCRIPTION
cc @Tecnativa TT27481

Adding this two extra triggers we achieve to wait until the load of the unit prices on website views. Furthermore we avoid posible errors with other modules such as `website_sale_b2x_alt_price`

ping @joao-p-marques @pedrobaeza, with this change we should avoid the problem on this migration https://github.com/OCA/e-commerce/pull/508