### PR TITLE
[13.0][FIX/FW] website_sale_product_brand: image proportions and website.published mixin

### DIFF
--- a/website_sale_product_brand/README.rst
+++ b/website_sale_product_brand/README.rst
@@ -29,9 +29,9 @@ This module was written to extend the functionality of product filtering on webs
 It will allow you to filter product based on its brand.
 
 While shopping online, we have seen various eShops having a feature to shop by brands
-which ODOO does not yet provide officially. Website Sale Product Brand fills the gap at certain
-extent and by providing basic search by brands, thus reducing end-user’s efforts in
-searching the products he/she wants to purchase.
+which ODOO does not yet provide officially. Website Sale Product Brand fills the gap
+at certain extent and by providing basic search by brands, thus reducing end-user’s
+efforts in searching the products he/she wants to purchase.
 
 **Table of contents**
 
@@ -41,26 +41,35 @@ searching the products he/she wants to purchase.
 Installation
 ============
 
-To install this module, you need to install following module:
-->https://github.com/OCA/product-attribute/tree/12.0/product_brand
+To install this module, you need to install the module `product_brand` form
+OCA/product-attribute.
+
+Configuration
+=============
+
+In order to hide brands from the e-commerce:
+
+#. Go to *Website > Settings > Products > Product brands*
+#. Click on the brand you want to unpublish.
+#. Click on the *Website published* smart button.
 
 Usage
 =====
 
-Shop by brand feature is available on various famous e-commerce websites like amazon, flipkart and many.
-Shop by brand feature enables you to display product relevant to that particular brand.
+Shop by brand feature is available on various famous e-commerce websites like amazon,
+flipkart and many. Shop by brand feature enables you to display product relevant to
+that particular brand.
 
 To use this module, you need to:
 
-Once you install this module, user will be able to create a new brand and define the brand to a product.
+Once you install this module, user will be able to create a new brand and define the
+brand to a product.
 
-- To create product brand
-    go to:
-        sales>products>product brands
+To create product brand go to *Website > Settings > Products > Product brands*:
 
-User can assign a nice logo with brand description.
-
-- After configuring the brand, user can assign a particular brand to a particular products.
+  - User can assign a nice logo with brand description.
+  - After configuring the brand, user can assign a particular brand to a particular
+    products.
 
 Based on this configuration, you will see the menuitem shop by brand next to shop menu.
 It will show all the brands and once you select that brand it will show product's which
@@ -95,6 +104,7 @@ Contributors
     * Ernesto Tejeda <ernesto.tejeda@tecnativa.com>
     * Sergio Teruel <sergio.teruel@tecnativa.com>
     * Alexandre Díaz
+    * David Vidal
 
 Maintainers
 ~~~~~~~~~~~

--- a/website_sale_product_brand/__init__.py
+++ b/website_sale_product_brand/__init__.py
@@ -1,4 +1,3 @@
-# © 2016 Serpent Consulting Services Pvt. Ltd. (http://www.serpentcs.com)
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from . import controllers
+from . import models

--- a/website_sale_product_brand/__manifest__.py
+++ b/website_sale_product_brand/__manifest__.py
@@ -16,6 +16,7 @@
         "data/website_menu.xml",
         "views/product_brand.xml",
         "views/assets.xml",
+        "views/product_brand_views.xml",
     ],
     "demo": [
         "demo/assets.xml",

--- a/website_sale_product_brand/__manifest__.py
+++ b/website_sale_product_brand/__manifest__.py
@@ -15,6 +15,7 @@
         "security/ir.model.access.csv",
         "data/website_menu.xml",
         "views/product_brand.xml",
+        "views/assets.xml",
     ],
     "demo": [
         "demo/assets.xml",

--- a/website_sale_product_brand/models/__init__.py
+++ b/website_sale_product_brand/models/__init__.py
@@ -1,0 +1,1 @@
+from . import product_brand

--- a/website_sale_product_brand/models/product_brand.py
+++ b/website_sale_product_brand/models/product_brand.py
@@ -1,0 +1,10 @@
+# Copyright 2020 Tecnativa - David Vidal
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html)
+from odoo import fields, models
+
+
+class ProductBrand(models.Model):
+    _name = "product.brand"
+    _inherit = ["product.brand", "website.published.mixin"]
+
+    is_published = fields.Boolean(default=True)

