### PR TITLE
[FIX] website_sale_product_minimal_price: Integration with website_sale_b2x_alt_price

### DIFF
--- a/website_sale_product_minimal_price/controllers/main.py
+++ b/website_sale_product_minimal_price/controllers/main.py
@@ -29,17 +29,21 @@ class WebsiteSaleVariantController(VariantController):
             combination = template._get_combination_info(
                 product_id=product_id, add_qty=add_qty, pricelist=pricelist
             )
-            res.append(
-                {
-                    "id": template.id,
-                    "price": combination.get("price"),
-                    "distinct_prices": has_distinct_price,
-                    "currency": {
-                        "position": template.currency_id.position,
-                        "symbol": template.currency_id.symbol,
-                    },
-                }
-            )
+            vals = {
+                "id": template.id,
+                "price": combination.get("price"),
+                "distinct_prices": has_distinct_price,
+                "currency": {
+                    "position": template.currency_id.position,
+                    "symbol": template.currency_id.symbol,
+                },
+            }
+            # As now the minimum price is set asynchronously, we need to set the second
+            # price value given by the website_sale_b2x_alt_price module and avoid the
+            # same value in both prices.
+            if combination.get("alt_price"):
+                vals["alt_price"] = combination["alt_price"]
+            res.append(vals)
         return res
 
     @http.route(

--- a/website_sale_product_minimal_price/static/src/js/website_sale_product_minimal_price.js
+++ b/website_sale_product_minimal_price/static/src/js/website_sale_product_minimal_price.js
@@ -73,6 +73,18 @@ odoo.define("website_sale_product_minimal_price.shop_min_price", function(requir
                                 ).get(0)
                             );
                     }
+                    /* As now the minimum price is set asynchronously, we need to set the
+                    second price value given by the website_sale_b2x_alt_price module
+                    and avoid the same value in both prices. */
+                    if (product.alt_price) {
+                        let price = this.widgetMonetary(product.alt_price, {});
+                        price = price.replace("&nbsp;", " ");
+                        $(product_dic[product.id])
+                            .find(".js_alt_price span")
+                            .replaceWith(
+                                "<span class='oe_currency_value'>" + price + "</span>"
+                            );
+                    }
                 }
                 return products_min_price;
             });


### PR DESCRIPTION
As now the minimum price is set asynchronously, we need to set manually the alt_price value given by the website_sale_b2x_alt_price module and avoid the same value in both prices.

Before change:
![imagen](https://user-images.githubusercontent.com/35952655/155174349-b5e00fb8-c466-4682-bac6-0367618f06e3.png)

After change:
![imagen](https://user-images.githubusercontent.com/35952655/155174399-e658cbf4-46f0-4591-a02a-810befcf3e84.png)

cc @Tecnativa TT34707

ping @sergio-teruel @chienandalu 