### PR TITLE
[13.0][IMP] website_sale_checkout_skip_payment: Changes on Confirm Order buttons

### DIFF
--- a/website_sale_checkout_skip_payment/i18n/am.po
+++ b/website_sale_checkout_skip_payment/i18n/am.po
@@ -8,15 +8,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-15 03:01+0000\n"
-"PO-Revision-Date: 2017-08-15 03:01+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Amharic (https://www.transifex.com/oca/teams/23907/am/)\n"
+"POT-Creation-Date: 2021-05-18 10:04+0000\n"
+"PO-Revision-Date: 2021-05-18 12:12+0200\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
+"Language-Team: Amharic (https://www.transifex.com/oca/teams/23907/"
+"am/)\n"
 "Language: am\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
@@ -34,7 +36,7 @@ msgstr ""
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
-msgid "<span>Confirm Order <span class=\"fa fa-chevron-right\"/></span>"
+msgid "<span>Confirm <span class=\"fa fa-chevron-right\"/></span>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -52,6 +54,16 @@ msgstr ""
 #. module: website_sale_checkout_skip_payment
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_config_settings
 msgid "Config Settings"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.cart
+msgid "Confirm"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.short_cart_summary
+msgid "Confirm <span class=\"fa fa-chevron-right\"/>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -99,6 +111,3 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.order_state_message
 msgid "Your order is waiting manual confirmation."
 msgstr ""
-
-#~ msgid "Partner"
-#~ msgstr "ተባባሪ"

--- a/website_sale_checkout_skip_payment/i18n/ar.po
+++ b/website_sale_checkout_skip_payment/i18n/ar.po
@@ -8,16 +8,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-15 03:01+0000\n"
-"PO-Revision-Date: 2017-08-15 03:01+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"POT-Creation-Date: 2021-05-18 10:04+0000\n"
+"PO-Revision-Date: 2021-05-18 12:12+0200\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
 "Language-Team: Arabic (https://www.transifex.com/oca/teams/23907/ar/)\n"
 "Language: ar\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 "
 "&& n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5;\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
@@ -35,7 +36,7 @@ msgstr ""
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
-msgid "<span>Confirm Order <span class=\"fa fa-chevron-right\"/></span>"
+msgid "<span>Confirm <span class=\"fa fa-chevron-right\"/></span>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -53,6 +54,16 @@ msgstr ""
 #. module: website_sale_checkout_skip_payment
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_config_settings
 msgid "Config Settings"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.cart
+msgid "Confirm"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.short_cart_summary
+msgid "Confirm <span class=\"fa fa-chevron-right\"/>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -100,6 +111,3 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.order_state_message
 msgid "Your order is waiting manual confirmation."
 msgstr ""
-
-#~ msgid "Partner"
-#~ msgstr "الشريك"

--- a/website_sale_checkout_skip_payment/i18n/bg.po
+++ b/website_sale_checkout_skip_payment/i18n/bg.po
@@ -8,15 +8,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-15 03:01+0000\n"
-"PO-Revision-Date: 2017-08-15 03:01+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Bulgarian (https://www.transifex.com/oca/teams/23907/bg/)\n"
+"POT-Creation-Date: 2021-05-18 10:04+0000\n"
+"PO-Revision-Date: 2021-05-18 12:11+0200\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
+"Language-Team: Bulgarian (https://www.transifex.com/oca/teams/23907/"
+"bg/)\n"
 "Language: bg\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
@@ -34,7 +36,7 @@ msgstr ""
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
-msgid "<span>Confirm Order <span class=\"fa fa-chevron-right\"/></span>"
+msgid "<span>Confirm <span class=\"fa fa-chevron-right\"/></span>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -52,6 +54,16 @@ msgstr ""
 #. module: website_sale_checkout_skip_payment
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_config_settings
 msgid "Config Settings"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.cart
+msgid "Confirm"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.short_cart_summary
+msgid "Confirm <span class=\"fa fa-chevron-right\"/>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -99,6 +111,3 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.order_state_message
 msgid "Your order is waiting manual confirmation."
 msgstr ""
-
-#~ msgid "Partner"
-#~ msgstr "Партньор"

--- a/website_sale_checkout_skip_payment/i18n/bs.po
+++ b/website_sale_checkout_skip_payment/i18n/bs.po
@@ -8,16 +8,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-15 03:01+0000\n"
-"PO-Revision-Date: 2017-08-15 03:01+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"POT-Creation-Date: 2021-05-18 10:04+0000\n"
+"PO-Revision-Date: 2021-05-18 12:11+0200\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
 "Language-Team: Bosnian (https://www.transifex.com/oca/teams/23907/bs/)\n"
 "Language: bs\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
@@ -35,7 +36,7 @@ msgstr ""
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
-msgid "<span>Confirm Order <span class=\"fa fa-chevron-right\"/></span>"
+msgid "<span>Confirm <span class=\"fa fa-chevron-right\"/></span>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -53,6 +54,16 @@ msgstr ""
 #. module: website_sale_checkout_skip_payment
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_config_settings
 msgid "Config Settings"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.cart
+msgid "Confirm"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.short_cart_summary
+msgid "Confirm <span class=\"fa fa-chevron-right\"/>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -100,6 +111,3 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.order_state_message
 msgid "Your order is waiting manual confirmation."
 msgstr ""
-
-#~ msgid "Partner"
-#~ msgstr "Partner"

--- a/website_sale_checkout_skip_payment/i18n/ca.po
+++ b/website_sale_checkout_skip_payment/i18n/ca.po
@@ -8,16 +8,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-15 03:01+0000\n"
-"PO-Revision-Date: 2021-02-25 17:45+0000\n"
-"Last-Translator: claudiagn <claudia.gargallo@qubiq.es>\n"
+"POT-Creation-Date: 2021-05-18 10:04+0000\n"
+"PO-Revision-Date: 2021-05-18 12:06+0200\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
 "Language-Team: Catalan (https://www.transifex.com/oca/teams/23907/ca/)\n"
 "Language: ca\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.3.2\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
@@ -39,8 +39,8 @@ msgstr ""
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
-msgid "<span>Confirm Order <span class=\"fa fa-chevron-right\"/></span>"
-msgstr "<span>Confirmar Comanda <span class=\"fa fa-chevron-right\"/></span>"
+msgid "<span>Confirm <span class=\"fa fa-chevron-right\"/></span>"
+msgstr "<span>Confirmar <span class=\"fa fa-chevron-right\"/></span>"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.confirmation_order_error
@@ -60,6 +60,16 @@ msgstr "Comanda Omet el pagament"
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_config_settings
 msgid "Config Settings"
 msgstr "Paràmetres de configuració"
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.cart
+msgid "Confirm"
+msgstr "Confirmar"
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.short_cart_summary
+msgid "Confirm <span class=\"fa fa-chevron-right\"/>"
+msgstr "<span>Confirmar <span class=\"fa fa-chevron-right\"/></span>"
 
 #. module: website_sale_checkout_skip_payment
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_partner
@@ -106,6 +116,3 @@ msgstr "Venda de llocs web Omet el missatge"
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.order_state_message
 msgid "Your order is waiting manual confirmation."
 msgstr "La vostra comanda està en espera de confirmació manual."
-
-#~ msgid "Partner"
-#~ msgstr "Empresa"

--- a/website_sale_checkout_skip_payment/i18n/cs.po
+++ b/website_sale_checkout_skip_payment/i18n/cs.po
@@ -8,15 +8,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-15 03:01+0000\n"
-"PO-Revision-Date: 2017-08-15 03:01+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"POT-Creation-Date: 2021-05-18 10:04+0000\n"
+"PO-Revision-Date: 2021-05-18 12:11+0200\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
 "Language-Team: Czech (https://www.transifex.com/oca/teams/23907/cs/)\n"
 "Language: cs\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : "
+"2;\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
@@ -34,7 +36,7 @@ msgstr ""
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
-msgid "<span>Confirm Order <span class=\"fa fa-chevron-right\"/></span>"
+msgid "<span>Confirm <span class=\"fa fa-chevron-right\"/></span>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -52,6 +54,16 @@ msgstr ""
 #. module: website_sale_checkout_skip_payment
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_config_settings
 msgid "Config Settings"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.cart
+msgid "Confirm"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.short_cart_summary
+msgid "Confirm <span class=\"fa fa-chevron-right\"/>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -99,6 +111,3 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.order_state_message
 msgid "Your order is waiting manual confirmation."
 msgstr ""
-
-#~ msgid "Partner"
-#~ msgstr "Společník"

--- a/website_sale_checkout_skip_payment/i18n/da.po
+++ b/website_sale_checkout_skip_payment/i18n/da.po
@@ -8,15 +8,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-15 03:01+0000\n"
-"PO-Revision-Date: 2017-08-15 03:01+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Danish (https://www.transifex.com/oca/teams/23907/da/)\n"
+"POT-Creation-Date: 2021-05-18 10:04+0000\n"
+"PO-Revision-Date: 2021-05-18 12:11+0200\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
+"Language-Team: Danish (https://www.transifex.com/oca/teams/23907/"
+"da/)\n"
 "Language: da\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
@@ -34,7 +36,7 @@ msgstr ""
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
-msgid "<span>Confirm Order <span class=\"fa fa-chevron-right\"/></span>"
+msgid "<span>Confirm <span class=\"fa fa-chevron-right\"/></span>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -52,6 +54,16 @@ msgstr ""
 #. module: website_sale_checkout_skip_payment
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_config_settings
 msgid "Config Settings"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.cart
+msgid "Confirm"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.short_cart_summary
+msgid "Confirm <span class=\"fa fa-chevron-right\"/>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -99,6 +111,3 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.order_state_message
 msgid "Your order is waiting manual confirmation."
 msgstr ""
-
-#~ msgid "Partner"
-#~ msgstr "Partner"

--- a/website_sale_checkout_skip_payment/i18n/de.po
+++ b/website_sale_checkout_skip_payment/i18n/de.po
@@ -8,15 +8,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-15 03:01+0000\n"
-"PO-Revision-Date: 2017-08-15 03:01+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: German (https://www.transifex.com/oca/teams/23907/de/)\n"
+"POT-Creation-Date: 2021-05-18 10:04+0000\n"
+"PO-Revision-Date: 2021-05-18 12:11+0200\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
+"Language-Team: German (https://www.transifex.com/oca/teams/23907/"
+"de/)\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
@@ -34,7 +36,7 @@ msgstr ""
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
-msgid "<span>Confirm Order <span class=\"fa fa-chevron-right\"/></span>"
+msgid "<span>Confirm <span class=\"fa fa-chevron-right\"/></span>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -52,6 +54,16 @@ msgstr ""
 #. module: website_sale_checkout_skip_payment
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_config_settings
 msgid "Config Settings"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.cart
