### PR TITLE
[13.0][IMP] website_snippet_product_category: Change website published field by published in snippet field

### DIFF
--- a/website_snippet_product_category/README.rst
+++ b/website_snippet_product_category/README.rst
@@ -39,7 +39,7 @@ You can select what categories can be shown by the snippet and an image for the 
 
 #. Go to website (backend) > Configuration > Products > eCommerce Categories
 #. Create or Edit one
-#. You can see two new options "Website Published" and "Category Image"
+#. You can see two new options "Published in product category snippet" and "Category Image"
 
 Usage
 =====
@@ -105,6 +105,7 @@ Contributors
   * Alexandre D. Díaz
   * Pedro M. Baeza
   * Carlos Roca
+  * Sergio Teruel
 
 Other credits
 ~~~~~~~~~~~~~

--- a/website_snippet_product_category/__manifest__.py
+++ b/website_snippet_product_category/__manifest__.py
@@ -4,7 +4,7 @@
     "name": "Website Snippet Product Category",
     "category": "Website",
     "summary": "Adds a new snippet to show e-commerce categories",
-    "version": "13.0.1.0.0",
+    "version": "13.0.2.0.0",
     "license": "LGPL-3",
     "website": "https://github.com/OCA/e-commerce",
     "author": "Tecnativa, Odoo Community Association (OCA)",

