### PR TITLE
[12.0][FIX] website_sale_hide_price: Override the right template

### DIFF
--- a/website_sale_hide_price/views/website_sale_template.xml
+++ b/website_sale_hide_price/views/website_sale_template.xml
@@ -14,13 +14,16 @@
                 </attribute>
             </xpath>
         </template>
-        <!-- Hide Add To Cart Button and quantity selector if not website_show_price -->
+        <!-- Hide Add To Cart Button if not website_show_price -->
         <template id="product" inherit_id="website_sale.product">
             <xpath expr="//a[@id='add_to_cart']" position="attributes">
                 <attribute name="t-if">
                     website.website_show_price
                 </attribute>
             </xpath>
+        </template>
+        <!-- Hide quantity selector if not website_show_price -->
+        <template id="product_quantity" inherit_id="website_sale.product_quantity">
             <xpath expr="//div[hasclass('css_quantity')]" position="attributes">
                 <attribute name="t-if">
                     website.website_show_price


### PR DESCRIPTION
Template `website_sale.product` don't have a div with `css_quantity` since this one is defined in the template `website_sale.product_quantity` (that inherit `website_sale.product` itself). This commit creates a new template override on the right one.