+msgid "Confirm"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.short_cart_summary
+msgid "Confirm <span class=\"fa fa-chevron-right\"/>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -99,6 +111,3 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.order_state_message
 msgid "Your order is waiting manual confirmation."
 msgstr ""
-
-#~ msgid "Partner"
-#~ msgstr "Partner"

--- a/website_sale_checkout_skip_payment/i18n/el_GR.po
+++ b/website_sale_checkout_skip_payment/i18n/el_GR.po
@@ -8,16 +8,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-15 03:01+0000\n"
-"PO-Revision-Date: 2017-08-15 03:01+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"POT-Creation-Date: 2021-05-18 10:04+0000\n"
+"PO-Revision-Date: 2021-05-18 12:11+0200\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
 "Language-Team: Greek (Greece) (https://www.transifex.com/oca/teams/23907/"
 "el_GR/)\n"
 "Language: el_GR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
@@ -35,7 +36,7 @@ msgstr ""
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
-msgid "<span>Confirm Order <span class=\"fa fa-chevron-right\"/></span>"
+msgid "<span>Confirm <span class=\"fa fa-chevron-right\"/></span>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -53,6 +54,16 @@ msgstr ""
 #. module: website_sale_checkout_skip_payment
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_config_settings
 msgid "Config Settings"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.cart
+msgid "Confirm"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.short_cart_summary
+msgid "Confirm <span class=\"fa fa-chevron-right\"/>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -100,6 +111,3 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.order_state_message
 msgid "Your order is waiting manual confirmation."
 msgstr ""
-
-#~ msgid "Partner"
-#~ msgstr "Συνεργάτης"

--- a/website_sale_checkout_skip_payment/i18n/en_GB.po
+++ b/website_sale_checkout_skip_payment/i18n/en_GB.po
@@ -8,16 +8,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-15 03:01+0000\n"
-"PO-Revision-Date: 2017-08-15 03:01+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"POT-Creation-Date: 2021-05-18 10:04+0000\n"
+"PO-Revision-Date: 2021-05-18 12:11+0200\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
 "Language-Team: English (United Kingdom) (https://www.transifex.com/oca/"
 "teams/23907/en_GB/)\n"
 "Language: en_GB\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
@@ -35,7 +36,7 @@ msgstr ""
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
-msgid "<span>Confirm Order <span class=\"fa fa-chevron-right\"/></span>"
+msgid "<span>Confirm <span class=\"fa fa-chevron-right\"/></span>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -53,6 +54,16 @@ msgstr ""
 #. module: website_sale_checkout_skip_payment
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_config_settings
 msgid "Config Settings"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.cart
+msgid "Confirm"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.short_cart_summary
+msgid "Confirm <span class=\"fa fa-chevron-right\"/>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -100,6 +111,3 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.order_state_message
 msgid "Your order is waiting manual confirmation."
 msgstr ""
-
-#~ msgid "Partner"
-#~ msgstr "Partner"

--- a/website_sale_checkout_skip_payment/i18n/es.po
+++ b/website_sale_checkout_skip_payment/i18n/es.po
@@ -8,16 +8,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-12-20 23:19+0100\n"
-"PO-Revision-Date: 2021-02-25 17:45+0000\n"
-"Last-Translator: claudiagn <claudia.gargallo@qubiq.es>\n"
+"POT-Creation-Date: 2021-05-18 10:04+0000\n"
+"PO-Revision-Date: 2021-05-18 12:05+0200\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
 "Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.3.2\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
@@ -39,8 +39,8 @@ msgstr ""
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
-msgid "<span>Confirm Order <span class=\"fa fa-chevron-right\"/></span>"
-msgstr "<span>Confirmar Orden<span class=\"fa fa-chevron-right\"/></span>"
+msgid "<span>Confirm <span class=\"fa fa-chevron-right\"/></span>"
+msgstr "<span>Confirmar <span class=\"fa fa-chevron-right\"/></span>"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.confirmation_order_error
@@ -60,6 +60,16 @@ msgstr "Saltar proceso de pago en la tienda online"
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_config_settings
 msgid "Config Settings"
 msgstr "Ajustes de Configuración"
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.cart
+msgid "Confirm"
+msgstr "Confirmar"
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.short_cart_summary
+msgid "Confirm <span class=\"fa fa-chevron-right\"/>"
+msgstr "Confirmar <span class=\"fa fa-chevron-right\"/>"
 
 #. module: website_sale_checkout_skip_payment
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_partner
@@ -106,13 +116,3 @@ msgstr "Mensaje de omisión de venta del sitio web"
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.order_state_message
 msgid "Your order is waiting manual confirmation."
 msgstr "Su pedido está a la espera de confirmación manual."
-
-#~ msgid ""
-#~ "Our team will check your order and send you payment\n"
-#~ "                information soon."
-#~ msgstr ""
-#~ "Nuestro equipo comprobará su pedido y le enviará la información del pago "
-#~ "pronto."
-
-#~ msgid "Partner"
-#~ msgstr "Empresa"

--- a/website_sale_checkout_skip_payment/i18n/es_AR.po
+++ b/website_sale_checkout_skip_payment/i18n/es_AR.po
@@ -8,16 +8,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-15 03:01+0000\n"
-"PO-Revision-Date: 2017-08-15 03:01+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"POT-Creation-Date: 2021-05-18 10:04+0000\n"
+"PO-Revision-Date: 2021-05-18 12:11+0200\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
 "Language-Team: Spanish (Argentina) (https://www.transifex.com/oca/"
 "teams/23907/es_AR/)\n"
 "Language: es_AR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
@@ -35,7 +36,7 @@ msgstr ""
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
-msgid "<span>Confirm Order <span class=\"fa fa-chevron-right\"/></span>"
+msgid "<span>Confirm <span class=\"fa fa-chevron-right\"/></span>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -53,6 +54,16 @@ msgstr ""
 #. module: website_sale_checkout_skip_payment
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_config_settings
 msgid "Config Settings"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.cart
+msgid "Confirm"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.short_cart_summary
+msgid "Confirm <span class=\"fa fa-chevron-right\"/>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment

--- a/website_sale_checkout_skip_payment/i18n/es_CL.po
+++ b/website_sale_checkout_skip_payment/i18n/es_CL.po
@@ -8,16 +8,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-15 03:01+0000\n"
-"PO-Revision-Date: 2017-08-15 03:01+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"POT-Creation-Date: 2021-05-18 10:04+0000\n"
+"PO-Revision-Date: 2021-05-18 12:11+0200\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
 "Language-Team: Spanish (Chile) (https://www.transifex.com/oca/teams/23907/"
 "es_CL/)\n"
 "Language: es_CL\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
@@ -35,7 +36,7 @@ msgstr ""
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
-msgid "<span>Confirm Order <span class=\"fa fa-chevron-right\"/></span>"
+msgid "<span>Confirm <span class=\"fa fa-chevron-right\"/></span>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -53,6 +54,16 @@ msgstr ""
 #. module: website_sale_checkout_skip_payment
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_config_settings
 msgid "Config Settings"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.cart
+msgid "Confirm"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.short_cart_summary
+msgid "Confirm <span class=\"fa fa-chevron-right\"/>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment

--- a/website_sale_checkout_skip_payment/i18n/es_CO.po
+++ b/website_sale_checkout_skip_payment/i18n/es_CO.po
@@ -8,16 +8,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-15 03:01+0000\n"
-"PO-Revision-Date: 2017-08-15 03:01+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"POT-Creation-Date: 2021-05-18 10:04+0000\n"
+"PO-Revision-Date: 2021-05-18 12:11+0200\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
 "Language-Team: Spanish (Colombia) (https://www.transifex.com/oca/teams/23907/"
 "es_CO/)\n"
 "Language: es_CO\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
@@ -35,7 +36,7 @@ msgstr ""
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
-msgid "<span>Confirm Order <span class=\"fa fa-chevron-right\"/></span>"
+msgid "<span>Confirm <span class=\"fa fa-chevron-right\"/></span>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -53,6 +54,16 @@ msgstr ""
 #. module: website_sale_checkout_skip_payment
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_config_settings
 msgid "Config Settings"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.cart
+msgid "Confirm"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.short_cart_summary
+msgid "Confirm <span class=\"fa fa-chevron-right\"/>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment

--- a/website_sale_checkout_skip_payment/i18n/es_CR.po
+++ b/website_sale_checkout_skip_payment/i18n/es_CR.po
@@ -8,16 +8,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-15 03:01+0000\n"
-"PO-Revision-Date: 2017-08-15 03:01+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"POT-Creation-Date: 2021-05-18 10:04+0000\n"
+"PO-Revision-Date: 2021-05-18 12:11+0200\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
 "Language-Team: Spanish (Costa Rica) (https://www.transifex.com/oca/"
 "teams/23907/es_CR/)\n"
 "Language: es_CR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
@@ -35,7 +36,7 @@ msgstr ""
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
-msgid "<span>Confirm Order <span class=\"fa fa-chevron-right\"/></span>"
+msgid "<span>Confirm <span class=\"fa fa-chevron-right\"/></span>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -53,6 +54,16 @@ msgstr ""
 #. module: website_sale_checkout_skip_payment
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_config_settings
 msgid "Config Settings"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.cart
+msgid "Confirm"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.short_cart_summary
+msgid "Confirm <span class=\"fa fa-chevron-right\"/>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -100,6 +111,3 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.order_state_message
 msgid "Your order is waiting manual confirmation."
 msgstr ""
-
-#~ msgid "Partner"
-#~ msgstr "Empresa"

--- a/website_sale_checkout_skip_payment/i18n/es_DO.po
+++ b/website_sale_checkout_skip_payment/i18n/es_DO.po
@@ -8,16 +8,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-15 03:01+0000\n"
-"PO-Revision-Date: 2017-08-15 03:01+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"POT-Creation-Date: 2021-05-18 10:04+0000\n"
+"PO-Revision-Date: 2021-05-18 12:11+0200\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
 "Language-Team: Spanish (Dominican Republic) (https://www.transifex.com/oca/"
 "teams/23907/es_DO/)\n"
 "Language: es_DO\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
@@ -35,7 +36,7 @@ msgstr ""
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
-msgid "<span>Confirm Order <span class=\"fa fa-chevron-right\"/></span>"
+msgid "<span>Confirm <span class=\"fa fa-chevron-right\"/></span>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -53,6 +54,16 @@ msgstr ""
 #. module: website_sale_checkout_skip_payment
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_config_settings
 msgid "Config Settings"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.cart
+msgid "Confirm"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.short_cart_summary
+msgid "Confirm <span class=\"fa fa-chevron-right\"/>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment

