### PR TITLE
[13.0][IMP] website_snippet_product_category: Reduced the icon size of the main sections

### DIFF
--- a/website_snippet_product_category/static/src/scss/snippet.scss
+++ b/website_snippet_product_category/static/src/scss/snippet.scss
@@ -1,36 +1,45 @@
-.categ_container {
-    .categ_scroll_wrapper {
-        border: 0 solid $border-color;
-        border-width: 0 1px 0 0;
-    }
-    .categ_scroll {
-        overflow: hidden;
-        overflow-y: auto;
+.js_product_category {
+    .categ_main_level_section {
+        .categ_img img {
+            max-height: 64px;
+            max-width: 64px;
+        }
     }
 
-    .categ_img img {
-        width: 1.4em;
-    }
-    .categ_tree_level {
-        &[data-tree-level="2"] {
-            font-size: 0.9em;
-            .categ_link {
-                text-transform: capitalize;
-                color: $gray-800;
-            }
+    .categ_container {
+        .categ_scroll_wrapper {
+            border: 0 solid $border-color;
+            border-width: 0 1px 0 0;
         }
-        &[data-tree-level="3"] {
-            font-size: 0.8em;
-            .categ_link {
-                text-transform: capitalize;
-                color: $gray-700;
-            }
+        .categ_scroll {
+            overflow: hidden;
+            overflow-y: auto;
         }
-        &[data-tree-level="4"] {
-            font-size: 0.7em;
-            .categ_link {
-                text-transform: lowercase;
-                color: $gray-600;
+
+        .categ_img img {
+            width: 1.4em;
+        }
+        .categ_tree_level {
+            &[data-tree-level="2"] {
+                font-size: 0.9em;
+                .categ_link {
+                    text-transform: capitalize;
+                    color: $gray-800;
+                }
+            }
+            &[data-tree-level="3"] {
+                font-size: 0.8em;
+                .categ_link {
+                    text-transform: capitalize;
+                    color: $gray-700;
+                }
+            }
+            &[data-tree-level="4"] {
+                font-size: 0.7em;
+                .categ_link {
+                    text-transform: lowercase;
+                    color: $gray-600;
+                }
             }
         }
     }


### PR DESCRIPTION
The smallest image Odoo offers is 128x128. This size can be large if you use square images. This commit limits the maximum size to 64x64.
The css has also been encapsulated inside the snippet class.

cc @tecnativa