### PR TITLE
[13.0][IMP] website_sale_product_attachment: Introduce website name

### DIFF
--- a/website_sale_product_attachment/README.rst
+++ b/website_sale_product_attachment/README.rst
@@ -89,6 +89,12 @@ Once you set up the product attachments, public users will be able to download t
 .. figure:: https://raw.githubusercontent.com/OCA/e-commerce/13.0/website_sale_product_attachment/static/description/frontend-download.gif
    :alt: Attachments view in backend
 
+Known issues / Roadmap
+======================
+
+- Make translatable the name of the attachment in the e-commerce. This will
+  mean to deal with the sorting of the translated terms.
+
 Bug Tracker
 ===========
 

--- a/website_sale_product_attachment/__manifest__.py
+++ b/website_sale_product_attachment/__manifest__.py
@@ -1,10 +1,11 @@
 # Copyright 2020 Tecnativa - Jairo Llopis
 # Copyright 2021 Tecnativa - Víctor Martínez
+# Copyright 2021 Tecnativa - Pedro M. Baeza
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 {
     "name": "eCommerce product attachments",
     "summary": "Let visitors download attachments from a product page",
-    "version": "13.0.1.1.0",
+    "version": "13.0.2.0.0",
     "development_status": "Beta",
     "category": "Website",
     "website": "https://github.com/OCA/e-commerce",

--- a/website_sale_product_attachment/i18n/es.po
+++ b/website_sale_product_attachment/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-28 11:01+0000\n"
-"PO-Revision-Date: 2020-06-22 10:19+0000\n"
+"POT-Creation-Date: 2021-09-28 07:24+0000\n"
+"PO-Revision-Date: 2021-09-28 09:28+0200\n"
 "Last-Translator: Jairo Llopis <jairo.llopis@tecnativa.com>\n"
 "Language-Team: \n"
 "Language: es\n"
@@ -15,7 +15,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 3.10\n"
+"X-Generator: Poedit 2.3\n"
 
 #. module: website_sale_product_attachment
 #: model_terms:ir.ui.view,arch_db:website_sale_product_attachment.product_attachments
@@ -43,6 +43,7 @@ msgstr ""
 
 #. module: website_sale_product_attachment
 #: model:ir.model.fields,field_description:website_sale_product_attachment.field_ir_attachment__attached_in_product_tmpl_ids
+#: model:ir.model.fields,field_description:website_sale_product_attachment.field_mrp_document__attached_in_product_tmpl_ids
 msgid "Attached in products"
 msgstr "Adjunto en los productos"
 
@@ -53,12 +54,18 @@ msgstr "Adjunto"
 
 #. module: website_sale_product_attachment
 #: model:ir.model.fields,help:website_sale_product_attachment.field_ir_attachment__attached_in_product_tmpl_ids
+#: model:ir.model.fields,help:website_sale_product_attachment.field_mrp_document__attached_in_product_tmpl_ids
 msgid ""
 "Attachment publicly downladable from eCommerce pages in these product "
 "templates."
 msgstr ""
 "Archivo descargable públicamente desde las páginas de estas plantillas de "
 "producto en la tienda del sitio web."
+
+#. module: website_sale_product_attachment
+#: model_terms:ir.ui.view,arch_db:website_sale_product_attachment.product_template_form_view
+msgid "File Name"
+msgstr "Nombre del archivo"
 
 #. module: website_sale_product_attachment
 #: model:ir.model.fields,help:website_sale_product_attachment.field_product_product__website_attachment_ids
@@ -69,9 +76,26 @@ msgstr ""
 "del sitio web."
 
 #. module: website_sale_product_attachment
+#: model:ir.model.fields,field_description:website_sale_product_attachment.field_ir_attachment__website_name
+#: model:ir.model.fields,field_description:website_sale_product_attachment.field_mrp_document__website_name
+msgid "Name in e-commerce"
+msgstr "Nombre en comercio electrónico"
+
+#. module: website_sale_product_attachment
 #: model:ir.model,name:website_sale_product_attachment.model_product_template
 msgid "Product Template"
 msgstr "Plantilla de producto"
+
+#. module: website_sale_product_attachment
+#: model:ir.model.fields,help:website_sale_product_attachment.field_ir_attachment__website_name
+#: model:ir.model.fields,help:website_sale_product_attachment.field_mrp_document__website_name
+msgid ""
+"The name of the download that will be displayed on the e-commerce product "
+"page. If not filled, the filename will be shown by default."
+msgstr ""
+"El nombre de la descarga que será mostrado en la página de producto del "
+"comercio electrónico. Si no está rellenado, se mostrará el nombre del "
+"archivo por defecto."
 
 #. module: website_sale_product_attachment
 #: model_terms:ir.ui.view,arch_db:website_sale_product_attachment.product_template_form_view

--- a/website_sale_product_attachment/i18n/website_sale_product_attachment.pot
+++ b/website_sale_product_attachment/i18n/website_sale_product_attachment.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-09-28 07:24+0000\n"
+"PO-Revision-Date: 2021-09-28 07:24+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -31,6 +33,7 @@ msgstr ""
 
 #. module: website_sale_product_attachment
 #: model:ir.model.fields,field_description:website_sale_product_attachment.field_ir_attachment__attached_in_product_tmpl_ids
+#: model:ir.model.fields,field_description:website_sale_product_attachment.field_mrp_document__attached_in_product_tmpl_ids
 msgid "Attached in products"
 msgstr ""
 
@@ -41,9 +44,15 @@ msgstr ""
 
 #. module: website_sale_product_attachment
 #: model:ir.model.fields,help:website_sale_product_attachment.field_ir_attachment__attached_in_product_tmpl_ids
+#: model:ir.model.fields,help:website_sale_product_attachment.field_mrp_document__attached_in_product_tmpl_ids
 msgid ""
 "Attachment publicly downladable from eCommerce pages in these product "
 "templates."
+msgstr ""
+
+#. module: website_sale_product_attachment
+#: model_terms:ir.ui.view,arch_db:website_sale_product_attachment.product_template_form_view
+msgid "File Name"
 msgstr ""
 
 #. module: website_sale_product_attachment
@@ -53,8 +62,22 @@ msgid "Files publicly downloadable from the product eCommerce page."
 msgstr ""
 
 #. module: website_sale_product_attachment
+#: model:ir.model.fields,field_description:website_sale_product_attachment.field_ir_attachment__website_name
+#: model:ir.model.fields,field_description:website_sale_product_attachment.field_mrp_document__website_name
+msgid "Name in e-commerce"
+msgstr ""
+
+#. module: website_sale_product_attachment
 #: model:ir.model,name:website_sale_product_attachment.model_product_template
 msgid "Product Template"
+msgstr ""
+
+#. module: website_sale_product_attachment
+#: model:ir.model.fields,help:website_sale_product_attachment.field_ir_attachment__website_name
+#: model:ir.model.fields,help:website_sale_product_attachment.field_mrp_document__website_name
+msgid ""
+"The name of the download that will be displayed on the e-commerce product "
+"page. If not filled, the filename will be shown by default."
 msgstr ""
 
 #. module: website_sale_product_attachment

--- a/website_sale_product_attachment/migrations/13.0.2.0.0/post-migration.py
+++ b/website_sale_product_attachment/migrations/13.0.2.0.0/post-migration.py
@@ -1,0 +1,16 @@
+# Copyright 2021 Tecnativa - Pedro M. Baeza
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+from psycopg2 import sql
+
+from odoo import tools
+
+
+def migrate(cr, version):
+    """Recover name column from v12 if exists to be used as website name."""
+    column = "openupgrade_legacy_13_0_name"
+    if tools.column_exists(cr, "ir_attachment", column):
+        cr.execute(
+            sql.SQL("UPDATE ir_attachment SET website_name = {}").format(
+                sql.Identifier(column)
+            )
+        )

--- a/website_sale_product_attachment/migrations/13.0.2.0.0/pre-migration.py
+++ b/website_sale_product_attachment/migrations/13.0.2.0.0/pre-migration.py
@@ -1,0 +1,11 @@
+# Copyright 2021 Tecnativa - Pedro M. Baeza
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+from odoo import SUPERUSER_ID, api
+
+
+def migrate(cr, version):
+    """Remove offending view for allowing to update."""
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    view = env.ref("website_sale_product_attachment.download_icons", False)
+    if view:
+        view.unlink()

--- a/website_sale_product_attachment/models/ir_attachment.py
+++ b/website_sale_product_attachment/models/ir_attachment.py
@@ -1,4 +1,5 @@
 # Copyright 2020 Tecnativa - Jairo Llopis
+# Copyright 2021 Tecnativa - Pedro M. Baeza
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
 from odoo import fields, models
@@ -12,4 +13,9 @@ class IrAttachment(models.Model):
         comodel_name="product.template",
         help="Attachment publicly downladable from eCommerce pages "
         "in these product templates.",
+    )
+    website_name = fields.Char(
+        string="Name in e-commerce",
+        help="The name of the download that will be displayed on the e-commerce "
+        "product page. If not filled, the filename will be shown by default.",
     )