--- a/website_sale_checkout_skip_payment/i18n/es_EC.po
+++ b/website_sale_checkout_skip_payment/i18n/es_EC.po
@@ -8,16 +8,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-15 03:01+0000\n"
-"PO-Revision-Date: 2017-08-15 03:01+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"POT-Creation-Date: 2021-05-18 10:04+0000\n"
+"PO-Revision-Date: 2021-05-18 12:10+0200\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
 "Language-Team: Spanish (Ecuador) (https://www.transifex.com/oca/teams/23907/"
 "es_EC/)\n"
 "Language: es_EC\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
@@ -35,7 +36,7 @@ msgstr ""
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
-msgid "<span>Confirm Order <span class=\"fa fa-chevron-right\"/></span>"
+msgid "<span>Confirm <span class=\"fa fa-chevron-right\"/></span>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -53,6 +54,16 @@ msgstr ""
 #. module: website_sale_checkout_skip_payment
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_config_settings
 msgid "Config Settings"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.cart
+msgid "Confirm"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.short_cart_summary
+msgid "Confirm <span class=\"fa fa-chevron-right\"/>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -100,6 +111,3 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.order_state_message
 msgid "Your order is waiting manual confirmation."
 msgstr ""
-
-#~ msgid "Partner"
-#~ msgstr "Empresa"

--- a/website_sale_checkout_skip_payment/i18n/es_MX.po
+++ b/website_sale_checkout_skip_payment/i18n/es_MX.po
@@ -8,16 +8,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-15 03:01+0000\n"
-"PO-Revision-Date: 2017-08-15 03:01+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"POT-Creation-Date: 2021-05-18 10:04+0000\n"
+"PO-Revision-Date: 2021-05-18 12:10+0200\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
 "Language-Team: Spanish (Mexico) (https://www.transifex.com/oca/teams/23907/"
 "es_MX/)\n"
 "Language: es_MX\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
@@ -35,7 +36,7 @@ msgstr ""
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
-msgid "<span>Confirm Order <span class=\"fa fa-chevron-right\"/></span>"
+msgid "<span>Confirm <span class=\"fa fa-chevron-right\"/></span>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -53,6 +54,16 @@ msgstr ""
 #. module: website_sale_checkout_skip_payment
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_config_settings
 msgid "Config Settings"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.cart
+msgid "Confirm"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.short_cart_summary
+msgid "Confirm <span class=\"fa fa-chevron-right\"/>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -100,6 +111,3 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.order_state_message
 msgid "Your order is waiting manual confirmation."
 msgstr ""
-
-#~ msgid "Partner"
-#~ msgstr "Compañero"

--- a/website_sale_checkout_skip_payment/i18n/es_PE.po
+++ b/website_sale_checkout_skip_payment/i18n/es_PE.po
@@ -8,16 +8,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-15 03:01+0000\n"
-"PO-Revision-Date: 2017-08-15 03:01+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"POT-Creation-Date: 2021-05-18 10:04+0000\n"
+"PO-Revision-Date: 2021-05-18 12:10+0200\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
 "Language-Team: Spanish (Peru) (https://www.transifex.com/oca/teams/23907/"
 "es_PE/)\n"
 "Language: es_PE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
@@ -35,7 +36,7 @@ msgstr ""
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
-msgid "<span>Confirm Order <span class=\"fa fa-chevron-right\"/></span>"
+msgid "<span>Confirm <span class=\"fa fa-chevron-right\"/></span>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -53,6 +54,16 @@ msgstr ""
 #. module: website_sale_checkout_skip_payment
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_config_settings
 msgid "Config Settings"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.cart
+msgid "Confirm"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.short_cart_summary
+msgid "Confirm <span class=\"fa fa-chevron-right\"/>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment

--- a/website_sale_checkout_skip_payment/i18n/es_VE.po
+++ b/website_sale_checkout_skip_payment/i18n/es_VE.po
@@ -8,16 +8,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-15 03:01+0000\n"
-"PO-Revision-Date: 2017-08-15 03:01+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"POT-Creation-Date: 2021-05-18 10:04+0000\n"
+"PO-Revision-Date: 2021-05-18 12:10+0200\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
 "Language-Team: Spanish (Venezuela) (https://www.transifex.com/oca/"
 "teams/23907/es_VE/)\n"
 "Language: es_VE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
@@ -35,7 +36,7 @@ msgstr ""
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
-msgid "<span>Confirm Order <span class=\"fa fa-chevron-right\"/></span>"
+msgid "<span>Confirm <span class=\"fa fa-chevron-right\"/></span>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -53,6 +54,16 @@ msgstr ""
 #. module: website_sale_checkout_skip_payment
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_config_settings
 msgid "Config Settings"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.cart
+msgid "Confirm"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.short_cart_summary
+msgid "Confirm <span class=\"fa fa-chevron-right\"/>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -100,6 +111,3 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.order_state_message
 msgid "Your order is waiting manual confirmation."
 msgstr ""
-
-#~ msgid "Partner"
-#~ msgstr "Empresa"

--- a/website_sale_checkout_skip_payment/i18n/et.po
+++ b/website_sale_checkout_skip_payment/i18n/et.po
@@ -8,15 +8,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-15 03:01+0000\n"
-"PO-Revision-Date: 2017-08-15 03:01+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Estonian (https://www.transifex.com/oca/teams/23907/et/)\n"
+"POT-Creation-Date: 2021-05-18 10:04+0000\n"
+"PO-Revision-Date: 2021-05-18 12:10+0200\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
+"Language-Team: Estonian (https://www.transifex.com/oca/teams/23907/"
+"et/)\n"
 "Language: et\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
@@ -34,7 +36,7 @@ msgstr ""
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
-msgid "<span>Confirm Order <span class=\"fa fa-chevron-right\"/></span>"
+msgid "<span>Confirm <span class=\"fa fa-chevron-right\"/></span>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -52,6 +54,16 @@ msgstr ""
 #. module: website_sale_checkout_skip_payment
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_config_settings
 msgid "Config Settings"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.cart
+msgid "Confirm"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.short_cart_summary
+msgid "Confirm <span class=\"fa fa-chevron-right\"/>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -99,6 +111,3 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.order_state_message
 msgid "Your order is waiting manual confirmation."
 msgstr ""
-
-#~ msgid "Partner"
-#~ msgstr "Partner"

--- a/website_sale_checkout_skip_payment/i18n/eu.po
+++ b/website_sale_checkout_skip_payment/i18n/eu.po
@@ -9,15 +9,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-15 03:01+0000\n"
-"PO-Revision-Date: 2017-08-15 03:01+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Basque (https://www.transifex.com/oca/teams/23907/eu/)\n"
+"POT-Creation-Date: 2021-05-18 10:04+0000\n"
+"PO-Revision-Date: 2021-05-18 12:10+0200\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
+"Language-Team: Basque (https://www.transifex.com/oca/teams/23907/"
+"eu/)\n"
 "Language: eu\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
@@ -35,7 +37,7 @@ msgstr ""
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
-msgid "<span>Confirm Order <span class=\"fa fa-chevron-right\"/></span>"
+msgid "<span>Confirm <span class=\"fa fa-chevron-right\"/></span>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -53,6 +55,16 @@ msgstr ""
 #. module: website_sale_checkout_skip_payment
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_config_settings
 msgid "Config Settings"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.cart
+msgid "Confirm"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.short_cart_summary
+msgid "Confirm <span class=\"fa fa-chevron-right\"/>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -100,6 +112,3 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.order_state_message
 msgid "Your order is waiting manual confirmation."
 msgstr ""
-
-#~ msgid "Partner"
-#~ msgstr "Kidea"

--- a/website_sale_checkout_skip_payment/i18n/fa.po
+++ b/website_sale_checkout_skip_payment/i18n/fa.po
@@ -8,15 +8,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-15 03:01+0000\n"
-"PO-Revision-Date: 2017-08-15 03:01+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Persian (https://www.transifex.com/oca/teams/23907/fa/)\n"
+"POT-Creation-Date: 2021-05-18 10:04+0000\n"
+"PO-Revision-Date: 2021-05-18 12:10+0200\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
+"Language-Team: Persian (https://www.transifex.com/oca/teams/23907/"
+"fa/)\n"
 "Language: fa\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
@@ -34,7 +36,7 @@ msgstr ""
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
-msgid "<span>Confirm Order <span class=\"fa fa-chevron-right\"/></span>"
+msgid "<span>Confirm <span class=\"fa fa-chevron-right\"/></span>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -52,6 +54,16 @@ msgstr ""
 #. module: website_sale_checkout_skip_payment
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_config_settings
 msgid "Config Settings"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.cart
+msgid "Confirm"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.short_cart_summary
+msgid "Confirm <span class=\"fa fa-chevron-right\"/>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment

--- a/website_sale_checkout_skip_payment/i18n/fi.po
+++ b/website_sale_checkout_skip_payment/i18n/fi.po
@@ -8,15 +8,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-15 03:01+0000\n"
-"PO-Revision-Date: 2017-08-15 03:01+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Finnish (https://www.transifex.com/oca/teams/23907/fi/)\n"
+"POT-Creation-Date: 2021-05-18 10:04+0000\n"
+"PO-Revision-Date: 2021-05-18 12:10+0200\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
+"Language-Team: Finnish (https://www.transifex.com/oca/teams/23907/"
+"fi/)\n"
 "Language: fi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
@@ -34,7 +36,7 @@ msgstr ""
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
-msgid "<span>Confirm Order <span class=\"fa fa-chevron-right\"/></span>"
+msgid "<span>Confirm <span class=\"fa fa-chevron-right\"/></span>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -52,6 +54,16 @@ msgstr ""
 #. module: website_sale_checkout_skip_payment
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_config_settings
 msgid "Config Settings"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.cart
+msgid "Confirm"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.short_cart_summary
+msgid "Confirm <span class=\"fa fa-chevron-right\"/>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -99,6 +111,3 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.order_state_message
 msgid "Your order is waiting manual confirmation."
 msgstr ""
-
-#~ msgid "Partner"
-#~ msgstr "Kumppani"

--- a/website_sale_checkout_skip_payment/i18n/fr.po
+++ b/website_sale_checkout_skip_payment/i18n/fr.po
@@ -9,15 +9,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-23 02:47+0000\n"
-"PO-Revision-Date: 2017-08-23 02:47+0000\n"
-"Last-Translator: Quentin THEURET <odoo@kerpeo.com>, 2017\n"
+"POT-Creation-Date: 2021-05-18 10:04+0000\n"
+"PO-Revision-Date: 2021-05-18 12:10+0200\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
 "Language-Team: French (https://www.transifex.com/oca/teams/23907/fr/)\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
