### PR TITLE
[12.0][FIX] website_sale_product_minimal_price: default variant

### DIFF
--- a/website_sale_product_minimal_price/README.rst
+++ b/website_sale_product_minimal_price/README.rst
@@ -52,6 +52,20 @@ Usage
 #. Click on product, the price displayed is the minimal variant price. On the chart
    under the buy button you can see the different taxes applied to the product.
 
+Known issues / Roadmap
+======================
+
+* When there are some variants with the same minimal price, we won't get the expected
+  attribute value sequence order to get the first combination but the default
+  `product.product` order. This is like this because we stretch the possible variants
+  to a single one which is the first to hit the minimum price. The next ones are
+  ignored.
+
+  A way to solve this would be to redisign the `_get_cheapest_info` to get all the
+  variants that meet the cheapest found price and return a recordset and then try
+  to rely on `super()` to get the first possible combination for those. Some refactor
+  would be needed though.
+
 Changelog
 =========
 

--- a/website_sale_product_minimal_price/models/product_template.py
+++ b/website_sale_product_minimal_price/models/product_template.py
@@ -125,7 +125,13 @@ class ProductTemplate(models.Model):
             # more than one variants and we know the pricelist
             pricelist = self.env["product.pricelist"].browse(
                 context["pricelist"])
-            product_id = self._get_cheapest_info(pricelist)[0]
+            product_id, add_qty, has_distinct_price = (
+                self._get_cheapest_info(pricelist)
+            )
+            # When all the variants have the same price, we want to rely on the
+            # default attribute value order.
+            if not has_distinct_price:
+                return res
             product = self.env["product.product"].browse(product_id)
             # Rebuild the combination in the expected order
             res = self.env["product.template.attribute.value"]

--- a/website_sale_product_minimal_price/readme/ROADMAP.rst
+++ b/website_sale_product_minimal_price/readme/ROADMAP.rst
@@ -1,0 +1,10 @@
+* When there are some variants with the same minimal price, we won't get the expected
+  attribute value sequence order to get the first combination but the default
+  `product.product` order. This is like this because we stretch the possible variants
+  to a single one which is the first to hit the minimum price. The next ones are
+  ignored.
+
+  A way to solve this would be to redisign the `_get_cheapest_info` to get all the
+  variants that meet the cheapest found price and return a recordset and then try
+  to rely on `super()` to get the first possible combination for those. Some refactor
+  would be needed though.

--- a/website_sale_product_minimal_price/static/description/index.html
+++ b/website_sale_product_minimal_price/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Website Sale Product Minimal Price</title>
 <style type="text/css">
 
@@ -376,17 +376,18 @@ price and set order by minimal price in product’s view.</p>
 <ul class="simple">
 <li><a class="reference internal" href="#configuration" id="id4">Configuration</a></li>
 <li><a class="reference internal" href="#usage" id="id5">Usage</a></li>
-<li><a class="reference internal" href="#changelog" id="id6">Changelog</a><ul>
-<li><a class="reference internal" href="#id1" id="id7">12.0.1.1.0 (2020-09-30)</a></li>
-<li><a class="reference internal" href="#id2" id="id8">12.0.1.0.0 (2019-12-12)</a></li>
-<li><a class="reference internal" href="#id3" id="id9">11.0.1.0.0 (2019-05-28)</a></li>
+<li><a class="reference internal" href="#known-issues-roadmap" id="id6">Known issues / Roadmap</a></li>
+<li><a class="reference internal" href="#changelog" id="id7">Changelog</a><ul>
+<li><a class="reference internal" href="#id1" id="id8">12.0.1.1.0 (2020-09-30)</a></li>
+<li><a class="reference internal" href="#id2" id="id9">12.0.1.0.0 (2019-12-12)</a></li>
+<li><a class="reference internal" href="#id3" id="id10">11.0.1.0.0 (2019-05-28)</a></li>
 </ul>
 </li>
-<li><a class="reference internal" href="#bug-tracker" id="id10">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="id11">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="id12">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="id13">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="id14">Maintainers</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="id11">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="id12">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="id13">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="id14">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="id15">Maintainers</a></li>
 </ul>
 </li>
 </ul>
@@ -411,10 +412,25 @@ rate on the current pricelist.</li>
 under the buy button you can see the different taxes applied to the product.</li>
 </ol>
 </div>
+<div class="section" id="known-issues-roadmap">
+<h1><a class="toc-backref" href="#id6">Known issues / Roadmap</a></h1>
+<ul>
+<li><p class="first">When there are some variants with the same minimal price, we won’t get the expected
+attribute value sequence order to get the first combination but the default
+<cite>product.product</cite> order. This is like this because we stretch the possible variants
+to a single one which is the first to hit the minimum price. The next ones are
+ignored.</p>
+<p>A way to solve this would be to redisign the <cite>_get_cheapest_info</cite> to get all the
+variants that meet the cheapest found price and return a recordset and then try
+to rely on <cite>super()</cite> to get the first possible combination for those. Some refactor
+would be needed though.</p>
+</li>
+</ul>
+</div>
 <div class="section" id="changelog">
-<h1><a class="toc-backref" href="#id6">Changelog</a></h1>
+<h1><a class="toc-backref" href="#id7">Changelog</a></h1>
 <div class="section" id="id1">
-<h2><a class="toc-backref" href="#id7">12.0.1.1.0 (2020-09-30)</a></h2>
+<h2><a class="toc-backref" href="#id8">12.0.1.1.0 (2020-09-30)</a></h2>
 <ul>
 <li><p class="first">[IMP] Has been added the functionality that allows to take care about the rates to
 calculate the minimum price of the product. Furthermore, a dynamic grid was added
@@ -427,20 +443,20 @@ to show next values.</p>
 </ul>
 </div>
 <div class="section" id="id2">
-<h2><a class="toc-backref" href="#id8">12.0.1.0.0 (2019-12-12)</a></h2>
+<h2><a class="toc-backref" href="#id9">12.0.1.0.0 (2019-12-12)</a></h2>
 <ul class="simple">
 <li>[MIG] Initial V12 version. Complete migration from v11.</li>
 </ul>
 </div>
 <div class="section" id="id3">
-<h2><a class="toc-backref" href="#id9">11.0.1.0.0 (2019-05-28)</a></h2>
+<h2><a class="toc-backref" href="#id10">11.0.1.0.0 (2019-05-28)</a></h2>
 <ul class="simple">
 <li>[NEW] Module added to v11.</li>
 </ul>
 </div>
 </div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#id10">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#id11">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/e-commerce/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us smashing it by providing a detailed and welcomed
@@ -448,15 +464,15 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#id11">Credits</a></h1>
+<h1><a class="toc-backref" href="#id12">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#id12">Authors</a></h2>
+<h2><a class="toc-backref" href="#id13">Authors</a></h2>
 <ul class="simple">
 <li>Tecnativa</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#id13">Contributors</a></h2>
+<h2><a class="toc-backref" href="#id14">Contributors</a></h2>
 <ul>
 <li><p class="first"><a class="reference external" href="https://www.tecnativa.com">Tecnativa</a>:</p>
 <blockquote>
@@ -470,7 +486,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#id14">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#id15">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose


### PR DESCRIPTION
When there's no minimal price (all the variant prices are the same) keep
the default first combination behavior, that is: take it counting on the
attribute values sequences.

cc @Tecnativa TT31880

please review @sergio-teruel @pedrobaeza @CarlosRoca13 