--- a/website_sale_product_attachment/readme/ROADMAP.rst
+++ b/website_sale_product_attachment/readme/ROADMAP.rst
@@ -1,0 +1,2 @@
+- Make translatable the name of the attachment in the e-commerce. This will
+  mean to deal with the sorting of the translated terms.

--- a/website_sale_product_attachment/static/description/index.html
+++ b/website_sale_product_attachment/static/description/index.html
@@ -376,11 +376,12 @@ or whatever document related to the product.</p>
 <ul class="simple">
 <li><a class="reference internal" href="#configuration" id="id1">Configuration</a></li>
 <li><a class="reference internal" href="#usage" id="id2">Usage</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="id3">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="id4">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="id5">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="id6">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="id7">Maintainers</a></li>
+<li><a class="reference internal" href="#known-issues-roadmap" id="id3">Known issues / Roadmap</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="id4">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="id5">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="id6">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="id7">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="id8">Maintainers</a></li>
 </ul>
 </li>
 </ul>
@@ -439,8 +440,15 @@ They must be public.</li>
 <img alt="Attachments view in backend" src="https://raw.githubusercontent.com/OCA/e-commerce/13.0/website_sale_product_attachment/static/description/frontend-download.gif" />
 </div>
 </div>
+<div class="section" id="known-issues-roadmap">
+<h1><a class="toc-backref" href="#id3">Known issues / Roadmap</a></h1>
+<ul class="simple">
+<li>Make translatable the name of the attachment in the e-commerce. This will
+mean to deal with the sorting of the translated terms.</li>
+</ul>
+</div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#id3">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#id4">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/e-commerce/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us smashing it by providing a detailed and welcomed
@@ -448,15 +456,15 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#id4">Credits</a></h1>
+<h1><a class="toc-backref" href="#id5">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#id5">Authors</a></h2>
+<h2><a class="toc-backref" href="#id6">Authors</a></h2>
 <ul class="simple">
 <li>Tecnativa</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#id6">Contributors</a></h2>