@@ -35,7 +36,7 @@ msgstr ""
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
-msgid "<span>Confirm Order <span class=\"fa fa-chevron-right\"/></span>"
+msgid "<span>Confirm <span class=\"fa fa-chevron-right\"/></span>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -56,6 +57,16 @@ msgstr ""
 #. module: website_sale_checkout_skip_payment
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_config_settings
 msgid "Config Settings"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.cart
+msgid "Confirm"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.short_cart_summary
+msgid "Confirm <span class=\"fa fa-chevron-right\"/>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -103,13 +114,3 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.order_state_message
 msgid "Your order is waiting manual confirmation."
 msgstr ""
-
-#~ msgid ""
-#~ "Our team will check your order and send you payment\n"
-#~ "                information soon."
-#~ msgstr ""
-#~ "Notre équipe va vérifier votre commande et vous enverra bientôt les "
-#~ "informations de paiement. "
-
-#~ msgid "Partner"
-#~ msgstr "Partenaire"

--- a/website_sale_checkout_skip_payment/i18n/fr_CA.po
+++ b/website_sale_checkout_skip_payment/i18n/fr_CA.po
@@ -8,16 +8,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-15 03:01+0000\n"
-"PO-Revision-Date: 2017-08-15 03:01+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"POT-Creation-Date: 2021-05-18 10:04+0000\n"
+"PO-Revision-Date: 2021-05-18 12:10+0200\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
 "Language-Team: French (Canada) (https://www.transifex.com/oca/teams/23907/"
 "fr_CA/)\n"
 "Language: fr_CA\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
@@ -35,7 +36,7 @@ msgstr ""
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
-msgid "<span>Confirm Order <span class=\"fa fa-chevron-right\"/></span>"
+msgid "<span>Confirm <span class=\"fa fa-chevron-right\"/></span>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -53,6 +54,16 @@ msgstr ""
 #. module: website_sale_checkout_skip_payment
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_config_settings
 msgid "Config Settings"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.cart
+msgid "Confirm"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.short_cart_summary
+msgid "Confirm <span class=\"fa fa-chevron-right\"/>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -100,6 +111,3 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.order_state_message
 msgid "Your order is waiting manual confirmation."
 msgstr ""
-
-#~ msgid "Partner"
-#~ msgstr "Partenaire"

--- a/website_sale_checkout_skip_payment/i18n/fr_CH.po
+++ b/website_sale_checkout_skip_payment/i18n/fr_CH.po
@@ -8,16 +8,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-15 03:01+0000\n"
-"PO-Revision-Date: 2017-08-15 03:01+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"POT-Creation-Date: 2021-05-18 10:04+0000\n"
+"PO-Revision-Date: 2021-05-18 12:09+0200\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
 "Language-Team: French (Switzerland) (https://www.transifex.com/oca/"
 "teams/23907/fr_CH/)\n"
 "Language: fr_CH\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
@@ -35,7 +36,7 @@ msgstr ""
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
-msgid "<span>Confirm Order <span class=\"fa fa-chevron-right\"/></span>"
+msgid "<span>Confirm <span class=\"fa fa-chevron-right\"/></span>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -53,6 +54,16 @@ msgstr ""
 #. module: website_sale_checkout_skip_payment
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_config_settings
 msgid "Config Settings"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.cart
+msgid "Confirm"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.short_cart_summary
+msgid "Confirm <span class=\"fa fa-chevron-right\"/>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -100,6 +111,3 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.order_state_message
 msgid "Your order is waiting manual confirmation."
 msgstr ""
-
-#~ msgid "Partner"
-#~ msgstr "Partenaire"

--- a/website_sale_checkout_skip_payment/i18n/gl.po
+++ b/website_sale_checkout_skip_payment/i18n/gl.po
@@ -8,15 +8,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-15 03:01+0000\n"
-"PO-Revision-Date: 2017-08-15 03:01+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Galician (https://www.transifex.com/oca/teams/23907/gl/)\n"
+"POT-Creation-Date: 2021-05-18 10:04+0000\n"
+"PO-Revision-Date: 2021-05-18 12:09+0200\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
+"Language-Team: Galician (https://www.transifex.com/oca/teams/23907/"
+"gl/)\n"
 "Language: gl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
@@ -34,7 +36,7 @@ msgstr ""
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
-msgid "<span>Confirm Order <span class=\"fa fa-chevron-right\"/></span>"
+msgid "<span>Confirm <span class=\"fa fa-chevron-right\"/></span>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -52,6 +54,16 @@ msgstr ""
 #. module: website_sale_checkout_skip_payment
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_config_settings
 msgid "Config Settings"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.cart
+msgid "Confirm"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.short_cart_summary
+msgid "Confirm <span class=\"fa fa-chevron-right\"/>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -99,6 +111,3 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.order_state_message
 msgid "Your order is waiting manual confirmation."
 msgstr ""
-
-#~ msgid "Partner"
-#~ msgstr "Empresa"

--- a/website_sale_checkout_skip_payment/i18n/he.po
+++ b/website_sale_checkout_skip_payment/i18n/he.po
@@ -8,15 +8,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-15 03:01+0000\n"
-"PO-Revision-Date: 2017-08-15 03:01+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Hebrew (https://www.transifex.com/oca/teams/23907/he/)\n"
+"POT-Creation-Date: 2021-05-18 10:04+0000\n"
+"PO-Revision-Date: 2021-05-18 12:09+0200\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
+"Language-Team: Hebrew (https://www.transifex.com/oca/teams/23907/"
+"he/)\n"
 "Language: he\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
@@ -34,7 +36,7 @@ msgstr ""
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
-msgid "<span>Confirm Order <span class=\"fa fa-chevron-right\"/></span>"
+msgid "<span>Confirm <span class=\"fa fa-chevron-right\"/></span>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -52,6 +54,16 @@ msgstr ""
 #. module: website_sale_checkout_skip_payment
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_config_settings
 msgid "Config Settings"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.cart
+msgid "Confirm"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.short_cart_summary
+msgid "Confirm <span class=\"fa fa-chevron-right\"/>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment

--- a/website_sale_checkout_skip_payment/i18n/hr.po
+++ b/website_sale_checkout_skip_payment/i18n/hr.po
@@ -8,16 +8,18 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-15 03:01+0000\n"
-"PO-Revision-Date: 2017-08-15 03:01+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Croatian (https://www.transifex.com/oca/teams/23907/hr/)\n"
+"POT-Creation-Date: 2021-05-18 10:04+0000\n"
+"PO-Revision-Date: 2021-05-18 12:09+0200\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
+"Language-Team: Croatian (https://www.transifex.com/oca/teams/23907/"
+"hr/)\n"
 "Language: hr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
@@ -35,7 +37,7 @@ msgstr ""
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
-msgid "<span>Confirm Order <span class=\"fa fa-chevron-right\"/></span>"
+msgid "<span>Confirm <span class=\"fa fa-chevron-right\"/></span>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -53,6 +55,16 @@ msgstr ""
 #. module: website_sale_checkout_skip_payment
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_config_settings
 msgid "Config Settings"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.cart
+msgid "Confirm"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.short_cart_summary
+msgid "Confirm <span class=\"fa fa-chevron-right\"/>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -100,6 +112,3 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.order_state_message
 msgid "Your order is waiting manual confirmation."
 msgstr ""
-
-#~ msgid "Partner"
-#~ msgstr "Partner"

--- a/website_sale_checkout_skip_payment/i18n/hr_HR.po
+++ b/website_sale_checkout_skip_payment/i18n/hr_HR.po
@@ -8,17 +8,18 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-15 03:01+0000\n"
-"PO-Revision-Date: 2017-08-15 03:01+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"POT-Creation-Date: 2021-05-18 10:04+0000\n"
+"PO-Revision-Date: 2021-05-18 12:09+0200\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
 "Language-Team: Croatian (Croatia) (https://www.transifex.com/oca/teams/23907/"
 "hr_HR/)\n"
 "Language: hr_HR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
@@ -36,7 +37,7 @@ msgstr ""
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
-msgid "<span>Confirm Order <span class=\"fa fa-chevron-right\"/></span>"
+msgid "<span>Confirm <span class=\"fa fa-chevron-right\"/></span>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -54,6 +55,16 @@ msgstr ""
 #. module: website_sale_checkout_skip_payment
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_config_settings
 msgid "Config Settings"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.cart
+msgid "Confirm"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.short_cart_summary
+msgid "Confirm <span class=\"fa fa-chevron-right\"/>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -101,6 +112,3 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.order_state_message
 msgid "Your order is waiting manual confirmation."
 msgstr ""
-
-#~ msgid "Partner"
-#~ msgstr "Partner"

--- a/website_sale_checkout_skip_payment/i18n/hu.po
+++ b/website_sale_checkout_skip_payment/i18n/hu.po
@@ -8,15 +8,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-15 03:01+0000\n"
-"PO-Revision-Date: 2017-08-15 03:01+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Hungarian (https://www.transifex.com/oca/teams/23907/hu/)\n"
+"POT-Creation-Date: 2021-05-18 10:04+0000\n"
+"PO-Revision-Date: 2021-05-18 12:09+0200\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
+"Language-Team: Hungarian (https://www.transifex.com/oca/teams/23907/"
+"hu/)\n"
 "Language: hu\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
@@ -34,7 +36,7 @@ msgstr ""
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
-msgid "<span>Confirm Order <span class=\"fa fa-chevron-right\"/></span>"
+msgid "<span>Confirm <span class=\"fa fa-chevron-right\"/></span>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -52,6 +54,16 @@ msgstr ""
 #. module: website_sale_checkout_skip_payment
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_config_settings
 msgid "Config Settings"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.cart
+msgid "Confirm"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.short_cart_summary
+msgid "Confirm <span class=\"fa fa-chevron-right\"/>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -99,6 +111,3 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.order_state_message
 msgid "Your order is waiting manual confirmation."
 msgstr ""
-
-#~ msgid "Partner"
-#~ msgstr "Partner"

--- a/website_sale_checkout_skip_payment/i18n/id.po
+++ b/website_sale_checkout_skip_payment/i18n/id.po
@@ -8,15 +8,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-15 03:01+0000\n"
-"PO-Revision-Date: 2017-08-15 03:01+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Indonesian (https://www.transifex.com/oca/teams/23907/id/)\n"
+"POT-Creation-Date: 2021-05-18 10:04+0000\n"
+"PO-Revision-Date: 2021-05-18 12:09+0200\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
+"Language-Team: Indonesian (https://www.transifex.com/oca/teams/23907/"
+"id/)\n"
 "Language: id\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