--- a/website_snippet_product_category/controllers/website.py
+++ b/website_snippet_product_category/controllers/website.py
@@ -15,7 +15,10 @@ class Website(http.Controller):
     )
     def render_product_category(self, template, **kwargs):
         categories = request.env["product.public.category"].search(
-            [("parent_id", "=", False), ("is_published", "=", True)]
+            [
+                ("parent_id", "=", False),
+                ("published_in_product_category_snippet", "=", True),
+            ]
         )
         keep = QueryURL("/shop", category=0)
         return request.website.viewref(template).render(

--- a/website_snippet_product_category/demo/demo.xml
+++ b/website_snippet_product_category/demo/demo.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo noupdate="1">
     <record id="website_sale.Components" model="product.public.category">
-        <field name="is_published" eval="True" />
+        <field name="published_in_product_category_snippet" eval="True" />
     </record>
     <record id="website_sale.public_category_boxes" model="product.public.category">
-        <field name="is_published" eval="True" />
+        <field name="published_in_product_category_snippet" eval="True" />
         <field
             name="image_128"
             type="base64"
@@ -12,51 +12,51 @@
         />
     </record>
     <record id="website_sale.public_category_desks" model="product.public.category">
-        <field name="is_published" eval="True" />
+        <field name="published_in_product_category_snippet" eval="True" />
     </record>
     <record id="website_sale.public_category_cabinets" model="product.public.category">
-        <field name="is_published" eval="True" />
+        <field name="published_in_product_category_snippet" eval="True" />
     </record>
     <record id="website_sale.public_category_bins" model="product.public.category">
-        <field name="is_published" eval="True" />
+        <field name="published_in_product_category_snippet" eval="True" />
     </record>
     <record id="website_sale.public_category_chairs" model="product.public.category">
-        <field name="is_published" eval="True" />
+        <field name="published_in_product_category_snippet" eval="True" />
     </record>
     <record id="website_sale.public_category_drawers" model="product.public.category">
-        <field name="is_published" eval="True" />
+        <field name="published_in_product_category_snippet" eval="True" />
     </record>
     <record id="website_sale.public_category_lamps" model="product.public.category">
-        <field name="is_published" eval="True" />
+        <field name="published_in_product_category_snippet" eval="True" />
     </record>
     <record
         id="website_sale.public_category_multimedia"
         model="product.public.category"
     >
-        <field name="is_published" eval="True" />
+        <field name="published_in_product_category_snippet" eval="True" />
     </record>
     <record id="website_sale.services" model="product.public.category">
-        <field name="is_published" eval="True" />
+        <field name="published_in_product_category_snippet" eval="True" />
     </record>
     <record id="public_category_boxes_metal" model="product.public.category">
         <field name="name">Metal Box</field>
         <field name="parent_id" ref="website_sale.public_category_boxes" />
-        <field name="is_published" eval="True" />
+        <field name="published_in_product_category_snippet" eval="True" />
     </record>
     <record id="public_category_boxes_wooden" model="product.public.category">
         <field name="name">Wooden Box</field>
         <field name="parent_id" ref="website_sale.public_category_boxes" />
-        <field name="is_published" eval="True" />
+        <field name="published_in_product_category_snippet" eval="True" />
     </record>
     <record id="public_category_boxes_metal_spec_a" model="product.public.category">
         <field name="name">Spec A</field>
         <field name="parent_id" ref="public_category_boxes_metal" />
-        <field name="is_published" eval="True" />
+        <field name="published_in_product_category_snippet" eval="True" />
     </record>
     <record id="public_category_boxes_metal_spec_b" model="product.public.category">
         <field name="name">Spec B</field>
         <field name="parent_id" ref="public_category_boxes_metal" />
-        <field name="is_published" eval="True" />
+        <field name="published_in_product_category_snippet" eval="True" />
     </record>
     <record
         id="public_category_boxes_metal_subspec_b_a"
@@ -64,6 +64,6 @@
     >
         <field name="name">SubSpec B - A</field>
         <field name="parent_id" ref="public_category_boxes_metal_spec_b" />
-        <field name="is_published" eval="True" />
+        <field name="published_in_product_category_snippet" eval="True" />
     </record>
 </odoo>

--- a/website_snippet_product_category/demo/pages.xml
+++ b/website_snippet_product_category/demo/pages.xml
@@ -13,7 +13,7 @@
         </t>
     </template>
     <record id="snippet_product_category_demo_page" model="website.page">
-        <field name="is_published">True</field>
+        <field name="published_in_product_category_snippet">True</field>
         <field name="url">/website_snippet_product_category.demo_page</field>
         <field name="view_id" ref="snippet_product_category_demo_view" />
     </record>

--- a/website_snippet_product_category/migrations/13.0.2.0.0/pre-migration.py
+++ b/website_snippet_product_category/migrations/13.0.2.0.0/pre-migration.py
@@ -1,0 +1,19 @@
+# Copyright 2021 Tecnativa - Sergio Teruel
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.rename_fields(
+        env,
+        [
+            (
+                "product.public.category",
+                "product_public_category",
+                "is_published",
+                "published_in_product_category_snippet",
+            )
+        ],
+    )

--- a/website_snippet_product_category/models/product_public_category.py
+++ b/website_snippet_product_category/models/product_public_category.py
@@ -1,8 +1,11 @@
 # Copyright 2020 Tecnativa - Alexandre Díaz
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-from odoo import models
+from odoo import fields, models
 
 
 class ProductPublicCategory(models.Model):
-    _inherit = ["product.public.category", "website.published.mixin"]
-    _name = "product.public.category"
+    _inherit = "product.public.category"
+
+    published_in_product_category_snippet = fields.Boolean(
+        "Published in product category snippet", copy=False
+    )

--- a/website_snippet_product_category/readme/CONFIGURE.rst
+++ b/website_snippet_product_category/readme/CONFIGURE.rst
@@ -2,4 +2,4 @@ You can select what categories can be shown by the snippet and an image for the 
 
 #. Go to website (backend) > Configuration > Products > eCommerce Categories
 #. Create or Edit one
-#. You can see two new options "Website Published" and "Category Image"
+#. You can see two new options "Published in product category snippet" and "Category Image"

--- a/website_snippet_product_category/readme/CONTRIBUTORS.rst
+++ b/website_snippet_product_category/readme/CONTRIBUTORS.rst
@@ -3,3 +3,4 @@
   * Alexandre D. Díaz
   * Pedro M. Baeza
   * Carlos Roca
+  * Sergio Teruel

--- a/website_snippet_product_category/static/description/index.html
+++ b/website_snippet_product_category/static/description/index.html
@@ -394,7 +394,7 @@ ul.auto-toc {
 <ol class="arabic simple">
 <li>Go to website (backend) &gt; Configuration &gt; Products &gt; eCommerce Categories</li>
 <li>Create or Edit one</li>
-<li>You can see two new options “Website Published” and “Category Image”</li>
+<li>You can see two new options “Published in product category snippet” and “Category Image”</li>
 </ol>
 </div>
 <div class="section" id="usage">
@@ -456,6 +456,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <li>Alexandre D. Díaz</li>
 <li>Pedro M. Baeza</li>
 <li>Carlos Roca</li>
+<li>Sergio Teruel</li>
 </ul>
 </li>
 </ul>

--- a/website_snippet_product_category/templates/snippets.xml
+++ b/website_snippet_product_category/templates/snippets.xml
@@ -26,7 +26,7 @@
             <div
                 t-attf-class="categ_tree_level {{'pb-2 main_tree_level text-primary text-uppercase' if cur_level == 1 else ''}} {{cur_level &gt; 2 and 'pl-'+str(min((cur_level-2)*2, 5))}}"
                 t-att-data-tree-level="cur_level"
-                t-if="category.is_published"
+                t-if="category.published_in_product_category_snippet"
             >
                 <div class="d-flex d-flex-row">
                     <div

--- a/website_snippet_product_category/views/product_public_category.xml
+++ b/website_snippet_product_category/views/product_public_category.xml
@@ -9,20 +9,27 @@
                 ref="website_sale.product_public_category_form_view"
             />
             <field name="arch" type="xml">
-                <field name="image_1920" position="before">
-                    <div class="oe_button_box" name="button_box">
-                        <button
-                            class="oe_stat_button"
-                            name="website_publish_button"
-                            type="object"
-                            icon="fa-globe"
-                        >
-                            <field
-                                name="is_published"
-                                widget="website_publish_button"
-                            />
-                        </button>
-                    </div>
+                <field name="sequence" position="after">
+                    <field
+                        name="published_in_product_category_snippet"
+                        widget="boolean_toggle"
+                    />
+                </field>
+            </field>
+        </record>
+        <record id="product_public_category_tree_view" model="ir.ui.view">
+            <field name="name">product.public.category.tree</field>
+            <field name="model">product.public.category</field>
+            <field
+                name="inherit_id"
+                ref="website_sale.product_public_category_tree_view"
+            />
+            <field name="arch" type="xml">
+                <field name="website_id" position="after">
+                    <field
+                        name="published_in_product_category_snippet"
+                        widget="boolean_toggle"
+                    />
                 </field>
             </field>
         </record>


### PR DESCRIPTION
Odoo core does not allow publish or no a public category.
This module is using the field webiste_published to display categories into snippet.
This field creates confusion, the user think that if do this the category does not appear in left tree category.

cc @Tecnativa TT33532

ping @Tardo @CarlosRoca13 