### PR TITLE
[FIX] website_sale_hide_price : bad inherit_id for the product view

### DIFF
--- a/website_sale_hide_price/views/website_sale_template.xml
+++ b/website_sale_hide_price/views/website_sale_template.xml
@@ -21,6 +21,8 @@
                     website.website_show_price
                 </attribute>
             </xpath>
+        </template>
+        <template id="product" inherit_id="website_sale.product_quantity">
             <xpath expr="//div[hasclass('css_quantity')]" position="attributes">
                 <attribute name="t-if">
                     website.website_show_price


### PR DESCRIPTION
Trivial patch.

Rational : 

- the current ``xpath expr="//div[hasclass('css_quantity')]"`` intherit from ``website_sale.product`` view but ``css_quantity`` is defined in ``website_sale.product_quantity``

ref : https://github.com/odoo/odoo/blob/12.0/addons/website_sale/views/templates.xml#L602

regards.

CC : @fcayre 