+<h2><a class="toc-backref" href="#id7">Contributors</a></h2>
 <ul class="simple">
 <li><a class="reference external" href="https://www.tecnativa.com">Tecnativa</a>:<ul>
 <li>Jairo Llopis</li>
@@ -466,7 +474,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#id7">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#id8">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose

--- a/website_sale_product_attachment/templates/product_template.xml
+++ b/website_sale_product_attachment/templates/product_template.xml
@@ -40,7 +40,7 @@
                     >
                         <ul class="list-group list-group-flush">
                             <t
-                                t-foreach="product.website_attachment_ids.sudo()"
+                                t-foreach="product.website_attachment_ids.sudo().sorted(lambda x: x.website_name or x.name)"
                                 t-as="attachment"
                             >
                                 <li class="list-group-item">
@@ -49,7 +49,9 @@
                                         target="_new"
                                         t-att-href="attachment.local_url"
                                     >
-                                        <span t-field="attachment.name" />
+                                        <span
+                                            t-esc="attachment.website_name or attachment.name"
+                                        />
                                     </a>
                                 </li>
                             </t>
@@ -65,7 +67,10 @@
         name="Download icons"
         customize_show="True"
     >
-        <xpath expr="//*[@t-field='attachment.name']" position="before">
+        <xpath
+            expr="//*[@t-esc='attachment.website_name or attachment.name']"
+            position="before"
+        >
             <span
                 class="o_image mr8 flex-shrink-0"
                 t-att-data-mimetype="attachment.mimetype"

--- a/website_sale_product_attachment/views/ir_attachment.xml
+++ b/website_sale_product_attachment/views/ir_attachment.xml
@@ -1,11 +1,14 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!-- Copyright 2020 Tecnativa - Jairo Llopis
+     Copyright 2021 Tecnativa - Pedro M. Baeza
      License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl). -->
 <data>
-    <record id="view_attachment_form" model="ir.ui.view">
-        <field name="name">Attached to product templates</field>
+    <record id="view_attachment_form_inherit_website" model="ir.ui.view">
+        <field
+            name="name"
+        >ir.attachment.form.inherit.website - Attached to product templates</field>
         <field name="model">ir.attachment</field>
-        <field name="inherit_id" ref="base.view_attachment_form" />
+        <field name="inherit_id" ref="website.view_attachment_form_inherit_website" />
         <field name="arch" type="xml">
             <field name="public" position="after">
                 <field
@@ -15,6 +18,9 @@
                     invisible="context.get('hide_attachment_products', False)"
                     attrs="{'invisible': [('public', '=', False)]}"
                 />
+            </field>
+            <field name="website_id" position="after">
+                <field name="website_name" />
             </field>
         </field>
     </record>

--- a/website_sale_product_attachment/views/product_template.xml
+++ b/website_sale_product_attachment/views/product_template.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!-- Copyright 2020 Tecnativa - Jairo Llopis
+     Copyright 2021 Tecnativa - Pedro M. Baeza
      License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl). -->
 <data>
     <record id="product_template_form_view" model="ir.ui.view">
@@ -16,8 +17,9 @@
                         or unpublish it from your database.
                     </div>
                     <field name="website_attachment_ids" nolabel="1">
-                        <tree>
-                            <field name="name" />
+                        <tree default_order="website_name,name,id">
+                            <field name="website_name" />
+                            <field name="name" string="File Name" />
                             <field
                                 name="website_id"
                                 groups="website.group_multi_website"


### PR DESCRIPTION
On previous version, attachments had 2 fields for adding both attachment name and file name.

Now on v13, there's only one, that is filled with the file name. On initial migration, it was considered that this field is enough, but putting file names on the website product page can be ugly, limited and confusing, so we are adding here a new field to store the name we want to give it for the website e-commerce product page.

It also includes migration script for recovering the old information if coming from v12.

@Tecnativa TT32160