--- a/website_sale_product_brand/readme/CONFIGURE.rst
+++ b/website_sale_product_brand/readme/CONFIGURE.rst
@@ -1,0 +1,5 @@
+In order to hide brands from the e-commerce:
+
+#. Go to *Website > Settings > Products > Product brands*
+#. Click on the brand you want to unpublish.
+#. Click on the *Website published* smart button.

--- a/website_sale_product_brand/readme/CONTRIBUTORS.rst
+++ b/website_sale_product_brand/readme/CONTRIBUTORS.rst
@@ -5,3 +5,4 @@
     * Ernesto Tejeda <ernesto.tejeda@tecnativa.com>
     * Sergio Teruel <sergio.teruel@tecnativa.com>
     * Alexandre Díaz
+    * David Vidal

--- a/website_sale_product_brand/readme/DESCRIPTION.rst
+++ b/website_sale_product_brand/readme/DESCRIPTION.rst
@@ -2,6 +2,6 @@ This module was written to extend the functionality of product filtering on webs
 It will allow you to filter product based on its brand.
 
 While shopping online, we have seen various eShops having a feature to shop by brands
-which ODOO does not yet provide officially. Website Sale Product Brand fills the gap at certain
-extent and by providing basic search by brands, thus reducing end-user’s efforts in
-searching the products he/she wants to purchase.
+which ODOO does not yet provide officially. Website Sale Product Brand fills the gap
+at certain extent and by providing basic search by brands, thus reducing end-user’s
+efforts in searching the products he/she wants to purchase.

--- a/website_sale_product_brand/readme/INSTALL.rst
+++ b/website_sale_product_brand/readme/INSTALL.rst
@@ -1,2 +1,2 @@
-To install this module, you need to install following module:
-->https://github.com/OCA/product-attribute/tree/12.0/product_brand
+To install this module, you need to install the module `product_brand` form
+OCA/product-attribute.

--- a/website_sale_product_brand/readme/USAGE.rst
+++ b/website_sale_product_brand/readme/USAGE.rst
@@ -1,17 +1,17 @@
-Shop by brand feature is available on various famous e-commerce websites like amazon, flipkart and many.
-Shop by brand feature enables you to display product relevant to that particular brand.
+Shop by brand feature is available on various famous e-commerce websites like amazon,
+flipkart and many. Shop by brand feature enables you to display product relevant to
+that particular brand.
 
 To use this module, you need to:
 
-Once you install this module, user will be able to create a new brand and define the brand to a product.
+Once you install this module, user will be able to create a new brand and define the
+brand to a product.
 
-- To create product brand
-    go to:
-        sales>products>product brands
+To create product brand go to *Website > Settings > Products > Product brands*:
 
-User can assign a nice logo with brand description.
-
-- After configuring the brand, user can assign a particular brand to a particular products.
+  - User can assign a nice logo with brand description.
+  - After configuring the brand, user can assign a particular brand to a particular
+    products.
 
 Based on this configuration, you will see the menuitem shop by brand next to shop menu.
 It will show all the brands and once you select that brand it will show product's which

--- a/website_sale_product_brand/static/description/index.html
+++ b/website_sale_product_brand/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Product Brand Filtering in Website</title>
 <style type="text/css">
 
