### PR TITLE
[FIX] webiste_sale_order_type: trigger onchanges

### DIFF
--- a/website_sale_order_type/models/sale_order.py
+++ b/website_sale_order_type/models/sale_order.py
@@ -19,4 +19,5 @@ class SaleOrder(models.Model):
                      self.partner_id.commercial_partner_id.sale_type)
         if sale_type:
             self.type_id = sale_type
+            self.onchange_type_id()
         return res


### PR DESCRIPTION
If we don't trigger the onchanges, we won't get some of the default
values that the order type has defined

cc @Tecnativa TT30235

please, review @joao-p-marques @pedrobaeza 