### PR TITLE
[13.0][FIX]website_account_fiscal_position_partner_type: force calculation fiscal position

### DIFF
--- a/website_account_fiscal_position_partner_type/controllers/main.py
+++ b/website_account_fiscal_position_partner_type/controllers/main.py
@@ -20,6 +20,7 @@ class WebsiteSale(WebsiteSale):
 
     @http.route()
     def address(self, **kw):
+        submitted = "submitted" in kw
         res = super(WebsiteSale, self).address(**kw)
         if res.qcontext:
             mode = res.qcontext.get("mode", False)
@@ -48,4 +49,8 @@ class WebsiteSale(WebsiteSale):
                         ),
                     }
                 )
+        if submitted:
+            order = request.website.sale_get_order()
+            if order:
+                order.onchange_partner_shipping_id()
         return res


### PR DESCRIPTION
Case:
1.- Go e-commer with public user.
2.- Buy something.
3.- Complete the purchase without registering.
4.- The fical position doesn't recalculate.