### PR TITLE
[13.0][IMP]website_sale_hide_empty_category improvements

### DIFF
--- a/website_sale_hide_empty_category/README.rst
+++ b/website_sale_hide_empty_category/README.rst
@@ -26,7 +26,7 @@ Website Sale - Hide Empty Categories
 |badge1| |badge2| |badge3| |badge4| |badge5| 
 
 Removes any category links from the Shop which have no products associated
-to them.
+to them. Also allows displaying number of products in individual categories.
 
 **Table of contents**
 

--- a/website_sale_hide_empty_category/models/product_public_category.py
+++ b/website_sale_hide_empty_category/models/product_public_category.py
@@ -12,10 +12,16 @@ class ProductPublicCategory(models.Model):
         compute="_compute_has_product_recursive",
     )
 
+    count_product_recursive = fields.Integer(
+        string="Number of products in this category or one of its children",
+        compute="_compute_has_product_recursive",
+    )
+
     @api.depends("product_tmpl_ids", "child_id.has_product_recursive")
     def _compute_has_product_recursive(self):
         for category in self:
-            category.has_product_recursive = bool(
-                category.product_tmpl_ids
-                or any(child.has_product_recursive for child in category.child_id)
+            product_count = len(category.product_tmpl_ids) + sum(
+                child.has_product_recursive for child in category.child_id
             )
+            category.count_product_recursive = product_count
+            category.has_product_recursive = bool(product_count)

--- a/website_sale_hide_empty_category/readme/DESCRIPTION.rst
+++ b/website_sale_hide_empty_category/readme/DESCRIPTION.rst
@@ -1,2 +1,2 @@
 Removes any category links from the Shop which have no products associated
-to them.
+to them. Also allows displaying number of products in individual categories.

--- a/website_sale_hide_empty_category/static/description/index.html
+++ b/website_sale_hide_empty_category/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils 0.16: http://docutils.sourceforge.net/" />
 <title>Website Sale - Hide Empty Categories</title>
 <style type="text/css">
 
@@ -369,7 +369,7 @@ ul.auto-toc {
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external" href="http://www.gnu.org/licenses/lgpl-3.0-standalone.html"><img alt="License: LGPL-3" src="https://img.shields.io/badge/licence-LGPL--3-blue.png" /></a> <a class="reference external" href="https://github.com/OCA/e-commerce/tree/13.0/website_sale_hide_empty_category"><img alt="OCA/e-commerce" src="https://img.shields.io/badge/github-OCA%2Fe--commerce-lightgray.png?logo=github" /></a> <a class="reference external" href="https://translation.odoo-community.org/projects/e-commerce-13-0/e-commerce-13-0-website_sale_hide_empty_category"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external" href="https://runbot.odoo-community.org/runbot/113/13.0"><img alt="Try me on Runbot" src="https://img.shields.io/badge/runbot-Try%20me-875A7B.png" /></a></p>
 <p>Removes any category links from the Shop which have no products associated
-to them.</p>
+to them. Also allows displaying number of products in individual categories.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">

--- a/website_sale_hide_empty_category/views/website_sale_templates.xml
+++ b/website_sale_hide_empty_category/views/website_sale_templates.xml
@@ -9,6 +9,13 @@
         id="hide_categories_recursive"
         name="Hide Empty Category list"
     >
+        <xpath expr="//li/a/span" position="after">
+            <t
+                t-set="product_count"
+                t-value="'  ({})'.format(c.count_product_recursive)"
+            />
+            <span t-if="show_product_count" t-esc="product_count" />
+        </xpath>
         <xpath
             expr="//t[@t-name='website_sale.categories_recursive']"
             position="attributes"
@@ -23,6 +30,17 @@
         id="hide_categories_collapse_recursive"
         name="Hide Empty Category Collapsible list"
     >
+        <xpath expr="//li/a" position="attributes">
+            <attribute name="t-field" />
+        </xpath>
+        <xpath expr="//li/a" position="inside">
+            <t
+                t-set="product_count"
+                t-value="'  ({})'.format(c.count_product_recursive)"
+            />
+            <span t-field="c.name" />
+            <span t-if="show_product_count" t-esc="product_count" />
+        </xpath>
         <xpath
             expr="//t[@t-name='website_sale.option_collapse_categories_recursive']"
             position="attributes"
@@ -41,6 +59,17 @@
     >
         <xpath expr="//t[@t-foreach='categories']" position="before">
             <t t-set="hide_empty_category" t-value="True" />
+        </xpath>
+    </template>
+    <template
+        inherit_id="website_sale.products_categories"
+        id="show_product_count_helper"
+        name="Show Product count in Category"
+        customize_show="True"
+        active="True"
+    >
+        <xpath expr="//t[@t-foreach='categories']" position="before">
+            <t t-set="show_product_count" t-value="True" />
         </xpath>
     </template>
 </odoo>


### PR DESCRIPTION
Don't know if you'll like this but I needed such functionality and I am sure it can be improved further. Generally the changes provide:

- Change from bool to int in counting number of products in categories
- Added option to display the number of products in each category based on the above
- Only published products are being counted (doesn't make sense to include non-published products)

Any comments/improvements are welcome.