@@ -34,7 +36,7 @@ msgstr ""
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
-msgid "<span>Confirm Order <span class=\"fa fa-chevron-right\"/></span>"
+msgid "<span>Confirm <span class=\"fa fa-chevron-right\"/></span>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -52,6 +54,16 @@ msgstr ""
 #. module: website_sale_checkout_skip_payment
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_config_settings
 msgid "Config Settings"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.cart
+msgid "Confirm"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.short_cart_summary
+msgid "Confirm <span class=\"fa fa-chevron-right\"/>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment

--- a/website_sale_checkout_skip_payment/i18n/it.po
+++ b/website_sale_checkout_skip_payment/i18n/it.po
@@ -8,16 +8,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-15 03:01+0000\n"
-"PO-Revision-Date: 2018-12-28 23:41+0000\n"
-"Last-Translator: paolovalier <paolo@valier.it>\n"
-"Language-Team: Italian (https://www.transifex.com/oca/teams/23907/it/)\n"
+"POT-Creation-Date: 2021-05-18 10:04+0000\n"
+"PO-Revision-Date: 2021-05-18 12:09+0200\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
+"Language-Team: Italian (https://www.transifex.com/oca/teams/23907/"
+"it/)\n"
 "Language: it\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 3.3\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
@@ -35,7 +36,7 @@ msgstr ""
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
-msgid "<span>Confirm Order <span class=\"fa fa-chevron-right\"/></span>"
+msgid "<span>Confirm <span class=\"fa fa-chevron-right\"/></span>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -53,6 +54,16 @@ msgstr ""
 #. module: website_sale_checkout_skip_payment
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_config_settings
 msgid "Config Settings"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.cart
+msgid "Confirm"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.short_cart_summary
+msgid "Confirm <span class=\"fa fa-chevron-right\"/>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -100,6 +111,3 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.order_state_message
 msgid "Your order is waiting manual confirmation."
 msgstr "Il tuo ordine è in attesa di conferma manuale."
-
-#~ msgid "Partner"
-#~ msgstr "Partner"

--- a/website_sale_checkout_skip_payment/i18n/ja.po
+++ b/website_sale_checkout_skip_payment/i18n/ja.po
@@ -8,15 +8,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-15 03:01+0000\n"
-"PO-Revision-Date: 2017-08-15 03:01+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Japanese (https://www.transifex.com/oca/teams/23907/ja/)\n"
+"POT-Creation-Date: 2021-05-18 10:04+0000\n"
+"PO-Revision-Date: 2021-05-18 12:09+0200\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
+"Language-Team: Japanese (https://www.transifex.com/oca/teams/23907/"
+"ja/)\n"
 "Language: ja\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
@@ -34,7 +36,7 @@ msgstr ""
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
-msgid "<span>Confirm Order <span class=\"fa fa-chevron-right\"/></span>"
+msgid "<span>Confirm <span class=\"fa fa-chevron-right\"/></span>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -52,6 +54,16 @@ msgstr ""
 #. module: website_sale_checkout_skip_payment
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_config_settings
 msgid "Config Settings"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.cart
+msgid "Confirm"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.short_cart_summary
+msgid "Confirm <span class=\"fa fa-chevron-right\"/>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -99,6 +111,3 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.order_state_message
 msgid "Your order is waiting manual confirmation."
 msgstr ""
-
-#~ msgid "Partner"
-#~ msgstr "パートナ"

--- a/website_sale_checkout_skip_payment/i18n/ko.po
+++ b/website_sale_checkout_skip_payment/i18n/ko.po
@@ -8,15 +8,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-15 03:01+0000\n"
-"PO-Revision-Date: 2017-08-15 03:01+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Korean (https://www.transifex.com/oca/teams/23907/ko/)\n"
+"POT-Creation-Date: 2021-05-18 10:04+0000\n"
+"PO-Revision-Date: 2021-05-18 12:09+0200\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
+"Language-Team: Korean (https://www.transifex.com/oca/teams/23907/"
+"ko/)\n"
 "Language: ko\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
@@ -34,7 +36,7 @@ msgstr ""
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
-msgid "<span>Confirm Order <span class=\"fa fa-chevron-right\"/></span>"
+msgid "<span>Confirm <span class=\"fa fa-chevron-right\"/></span>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -52,6 +54,16 @@ msgstr ""
 #. module: website_sale_checkout_skip_payment
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_config_settings
 msgid "Config Settings"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.cart
+msgid "Confirm"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.short_cart_summary
+msgid "Confirm <span class=\"fa fa-chevron-right\"/>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment

--- a/website_sale_checkout_skip_payment/i18n/lt.po
+++ b/website_sale_checkout_skip_payment/i18n/lt.po
@@ -8,16 +8,18 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-15 03:01+0000\n"
-"PO-Revision-Date: 2017-08-15 03:01+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Lithuanian (https://www.transifex.com/oca/teams/23907/lt/)\n"
+"POT-Creation-Date: 2021-05-18 10:04+0000\n"
+"PO-Revision-Date: 2021-05-18 12:09+0200\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
+"Language-Team: Lithuanian (https://www.transifex.com/oca/teams/23907/"
+"lt/)\n"
 "Language: lt\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n"
 "%100<10 || n%100>=20) ? 1 : 2);\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
@@ -35,7 +37,7 @@ msgstr ""
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
-msgid "<span>Confirm Order <span class=\"fa fa-chevron-right\"/></span>"
+msgid "<span>Confirm <span class=\"fa fa-chevron-right\"/></span>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -53,6 +55,16 @@ msgstr ""
 #. module: website_sale_checkout_skip_payment
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_config_settings
 msgid "Config Settings"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.cart
+msgid "Confirm"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.short_cart_summary
+msgid "Confirm <span class=\"fa fa-chevron-right\"/>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -100,6 +112,3 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.order_state_message
 msgid "Your order is waiting manual confirmation."
 msgstr ""
-
-#~ msgid "Partner"
-#~ msgstr "Partneris"

--- a/website_sale_checkout_skip_payment/i18n/lv.po
+++ b/website_sale_checkout_skip_payment/i18n/lv.po
@@ -8,16 +8,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-15 03:01+0000\n"
-"PO-Revision-Date: 2017-08-15 03:01+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"POT-Creation-Date: 2021-05-18 10:04+0000\n"
+"PO-Revision-Date: 2021-05-18 12:09+0200\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
 "Language-Team: Latvian (https://www.transifex.com/oca/teams/23907/lv/)\n"
 "Language: lv\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n != 0 ? 1 : "
 "2);\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
@@ -35,7 +36,7 @@ msgstr ""
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
-msgid "<span>Confirm Order <span class=\"fa fa-chevron-right\"/></span>"
+msgid "<span>Confirm <span class=\"fa fa-chevron-right\"/></span>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -53,6 +54,16 @@ msgstr ""
 #. module: website_sale_checkout_skip_payment
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_config_settings
 msgid "Config Settings"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.cart
+msgid "Confirm"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.short_cart_summary
+msgid "Confirm <span class=\"fa fa-chevron-right\"/>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -100,6 +111,3 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.order_state_message
 msgid "Your order is waiting manual confirmation."
 msgstr ""
-
-#~ msgid "Partner"
-#~ msgstr "Partneris"

--- a/website_sale_checkout_skip_payment/i18n/mk.po
+++ b/website_sale_checkout_skip_payment/i18n/mk.po
@@ -8,15 +8,18 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-15 03:01+0000\n"
-"PO-Revision-Date: 2017-08-15 03:01+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Macedonian (https://www.transifex.com/oca/teams/23907/mk/)\n"
+"POT-Creation-Date: 2021-05-18 10:04+0000\n"
+"PO-Revision-Date: 2021-05-18 12:08+0200\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
+"Language-Team: Macedonian (https://www.transifex.com/oca/teams/23907/"
+"mk/)\n"
 "Language: mk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=2; plural=(n % 10 == 1 && n % 100 != 11) ? 0 : 1;\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n % 10 == 1 && n % 100 != 11) ? 0 : "
+"1;\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
@@ -34,7 +37,7 @@ msgstr ""
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
-msgid "<span>Confirm Order <span class=\"fa fa-chevron-right\"/></span>"
+msgid "<span>Confirm <span class=\"fa fa-chevron-right\"/></span>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -52,6 +55,16 @@ msgstr ""
 #. module: website_sale_checkout_skip_payment
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_config_settings
 msgid "Config Settings"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.cart
+msgid "Confirm"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.short_cart_summary
+msgid "Confirm <span class=\"fa fa-chevron-right\"/>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -99,6 +112,3 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.order_state_message
 msgid "Your order is waiting manual confirmation."
 msgstr ""
-
-#~ msgid "Partner"
-#~ msgstr "Партнер"

--- a/website_sale_checkout_skip_payment/i18n/mn.po
+++ b/website_sale_checkout_skip_payment/i18n/mn.po
@@ -8,15 +8,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-15 03:01+0000\n"
-"PO-Revision-Date: 2017-08-15 03:01+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Mongolian (https://www.transifex.com/oca/teams/23907/mn/)\n"
+"POT-Creation-Date: 2021-05-18 10:04+0000\n"
+"PO-Revision-Date: 2021-05-18 12:08+0200\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
+"Language-Team: Mongolian (https://www.transifex.com/oca/teams/23907/"
+"mn/)\n"
 "Language: mn\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
@@ -34,7 +36,7 @@ msgstr ""
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
-msgid "<span>Confirm Order <span class=\"fa fa-chevron-right\"/></span>"
+msgid "<span>Confirm <span class=\"fa fa-chevron-right\"/></span>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -52,6 +54,16 @@ msgstr ""
 #. module: website_sale_checkout_skip_payment
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_config_settings
 msgid "Config Settings"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.cart
+msgid "Confirm"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.short_cart_summary
+msgid "Confirm <span class=\"fa fa-chevron-right\"/>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -99,6 +111,3 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.order_state_message
 msgid "Your order is waiting manual confirmation."
 msgstr ""
-
-#~ msgid "Partner"
-#~ msgstr "Харилцагч"

--- a/website_sale_checkout_skip_payment/i18n/nb.po
+++ b/website_sale_checkout_skip_payment/i18n/nb.po
@@ -8,16 +8,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-15 03:01+0000\n"
-"PO-Revision-Date: 2017-08-15 03:01+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"POT-Creation-Date: 2021-05-18 10:04+0000\n"
+"PO-Revision-Date: 2021-05-18 12:08+0200\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
 "Language-Team: Norwegian Bokmål (https://www.transifex.com/oca/teams/23907/"
 "nb/)\n"
 "Language: nb\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
@@ -35,7 +36,7 @@ msgstr ""
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
-msgid "<span>Confirm Order <span class=\"fa fa-chevron-right\"/></span>"
+msgid "<span>Confirm <span class=\"fa fa-chevron-right\"/></span>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -53,6 +54,16 @@ msgstr ""
 #. module: website_sale_checkout_skip_payment
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_config_settings
 msgid "Config Settings"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.cart
