### PR TITLE
[13.0][FIX] website_snippet_carousel_product: Use flexible height

### DIFF
--- a/website_snippet_carousel_product/static/src/scss/s_product_carousel.scss
+++ b/website_snippet_carousel_product/static/src/scss/s_product_carousel.scss
@@ -3,14 +3,19 @@
 .s_product_carousel {
     .oe_product {
         border-width: 0;
+        height: 100%;
 
         .oe_product_cart {
-            height: 300px;
-        }
+            height: 100%;
 
-        .oe_product_image,
-        .oe_product_image img {
-            position: unset;
+            .oe_product_image {
+                height: unset;
+            }
+
+            .oe_product_image,
+            .oe_product_image img {
+                position: unset;
+            }
         }
     }
 }


### PR DESCRIPTION
This prevents flattened images from being displayed.

** There is no difference between the new and the old because there are no elements that make the card expand
**New:**
![cp_new](https://user-images.githubusercontent.com/731270/147369644-d5d233fc-6a90-40a8-a26d-291e2efae09b.png)

**Old:**
![cp_old_t](https://user-images.githubusercontent.com/731270/147369647-a0ec10f0-ff0f-4f25-b052-026baed408d1.png)


cc @tecnativa

