### PR TITLE
[FIX] website_sale_stock_provisioning_date: timezone

### DIFF
--- a/website_sale_stock_provisioning_date/__init__.py
+++ b/website_sale_stock_provisioning_date/__init__.py
@@ -1,2 +1,3 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from . import models
+from .hooks import pre_init_hook

--- a/website_sale_stock_provisioning_date/__manifest__.py
+++ b/website_sale_stock_provisioning_date/__manifest__.py
@@ -13,4 +13,5 @@
     "installable": True,
     "depends": ["website_sale_stock"],
     "data": ["views/assets.xml", "views/product_template_views.xml"],
+    "pre_init_hook": "pre_init_hook",
 }

--- a/website_sale_stock_provisioning_date/hooks.py
+++ b/website_sale_stock_provisioning_date/hooks.py
@@ -1,0 +1,22 @@
+# Copyright 2021 Tecnativa - David Vidal
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+
+def pre_init_hook(cr):
+    """Precompute all the dates at once"""
+    cr.execute("ALTER TABLE stock_move ADD COLUMN IF NOT EXISTS date_provisioning DATE")
+    cr.execute(
+        """
+        UPDATE stock_move sm0
+        SET date_provisioning = (
+            sm.date_expected AT TIME ZONE COALESCE(rp.tz, 'UTC')
+        )::date
+        FROM stock_move sm
+        LEFT JOIN res_users ru ON sm.write_uid = ru.id
+        LEFT JOIN res_partner rp ON ru.partner_id = rp.id
+        WHERE
+            sm0.id = sm.id
+            AND sm.date_expected IS NOT NULL
+            AND sm.state NOT IN ('cancel', 'done')
+    """
+    )

--- a/website_sale_stock_provisioning_date/models/__init__.py
+++ b/website_sale_stock_provisioning_date/models/__init__.py
@@ -1,3 +1,4 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from . import product_product
 from . import product_template
+from . import stock_move

--- a/website_sale_stock_provisioning_date/models/product_product.py
+++ b/website_sale_stock_provisioning_date/models/product_product.py
@@ -13,9 +13,11 @@ class ProductProduct(models.Model):
             ("state", "not in", ["draft", "done", "cancel"]),
             ("location_id.usage", "=", "supplier"),
             ("location_dest_id.usage", "=", "internal"),
-            ("date_expected", ">=", fields.Datetime.now()),
+            ("date_provisioning", ">=", fields.Datetime.today()),
         ]
         move = (
-            self.env["stock.move"].sudo().search(domain, order="date_expected", limit=1)
+            self.env["stock.move"]
+            .sudo()
+            .search(domain, order="date_provisioning", limit=1)
         )
-        return move and move.date_expected.date() or False
+        return move and move.date_provisioning or False

--- a/website_sale_stock_provisioning_date/models/stock_move.py
+++ b/website_sale_stock_provisioning_date/models/stock_move.py
@@ -1,0 +1,23 @@
+# Copyright 2021 Tecnativa - David Vidal
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from pytz import timezone
+
+from odoo import api, fields, models
+
+
+class StockMove(models.Model):
+    _inherit = "stock.move"
+
+    date_provisioning = fields.Date(
+        string="Date expected", compute="_compute_date_provisioning", store=True,
+    )
+
+    @api.depends("date_expected")
+    def _compute_date_provisioning(self):
+        """We want to store the date in the context of the user that sets it avoiding
+        offsets due to timezones. This way, when it's shown in the website, we can
+        ensure that it's our date and not the user's"""
+        self.date_provisioning = False
+        tz = timezone(self.env.user.tz or "UTC")
+        for move in self.filtered("date_expected"):
+            move.date_provisioning = move.date_expected.astimezone(tz).date()


### PR DESCRIPTION
We want to show the provisioning date in the context of the company
timezone. Otherwise we could get missleading dates.

cc @Tecnativa TT33244

ping @ernestotejeda @pedrobaeza 