+msgid "Confirm"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.short_cart_summary
+msgid "Confirm <span class=\"fa fa-chevron-right\"/>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -100,6 +111,3 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.order_state_message
 msgid "Your order is waiting manual confirmation."
 msgstr ""
-
-#~ msgid "Partner"
-#~ msgstr "Partner"

--- a/website_sale_checkout_skip_payment/i18n/nb_NO.po
+++ b/website_sale_checkout_skip_payment/i18n/nb_NO.po
@@ -8,16 +8,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-15 03:01+0000\n"
-"PO-Revision-Date: 2017-08-15 03:01+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"POT-Creation-Date: 2021-05-18 10:04+0000\n"
+"PO-Revision-Date: 2021-05-18 12:08+0200\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
 "Language-Team: Norwegian Bokmål (Norway) (https://www.transifex.com/oca/"
 "teams/23907/nb_NO/)\n"
 "Language: nb_NO\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
@@ -35,7 +36,7 @@ msgstr ""
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
-msgid "<span>Confirm Order <span class=\"fa fa-chevron-right\"/></span>"
+msgid "<span>Confirm <span class=\"fa fa-chevron-right\"/></span>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -53,6 +54,16 @@ msgstr ""
 #. module: website_sale_checkout_skip_payment
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_config_settings
 msgid "Config Settings"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.cart
+msgid "Confirm"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.short_cart_summary
+msgid "Confirm <span class=\"fa fa-chevron-right\"/>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -100,6 +111,3 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.order_state_message
 msgid "Your order is waiting manual confirmation."
 msgstr ""
-
-#~ msgid "Partner"
-#~ msgstr "Partner"

--- a/website_sale_checkout_skip_payment/i18n/nl.po
+++ b/website_sale_checkout_skip_payment/i18n/nl.po
@@ -8,16 +8,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-15 03:01+0000\n"
-"PO-Revision-Date: 2020-12-15 13:19+0000\n"
-"Last-Translator: Bosd <c5e2fd43-d292-4c90-9d1f-74ff3436329a@anonaddy.me>\n"
+"POT-Creation-Date: 2021-05-18 10:04+0000\n"
+"PO-Revision-Date: 2021-05-18 12:08+0200\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
 "Language-Team: Dutch (https://www.transifex.com/oca/teams/23907/nl/)\n"
 "Language: nl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.3.2\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
@@ -37,7 +37,7 @@ msgstr ""
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
-msgid "<span>Confirm Order <span class=\"fa fa-chevron-right\"/></span>"
+msgid "<span>Confirm <span class=\"fa fa-chevron-right\"/></span>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -55,6 +55,16 @@ msgstr ""
 #. module: website_sale_checkout_skip_payment
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_config_settings
 msgid "Config Settings"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.cart
+msgid "Confirm"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.short_cart_summary
+msgid "Confirm <span class=\"fa fa-chevron-right\"/>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -102,6 +112,3 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.order_state_message
 msgid "Your order is waiting manual confirmation."
 msgstr "Uw bestelling wacht op handmatige bevestiging."
-
-#~ msgid "Partner"
-#~ msgstr "Relatie"

--- a/website_sale_checkout_skip_payment/i18n/nl_BE.po
+++ b/website_sale_checkout_skip_payment/i18n/nl_BE.po
@@ -8,16 +8,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-15 03:01+0000\n"
-"PO-Revision-Date: 2017-08-15 03:01+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"POT-Creation-Date: 2021-05-18 10:04+0000\n"
+"PO-Revision-Date: 2021-05-18 12:08+0200\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
 "Language-Team: Dutch (Belgium) (https://www.transifex.com/oca/teams/23907/"
 "nl_BE/)\n"
 "Language: nl_BE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
@@ -35,7 +36,7 @@ msgstr ""
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
-msgid "<span>Confirm Order <span class=\"fa fa-chevron-right\"/></span>"
+msgid "<span>Confirm <span class=\"fa fa-chevron-right\"/></span>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -53,6 +54,16 @@ msgstr ""
 #. module: website_sale_checkout_skip_payment
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_config_settings
 msgid "Config Settings"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.cart
+msgid "Confirm"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.short_cart_summary
+msgid "Confirm <span class=\"fa fa-chevron-right\"/>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -100,6 +111,3 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.order_state_message
 msgid "Your order is waiting manual confirmation."
 msgstr ""
-
-#~ msgid "Partner"
-#~ msgstr "Relatie"

--- a/website_sale_checkout_skip_payment/i18n/pl.po
+++ b/website_sale_checkout_skip_payment/i18n/pl.po
@@ -8,17 +8,18 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-15 03:01+0000\n"
-"PO-Revision-Date: 2017-08-15 03:01+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"POT-Creation-Date: 2021-05-18 10:04+0000\n"
+"PO-Revision-Date: 2021-05-18 12:08+0200\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
 "Language-Team: Polish (https://www.transifex.com/oca/teams/23907/pl/)\n"
 "Language: pl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=4; plural=(n==1 ? 0 : (n%10>=2 && n%10<=4) && (n"
 "%100<12 || n%100>14) ? 1 : n!=1 && (n%10>=0 && n%10<=1) || (n%10>=5 && n"
 "%10<=9) || (n%100>=12 && n%100<=14) ? 2 : 3);\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
@@ -36,7 +37,7 @@ msgstr ""
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
-msgid "<span>Confirm Order <span class=\"fa fa-chevron-right\"/></span>"
+msgid "<span>Confirm <span class=\"fa fa-chevron-right\"/></span>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -54,6 +55,16 @@ msgstr ""
 #. module: website_sale_checkout_skip_payment
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_config_settings
 msgid "Config Settings"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.cart
+msgid "Confirm"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.short_cart_summary
+msgid "Confirm <span class=\"fa fa-chevron-right\"/>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -101,6 +112,3 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.order_state_message
 msgid "Your order is waiting manual confirmation."
 msgstr ""
-
-#~ msgid "Partner"
-#~ msgstr "Partner"

--- a/website_sale_checkout_skip_payment/i18n/pt.po
+++ b/website_sale_checkout_skip_payment/i18n/pt.po
@@ -8,15 +8,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-15 03:01+0000\n"
-"PO-Revision-Date: 2017-08-15 03:01+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Portuguese (https://www.transifex.com/oca/teams/23907/pt/)\n"
+"POT-Creation-Date: 2021-05-18 10:04+0000\n"
+"PO-Revision-Date: 2021-05-18 12:08+0200\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
+"Language-Team: Portuguese (https://www.transifex.com/oca/teams/23907/"
+"pt/)\n"
 "Language: pt\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
@@ -34,7 +36,7 @@ msgstr ""
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
-msgid "<span>Confirm Order <span class=\"fa fa-chevron-right\"/></span>"
+msgid "<span>Confirm <span class=\"fa fa-chevron-right\"/></span>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -52,6 +54,16 @@ msgstr ""
 #. module: website_sale_checkout_skip_payment
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_config_settings
 msgid "Config Settings"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.cart
+msgid "Confirm"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.short_cart_summary
+msgid "Confirm <span class=\"fa fa-chevron-right\"/>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -99,6 +111,3 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.order_state_message
 msgid "Your order is waiting manual confirmation."
 msgstr ""
-
-#~ msgid "Partner"
-#~ msgstr "Parceiro"

--- a/website_sale_checkout_skip_payment/i18n/pt_BR.po
+++ b/website_sale_checkout_skip_payment/i18n/pt_BR.po
@@ -8,16 +8,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-15 03:01+0000\n"
-"PO-Revision-Date: 2017-08-15 03:01+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"POT-Creation-Date: 2021-05-18 10:04+0000\n"
+"PO-Revision-Date: 2021-05-18 12:08+0200\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
 "Language-Team: Portuguese (Brazil) (https://www.transifex.com/oca/"
 "teams/23907/pt_BR/)\n"
 "Language: pt_BR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
@@ -35,7 +36,7 @@ msgstr ""
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
-msgid "<span>Confirm Order <span class=\"fa fa-chevron-right\"/></span>"
+msgid "<span>Confirm <span class=\"fa fa-chevron-right\"/></span>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -53,6 +54,16 @@ msgstr ""
 #. module: website_sale_checkout_skip_payment
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_config_settings
 msgid "Config Settings"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.cart
+msgid "Confirm"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.short_cart_summary
+msgid "Confirm <span class=\"fa fa-chevron-right\"/>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -100,6 +111,3 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.order_state_message
 msgid "Your order is waiting manual confirmation."
 msgstr ""
-
-#~ msgid "Partner"
-#~ msgstr "Parceiro"

--- a/website_sale_checkout_skip_payment/i18n/pt_PT.po
+++ b/website_sale_checkout_skip_payment/i18n/pt_PT.po
@@ -8,16 +8,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-15 03:01+0000\n"
-"PO-Revision-Date: 2017-08-15 03:01+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"POT-Creation-Date: 2021-05-18 10:04+0000\n"
+"PO-Revision-Date: 2021-05-18 12:07+0200\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
 "Language-Team: Portuguese (Portugal) (https://www.transifex.com/oca/"
 "teams/23907/pt_PT/)\n"
 "Language: pt_PT\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
@@ -35,7 +36,7 @@ msgstr ""
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
-msgid "<span>Confirm Order <span class=\"fa fa-chevron-right\"/></span>"
+msgid "<span>Confirm <span class=\"fa fa-chevron-right\"/></span>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -53,6 +54,16 @@ msgstr ""
 #. module: website_sale_checkout_skip_payment
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_config_settings
 msgid "Config Settings"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.cart
+msgid "Confirm"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.short_cart_summary
+msgid "Confirm <span class=\"fa fa-chevron-right\"/>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -100,6 +111,3 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.order_state_message
 msgid "Your order is waiting manual confirmation."
 msgstr ""
-
-#~ msgid "Partner"
-#~ msgstr "Parceiro"

--- a/website_sale_checkout_skip_payment/i18n/ro.po
+++ b/website_sale_checkout_skip_payment/i18n/ro.po
@@ -8,16 +8,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-15 03:01+0000\n"
-"PO-Revision-Date: 2017-08-15 03:01+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"POT-Creation-Date: 2021-05-18 10:04+0000\n"
+"PO-Revision-Date: 2021-05-18 12:07+0200\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
 "Language-Team: Romanian (https://www.transifex.com/oca/teams/23907/ro/)\n"
 "Language: ro\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==1?0:(((n%100>19)||((n%100==0)&&(n!=0)))?"
 "2:1));\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
