### PR TITLE
[14.0][IMP] website_sale_stock_available: make the available qty dependent on a defined field

### DIFF
--- a/website_sale_stock_available/__manifest__.py
+++ b/website_sale_stock_available/__manifest__.py
@@ -13,6 +13,8 @@
         "stock_available",
         "website_sale_stock",
     ],
-    "data": [],
+    "data": [
+        "views/product_views.xml",
+    ],
     "installable": True,
 }

--- a/website_sale_stock_available/models/product_product.py
+++ b/website_sale_stock_available/models/product_product.py
@@ -15,6 +15,10 @@ class Product(models.Model):
         )
         if self.env.context.get("website_sale_stock_available"):
             for product in self.with_context(website_sale_stock_available=False):
-                immediately = product.immediately_usable_qty
+                stock_field = (
+                    product.stock_available_website_based_on.name
+                    or "immediately_usable_qty"
+                )
+                immediately = getattr(product, stock_field, 0.0)
                 res[product.id]["virtual_available"] = immediately
         return res

--- a/website_sale_stock_available/models/product_template.py
+++ b/website_sale_stock_available/models/product_template.py
@@ -1,7 +1,7 @@
 # Copyright 2020 Tecnativa - Ernesto Tejeda
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import models
+from odoo import fields, models
 
 
 class ProductTemplate(models.Model):
@@ -25,3 +25,11 @@ class ProductTemplate(models.Model):
             parent_combination,
             only_template,
         )
+
+    stock_available_website_based_on = fields.Many2one(
+        comodel_name="ir.model.fields",
+        string="Availability based on",
+        help="Choose the field of the product which will be used to compute "
+        "availability on website.\nIf empty, Available to promise is used.\n"
+        "Only the quantity fields have meaning for computing stock",
+    )

--- a/website_sale_stock_available/views/product_views.xml
+++ b/website_sale_stock_available/views/product_views.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <record
+        id="product_template_form_view_inherit_website_sale_stock_available"
+        model="ir.ui.view"
+    >
+        <field name="name">product.template.website.stock.available</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_form_view" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='available_threshold']" position="before">
+                <field
+                    name="stock_available_website_based_on"
+                    options="{'no_open': True, 'no_create': True}"
+                    attrs="{'invisible': [('type', 'in', ['service', 'consu'])]}"
+                    domain="[('model', '=', 'product.product'), ('ttype', '=', 'float')]"
+                />
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
The objective is to be able to define through UI on which field to use for calculating the quantity available on the website, by `product.template`.
It is interesting for example for manufactured products or with kit type BoMs.
The original behavior of the module is maintained by default, if no field is defined in the product.