@@ -371,55 +371,60 @@ ul.auto-toc {
 <p>This module was written to extend the functionality of product filtering on website.
 It will allow you to filter product based on its brand.</p>
 <p>While shopping online, we have seen various eShops having a feature to shop by brands
-which ODOO does not yet provide officially. Website Sale Product Brand fills the gap at certain
-extent and by providing basic search by brands, thus reducing end-user’s efforts in
-searching the products he/she wants to purchase.</p>
+which ODOO does not yet provide officially. Website Sale Product Brand fills the gap
+at certain extent and by providing basic search by brands, thus reducing end-user’s
+efforts in searching the products he/she wants to purchase.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
 <li><a class="reference internal" href="#installation" id="id1">Installation</a></li>
-<li><a class="reference internal" href="#usage" id="id2">Usage</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="id3">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="id4">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="id5">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="id6">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="id7">Maintainers</a></li>
+<li><a class="reference internal" href="#configuration" id="id2">Configuration</a></li>
+<li><a class="reference internal" href="#usage" id="id3">Usage</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="id4">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="id5">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="id6">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="id7">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="id8">Maintainers</a></li>
 </ul>
 </li>
 </ul>
 </div>
 <div class="section" id="installation">
 <h1><a class="toc-backref" href="#id1">Installation</a></h1>
-<p>To install this module, you need to install following module:
--&gt;https://github.com/OCA/product-attribute/tree/12.0/product_brand</p>
+<p>To install this module, you need to install the module <cite>product_brand</cite> form
+OCA/product-attribute.</p>
+</div>
+<div class="section" id="configuration">
+<h1><a class="toc-backref" href="#id2">Configuration</a></h1>
+<p>In order to hide brands from the e-commerce:</p>
+<ol class="arabic simple">
+<li>Go to <em>Website &gt; Settings &gt; Products &gt; Product brands</em></li>
+<li>Click on the brand you want to unpublish.</li>
+<li>Click on the <em>Website published</em> smart button.</li>
+</ol>
 </div>
 <div class="section" id="usage">
-<h1><a class="toc-backref" href="#id2">Usage</a></h1>
-<p>Shop by brand feature is available on various famous e-commerce websites like amazon, flipkart and many.
-Shop by brand feature enables you to display product relevant to that particular brand.</p>
+<h1><a class="toc-backref" href="#id3">Usage</a></h1>
+<p>Shop by brand feature is available on various famous e-commerce websites like amazon,
+flipkart and many. Shop by brand feature enables you to display product relevant to
+that particular brand.</p>
 <p>To use this module, you need to:</p>
-<p>Once you install this module, user will be able to create a new brand and define the brand to a product.</p>
+<p>Once you install this module, user will be able to create a new brand and define the
+brand to a product.</p>
+<p>To create product brand go to <em>Website &gt; Settings &gt; Products &gt; Product brands</em>:</p>
+<blockquote>
 <ul class="simple">
-<li><dl class="first docutils">
-<dt>To create product brand</dt>
-<dd><dl class="first last docutils">
-<dt>go to:</dt>
-<dd>sales&gt;products&gt;product brands</dd>
-</dl>
-</dd>
-</dl>
-</li>
+<li>User can assign a nice logo with brand description.</li>
+<li>After configuring the brand, user can assign a particular brand to a particular
+products.</li>
 </ul>
-<p>User can assign a nice logo with brand description.</p>
-<ul class="simple">
-<li>After configuring the brand, user can assign a particular brand to a particular products.</li>
-</ul>
+</blockquote>
 <p>Based on this configuration, you will see the menuitem shop by brand next to shop menu.
 It will show all the brands and once you select that brand it will show product’s which
 is related to this brand.</p>
 </div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#id3">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#id4">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/e-commerce/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us smashing it by providing a detailed and welcomed
@@ -427,16 +432,16 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#id4">Credits</a></h1>
+<h1><a class="toc-backref" href="#id5">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#id5">Authors</a></h2>
+<h2><a class="toc-backref" href="#id6">Authors</a></h2>
 <ul class="simple">
 <li>Serpent Consulting Services Pvt. Ltd.</li>
 <li>Tecnativa</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#id6">Contributors</a></h2>
+<h2><a class="toc-backref" href="#id7">Contributors</a></h2>
 <ul>
 <li><p class="first">Jay Vora &lt;<a class="reference external" href="mailto:jay.vora&#64;serpentcs.com">jay.vora&#64;serpentcs.com</a>&gt;</p>
 </li>
@@ -448,13 +453,14 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <li>Ernesto Tejeda &lt;<a class="reference external" href="mailto:ernesto.tejeda&#64;tecnativa.com">ernesto.tejeda&#64;tecnativa.com</a>&gt;</li>
 <li>Sergio Teruel &lt;<a class="reference external" href="mailto:sergio.teruel&#64;tecnativa.com">sergio.teruel&#64;tecnativa.com</a>&gt;</li>
 <li>Alexandre Díaz</li>
+<li>David Vidal</li>
 </ul>
 </blockquote>
 </li>
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#id7">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#id8">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose

--- a/website_sale_product_brand/static/src/scss/website_sale_product_brand.scss
+++ b/website_sale_product_brand/static/src/scss/website_sale_product_brand.scss
@@ -1,0 +1,7 @@
+.brand_item {
+    .brand_item_image {
+        object-fit: scale-down;
+        height: 200px;
+        width: 200px;
+    }
+}

--- a/website_sale_product_brand/views/assets.xml
+++ b/website_sale_product_brand/views/assets.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2022 Tecnativa - David Vidal
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <template id="assets_frontend" inherit_id="website.assets_frontend">
+        <xpath expr=".">
+            <link
+                type="text/css"
+                rel="stylesheet"
+                href="/website_sale_product_brand/static/src/scss/website_sale_product_brand.scss"
+            />
+        </xpath>
+    </template>
+</odoo>

--- a/website_sale_product_brand/views/product_brand.xml
+++ b/website_sale_product_brand/views/product_brand.xml
@@ -38,25 +38,19 @@
                         <t t-if="brand_rec">
                             <div class="row">
                                 <t t-foreach="brand_rec" t-as="o">
-                                    <div class="col-lg-3 d-lg-inline-block">
+                                    <div
+                                        class="card border-0 col-lg-3 col-md-6 mb-4 text-center brand_item"
+                                    >
                                         <a
                                             t-att-href="keep('/shop/brands',brand = o.id)"
                                         >
-                                            <div class="row text-center">
-                                                <div class="col">
-                                                    <img
-                                                        itemprop="image"
-                                                        width="200px"
-                                                        height="200px"
-                                                        class="img"
-                                                        t-attf-src="/website/image/product.brand/#{o.id}/logo#{'?max_width=300&amp;max_height=300'}"
-                                                    />
-                                                </div>
-                                            </div>
-                                            <div class="row text-center">
-                                                <div class="col">
-                                                    <t t-esc="o.name" />
-                                                </div>
+                                            <img
+                                                class="card-img-top img-fluid brand_item_image"
+                                                t-attf-src="/website/image/product.brand/#{o.id}/logo"
+                                                t-att-alt="o.name"
+                                            />
+                                            <div class="card-body border-0">
+                                                <span t-esc="o.name" />
                                             </div>
                                         </a>
                                     </div>

--- a/website_sale_product_brand/views/product_brand_views.xml
+++ b/website_sale_product_brand/views/product_brand_views.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="view_product_brand_form" model="ir.ui.view">
+        <field name="model">product.brand</field>
+        <field name="inherit_id" ref="product_brand.view_product_brand_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//div[hasclass('oe_button_box')]" position="inside">
+                <button
+                    name="website_publish_button"
+                    type="object"
+                    class="oe_stat_button"
+                    icon="fa-globe"
+                >
+                    <field name="website_published" widget="website_publish_button" />
+                </button>
+            </xpath>
+        </field>
+    </record>
+    <record id="view_product_brand_tree" model="ir.ui.view">
+        <field name="model">product.brand</field>
+        <field name="inherit_id" ref="product_brand.view_product_brand_tree" />
+        <field name="arch" type="xml">
+            <field name="partner_id" position="after">
+                <field name="website_published" widget="boolean_toggle" />
+            </field>
+        </field>
+    </record>
+    <menuitem
+        name="Product Brands"
+        id="menu_product_brand"
+        action="product_brand.action_product_brand"
+        parent="website_sale.menu_product_settings"
+    />
+</odoo>


### PR DESCRIPTION
This PR includes:

- [x] A fix to correctly display the brands
- [x] A FW of #426 

Before this patch, images were deformed if they didn't meet precise
proportions.

Before:

![image](https://user-images.githubusercontent.com/5040182/155320002-32ea546f-63d8-4cd5-a5e4-ac8ba4a7f1d6.png)

After:

![image](https://user-images.githubusercontent.com/5040182/155320029-bd0f1e56-55a8-49e4-aa2b-dd653f3bafae.png)


cc @Tecnativa TT34753

please review @Tardo @CarlosRoca13 