@@ -35,7 +36,7 @@ msgstr ""
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
-msgid "<span>Confirm Order <span class=\"fa fa-chevron-right\"/></span>"
+msgid "<span>Confirm <span class=\"fa fa-chevron-right\"/></span>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -53,6 +54,16 @@ msgstr ""
 #. module: website_sale_checkout_skip_payment
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_config_settings
 msgid "Config Settings"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.cart
+msgid "Confirm"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.short_cart_summary
+msgid "Confirm <span class=\"fa fa-chevron-right\"/>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -100,6 +111,3 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.order_state_message
 msgid "Your order is waiting manual confirmation."
 msgstr ""
-
-#~ msgid "Partner"
-#~ msgstr "Partener"

--- a/website_sale_checkout_skip_payment/i18n/ru.po
+++ b/website_sale_checkout_skip_payment/i18n/ru.po
@@ -8,17 +8,18 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-15 03:01+0000\n"
-"PO-Revision-Date: 2017-08-15 03:01+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"POT-Creation-Date: 2021-05-18 10:04+0000\n"
+"PO-Revision-Date: 2021-05-18 12:07+0200\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
 "Language-Team: Russian (https://www.transifex.com/oca/teams/23907/ru/)\n"
 "Language: ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
 "%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n"
 "%100>=11 && n%100<=14)? 2 : 3);\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
@@ -36,7 +37,7 @@ msgstr ""
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
-msgid "<span>Confirm Order <span class=\"fa fa-chevron-right\"/></span>"
+msgid "<span>Confirm <span class=\"fa fa-chevron-right\"/></span>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -54,6 +55,16 @@ msgstr ""
 #. module: website_sale_checkout_skip_payment
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_config_settings
 msgid "Config Settings"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.cart
+msgid "Confirm"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.short_cart_summary
+msgid "Confirm <span class=\"fa fa-chevron-right\"/>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -101,6 +112,3 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.order_state_message
 msgid "Your order is waiting manual confirmation."
 msgstr ""
-
-#~ msgid "Partner"
-#~ msgstr "Контрагент"

--- a/website_sale_checkout_skip_payment/i18n/sk.po
+++ b/website_sale_checkout_skip_payment/i18n/sk.po
@@ -8,15 +8,18 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-15 03:01+0000\n"
-"PO-Revision-Date: 2017-08-15 03:01+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Slovak (https://www.transifex.com/oca/teams/23907/sk/)\n"
+"POT-Creation-Date: 2021-05-18 10:04+0000\n"
+"PO-Revision-Date: 2021-05-18 12:07+0200\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
+"Language-Team: Slovak (https://www.transifex.com/oca/teams/23907/"
+"sk/)\n"
 "Language: sk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : "
+"2;\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
@@ -34,7 +37,7 @@ msgstr ""
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
-msgid "<span>Confirm Order <span class=\"fa fa-chevron-right\"/></span>"
+msgid "<span>Confirm <span class=\"fa fa-chevron-right\"/></span>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -52,6 +55,16 @@ msgstr ""
 #. module: website_sale_checkout_skip_payment
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_config_settings
 msgid "Config Settings"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.cart
+msgid "Confirm"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.short_cart_summary
+msgid "Confirm <span class=\"fa fa-chevron-right\"/>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -99,6 +112,3 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.order_state_message
 msgid "Your order is waiting manual confirmation."
 msgstr ""
-
-#~ msgid "Partner"
-#~ msgstr "Partner"

--- a/website_sale_checkout_skip_payment/i18n/sl.po
+++ b/website_sale_checkout_skip_payment/i18n/sl.po
@@ -8,16 +8,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-15 03:01+0000\n"
-"PO-Revision-Date: 2017-08-15 03:01+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"POT-Creation-Date: 2021-05-18 10:04+0000\n"
+"PO-Revision-Date: 2021-05-18 12:07+0200\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
 "Language-Team: Slovenian (https://www.transifex.com/oca/teams/23907/sl/)\n"
 "Language: sl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n"
 "%100==4 ? 2 : 3);\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
@@ -35,7 +36,7 @@ msgstr ""
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
-msgid "<span>Confirm Order <span class=\"fa fa-chevron-right\"/></span>"
+msgid "<span>Confirm <span class=\"fa fa-chevron-right\"/></span>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -53,6 +54,16 @@ msgstr ""
 #. module: website_sale_checkout_skip_payment
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_config_settings
 msgid "Config Settings"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.cart
+msgid "Confirm"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.short_cart_summary
+msgid "Confirm <span class=\"fa fa-chevron-right\"/>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -100,6 +111,3 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.order_state_message
 msgid "Your order is waiting manual confirmation."
 msgstr ""
-
-#~ msgid "Partner"
-#~ msgstr "Partner"

--- a/website_sale_checkout_skip_payment/i18n/sr.po
+++ b/website_sale_checkout_skip_payment/i18n/sr.po
@@ -8,16 +8,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-15 03:01+0000\n"
-"PO-Revision-Date: 2017-08-15 03:01+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"POT-Creation-Date: 2021-05-18 10:04+0000\n"
+"PO-Revision-Date: 2021-05-18 12:07+0200\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
 "Language-Team: Serbian (https://www.transifex.com/oca/teams/23907/sr/)\n"
 "Language: sr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
@@ -35,7 +36,7 @@ msgstr ""
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
-msgid "<span>Confirm Order <span class=\"fa fa-chevron-right\"/></span>"
+msgid "<span>Confirm <span class=\"fa fa-chevron-right\"/></span>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -53,6 +54,16 @@ msgstr ""
 #. module: website_sale_checkout_skip_payment
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_config_settings
 msgid "Config Settings"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.cart
+msgid "Confirm"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.short_cart_summary
+msgid "Confirm <span class=\"fa fa-chevron-right\"/>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment

--- a/website_sale_checkout_skip_payment/i18n/sr@latin.po
+++ b/website_sale_checkout_skip_payment/i18n/sr@latin.po
@@ -8,17 +8,18 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-15 03:01+0000\n"
-"PO-Revision-Date: 2017-08-15 03:01+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"POT-Creation-Date: 2021-05-18 10:04+0000\n"
+"PO-Revision-Date: 2021-05-18 12:07+0200\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
 "Language-Team: Serbian (Latin) (https://www.transifex.com/oca/teams/23907/"
 "sr@latin/)\n"
 "Language: sr@latin\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
@@ -36,7 +37,7 @@ msgstr ""
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
-msgid "<span>Confirm Order <span class=\"fa fa-chevron-right\"/></span>"
+msgid "<span>Confirm <span class=\"fa fa-chevron-right\"/></span>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -54,6 +55,16 @@ msgstr ""
 #. module: website_sale_checkout_skip_payment
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_config_settings
 msgid "Config Settings"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.cart
+msgid "Confirm"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.short_cart_summary
+msgid "Confirm <span class=\"fa fa-chevron-right\"/>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -101,6 +112,3 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.order_state_message
 msgid "Your order is waiting manual confirmation."
 msgstr ""
-
-#~ msgid "Partner"
-#~ msgstr "Partner"

--- a/website_sale_checkout_skip_payment/i18n/sv.po
+++ b/website_sale_checkout_skip_payment/i18n/sv.po
@@ -8,15 +8,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-15 03:01+0000\n"
-"PO-Revision-Date: 2017-08-15 03:01+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Swedish (https://www.transifex.com/oca/teams/23907/sv/)\n"
+"POT-Creation-Date: 2021-05-18 10:04+0000\n"
+"PO-Revision-Date: 2021-05-18 12:07+0200\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
+"Language-Team: Swedish (https://www.transifex.com/oca/teams/23907/"
+"sv/)\n"
 "Language: sv\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
@@ -34,7 +36,7 @@ msgstr ""
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
-msgid "<span>Confirm Order <span class=\"fa fa-chevron-right\"/></span>"
+msgid "<span>Confirm <span class=\"fa fa-chevron-right\"/></span>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -52,6 +54,16 @@ msgstr ""
 #. module: website_sale_checkout_skip_payment
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_config_settings
 msgid "Config Settings"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.cart
+msgid "Confirm"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.short_cart_summary
+msgid "Confirm <span class=\"fa fa-chevron-right\"/>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -99,6 +111,3 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.order_state_message
 msgid "Your order is waiting manual confirmation."
 msgstr ""
-
-#~ msgid "Partner"
-#~ msgstr "Företag"

--- a/website_sale_checkout_skip_payment/i18n/th.po
+++ b/website_sale_checkout_skip_payment/i18n/th.po
@@ -8,15 +8,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-15 03:01+0000\n"
-"PO-Revision-Date: 2017-08-15 03:01+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"POT-Creation-Date: 2021-05-18 10:04+0000\n"
+"PO-Revision-Date: 2021-05-18 12:06+0200\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
 "Language-Team: Thai (https://www.transifex.com/oca/teams/23907/th/)\n"
 "Language: th\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
@@ -34,7 +35,7 @@ msgstr ""
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
-msgid "<span>Confirm Order <span class=\"fa fa-chevron-right\"/></span>"
+msgid "<span>Confirm <span class=\"fa fa-chevron-right\"/></span>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -52,6 +53,16 @@ msgstr ""
 #. module: website_sale_checkout_skip_payment
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_config_settings
 msgid "Config Settings"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.cart
+msgid "Confirm"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.short_cart_summary
+msgid "Confirm <span class=\"fa fa-chevron-right\"/>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -99,6 +110,3 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.order_state_message
 msgid "Your order is waiting manual confirmation."
 msgstr ""
-
-#~ msgid "Partner"
-#~ msgstr "พาร์ทเนอร์"

--- a/website_sale_checkout_skip_payment/i18n/tr.po
+++ b/website_sale_checkout_skip_payment/i18n/tr.po
@@ -9,15 +9,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-15 03:01+0000\n"
-"PO-Revision-Date: 2017-08-15 03:01+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Turkish (https://www.transifex.com/oca/teams/23907/tr/)\n"
+"POT-Creation-Date: 2021-05-18 10:04+0000\n"
+"PO-Revision-Date: 2021-05-18 12:06+0200\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
+"Language-Team: Turkish (https://www.transifex.com/oca/teams/23907/"
+"tr/)\n"
 "Language: tr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
@@ -35,7 +37,7 @@ msgstr ""
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
-msgid "<span>Confirm Order <span class=\"fa fa-chevron-right\"/></span>"
+msgid "<span>Confirm <span class=\"fa fa-chevron-right\"/></span>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -53,6 +55,16 @@ msgstr ""
 #. module: website_sale_checkout_skip_payment
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_config_settings
 msgid "Config Settings"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.cart
+msgid "Confirm"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.short_cart_summary
+msgid "Confirm <span class=\"fa fa-chevron-right\"/>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -100,6 +112,3 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.order_state_message
 msgid "Your order is waiting manual confirmation."
 msgstr ""
-
-#~ msgid "Partner"
-#~ msgstr "İş Ortağı"

--- a/website_sale_checkout_skip_payment/i18n/tr_TR.po
+++ b/website_sale_checkout_skip_payment/i18n/tr_TR.po
@@ -8,16 +8,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-15 03:01+0000\n"
-"PO-Revision-Date: 2017-08-15 03:01+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"POT-Creation-Date: 2021-05-18 10:04+0000\n"
+"PO-Revision-Date: 2021-05-18 12:06+0200\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
 "Language-Team: Turkish (Turkey) (https://www.transifex.com/oca/teams/23907/"
 "tr_TR/)\n"
 "Language: tr_TR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
@@ -35,7 +36,7 @@ msgstr ""
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
-msgid "<span>Confirm Order <span class=\"fa fa-chevron-right\"/></span>"
+msgid "<span>Confirm <span class=\"fa fa-chevron-right\"/></span>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -53,6 +54,16 @@ msgstr ""
 #. module: website_sale_checkout_skip_payment
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_config_settings
 msgid "Config Settings"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.cart
+msgid "Confirm"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.short_cart_summary
+msgid "Confirm <span class=\"fa fa-chevron-right\"/>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -100,6 +111,3 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.order_state_message
 msgid "Your order is waiting manual confirmation."
 msgstr ""
-
-#~ msgid "Partner"
-#~ msgstr "Ortak"

--- a/website_sale_checkout_skip_payment/i18n/uk.po
+++ b/website_sale_checkout_skip_payment/i18n/uk.po
@@ -8,16 +8,18 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-15 03:01+0000\n"
-"PO-Revision-Date: 2017-08-15 03:01+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Ukrainian (https://www.transifex.com/oca/teams/23907/uk/)\n"
+"POT-Creation-Date: 2021-05-18 10:04+0000\n"
+"PO-Revision-Date: 2021-05-18 12:06+0200\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
+"Language-Team: Ukrainian (https://www.transifex.com/oca/teams/23907/"
+"uk/)\n"
 "Language: uk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
@@ -35,7 +37,7 @@ msgstr ""
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
-msgid "<span>Confirm Order <span class=\"fa fa-chevron-right\"/></span>"
+msgid "<span>Confirm <span class=\"fa fa-chevron-right\"/></span>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -53,6 +55,16 @@ msgstr ""
 #. module: website_sale_checkout_skip_payment
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_config_settings
 msgid "Config Settings"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.cart
+msgid "Confirm"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.short_cart_summary
+msgid "Confirm <span class=\"fa fa-chevron-right\"/>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment

--- a/website_sale_checkout_skip_payment/i18n/vi.po
+++ b/website_sale_checkout_skip_payment/i18n/vi.po
@@ -8,15 +8,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-15 03:01+0000\n"
-"PO-Revision-Date: 2017-08-15 03:01+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Vietnamese (https://www.transifex.com/oca/teams/23907/vi/)\n"
+"POT-Creation-Date: 2021-05-18 10:04+0000\n"
+"PO-Revision-Date: 2021-05-18 12:06+0200\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
+"Language-Team: Vietnamese (https://www.transifex.com/oca/teams/23907/"
+"vi/)\n"
 "Language: vi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
@@ -34,7 +36,7 @@ msgstr ""
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
-msgid "<span>Confirm Order <span class=\"fa fa-chevron-right\"/></span>"
+msgid "<span>Confirm <span class=\"fa fa-chevron-right\"/></span>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -52,6 +54,16 @@ msgstr ""
 #. module: website_sale_checkout_skip_payment
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_config_settings
 msgid "Config Settings"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.cart
+msgid "Confirm"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.short_cart_summary
+msgid "Confirm <span class=\"fa fa-chevron-right\"/>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -99,6 +111,3 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.order_state_message
 msgid "Your order is waiting manual confirmation."
 msgstr ""
-
-#~ msgid "Partner"
-#~ msgstr "Đối tác"

--- a/website_sale_checkout_skip_payment/i18n/website_sale_checkout_skip_payment.pot
+++ b/website_sale_checkout_skip_payment/i18n/website_sale_checkout_skip_payment.pot
@@ -4,8 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 13.0\n"
+"Project-Id-Version: Odoo Server 13.0+e\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-05-18 10:04+0000\n"
+"PO-Revision-Date: 2021-05-18 10:04+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -29,7 +31,7 @@ msgstr ""
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
-msgid "<span>Confirm Order <span class=\"fa fa-chevron-right\"/></span>"
+msgid "<span>Confirm <span class=\"fa fa-chevron-right\"/></span>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -47,6 +49,16 @@ msgstr ""
 #. module: website_sale_checkout_skip_payment
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_config_settings
 msgid "Config Settings"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.cart
+msgid "Confirm"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.short_cart_summary
+msgid "Confirm <span class=\"fa fa-chevron-right\"/>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment

--- a/website_sale_checkout_skip_payment/i18n/zh_CN.po
+++ b/website_sale_checkout_skip_payment/i18n/zh_CN.po
@@ -8,16 +8,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-15 03:01+0000\n"
-"PO-Revision-Date: 2017-08-15 03:01+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"POT-Creation-Date: 2021-05-18 10:04+0000\n"
+"PO-Revision-Date: 2021-05-18 12:06+0200\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
 "Language-Team: Chinese (China) (https://www.transifex.com/oca/teams/23907/"
 "zh_CN/)\n"
 "Language: zh_CN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
@@ -35,7 +36,7 @@ msgstr ""
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
-msgid "<span>Confirm Order <span class=\"fa fa-chevron-right\"/></span>"
+msgid "<span>Confirm <span class=\"fa fa-chevron-right\"/></span>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -53,6 +54,16 @@ msgstr ""
 #. module: website_sale_checkout_skip_payment
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_config_settings
 msgid "Config Settings"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.cart
+msgid "Confirm"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.short_cart_summary
+msgid "Confirm <span class=\"fa fa-chevron-right\"/>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -100,6 +111,3 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.order_state_message
 msgid "Your order is waiting manual confirmation."
 msgstr ""
-
-#~ msgid "Partner"
-#~ msgstr "业务伙伴"

--- a/website_sale_checkout_skip_payment/i18n/zh_TW.po
+++ b/website_sale_checkout_skip_payment/i18n/zh_TW.po
@@ -8,16 +8,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-15 03:01+0000\n"
-"PO-Revision-Date: 2017-08-15 03:01+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"POT-Creation-Date: 2021-05-18 10:04+0000\n"
+"PO-Revision-Date: 2021-05-18 12:06+0200\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
 "Language-Team: Chinese (Taiwan) (https://www.transifex.com/oca/teams/23907/"
 "zh_TW/)\n"
 "Language: zh_TW\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
@@ -35,7 +36,7 @@ msgstr ""
 
 #. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.payment
-msgid "<span>Confirm Order <span class=\"fa fa-chevron-right\"/></span>"
+msgid "<span>Confirm <span class=\"fa fa-chevron-right\"/></span>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -53,6 +54,16 @@ msgstr ""
 #. module: website_sale_checkout_skip_payment
 #: model:ir.model,name:website_sale_checkout_skip_payment.model_res_config_settings
 msgid "Config Settings"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.cart
+msgid "Confirm"
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
+#: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.short_cart_summary
+msgid "Confirm <span class=\"fa fa-chevron-right\"/>"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
@@ -100,6 +111,3 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.order_state_message
 msgid "Your order is waiting manual confirmation."
 msgstr ""
-
-#~ msgid "Partner"
-#~ msgstr "夥伴"

--- a/website_sale_checkout_skip_payment/models/website.py
+++ b/website_sale_checkout_skip_payment/models/website.py
@@ -17,7 +17,6 @@ class Website(models.Model):
 
     def _compute_checkout_skip_payment(self):
         for rec in self:
-            if request.session.uid:
-                rec.checkout_skip_payment = (
-                    request.env.user.partner_id.skip_website_checkout_payment
-                )
+            rec.checkout_skip_payment = (
+                request.env.user.partner_id.skip_website_checkout_payment
+            )

--- a/website_sale_checkout_skip_payment/static/src/js/website_sale_checkout_skip_payment_tour.js
+++ b/website_sale_checkout_skip_payment/static/src/js/website_sale_checkout_skip_payment_tour.js
@@ -15,10 +15,11 @@ odoo.define("website_sale_checkout_skip_payment.tour", function(require) {
             trigger: "a:contains('Add to Cart')",
         },
         {
-            trigger: ".btn-primary:contains('Process Checkout')",
+            trigger: ".btn-primary:contains('Confirm')",
         },
         {
-            trigger: ".btn:contains('Confirm Order')",
+            trigger: ".btn:contains('Confirm')",
+            extra_trigger: "b:contains('Billing & Shipping:')",
         },
         {
             trigger: "a[href='/shop']",

--- a/website_sale_checkout_skip_payment/views/website_sale_template.xml
+++ b/website_sale_checkout_skip_payment/views/website_sale_template.xml
@@ -27,7 +27,7 @@
                         t-att-value="request.csrf_token()"
                     />
                     <a role="button" class="btn btn-primary a-submit" href="#">
-                        <span>Confirm Order <span class="fa fa-chevron-right" /></span>
+                        <span>Confirm <span class="fa fa-chevron-right" /></span>
                     </a>
                 </form>
             </div>
@@ -75,5 +75,23 @@
     <template id="order_state_message">
         <p>Your order is waiting manual confirmation.</p>
         <br />
+    </template>
+    <template id="cart" inherit_id="website_sale.cart">
+        <xpath expr="//a[@href='/shop/checkout?express=1']/span" position="attributes">
+            <attribute name="t-if">not website.checkout_skip_payment</attribute>
+        </xpath>
+        <xpath expr="//a[@href='/shop/checkout?express=1']/span" position="after">
+            <span t-if="website.checkout_skip_payment">Confirm</span>
+        </xpath>
+    </template>
+    <template id="short_cart_summary" inherit_id="website_sale.short_cart_summary">
+        <xpath expr="//a[@href='/shop/checkout?express=1']/span" position="attributes">
+            <attribute name="t-if">not website.checkout_skip_payment</attribute>
+        </xpath>
+        <xpath expr="//a[@href='/shop/checkout?express=1']/span" position="after">
+            <span t-if="website.checkout_skip_payment">Confirm <span
+                    class="fa fa-chevron-right"
+                /></span>
+        </xpath>
     </template>
 </odoo>


### PR DESCRIPTION
With this changes the 'Process Checkout' button change to 'Confirm' when the partner has selected the option skip_website_checkout_payment. Furthermore, the button text 'Confirm Order' has been changed to 'Confirm'.

cc @Tecnativa TT29736

please @pedrobaeza @victoralmau review this