### PR TITLE
[13.0][FIX] website_sale_checkout_skip_payment: ensure the order isn't draft

### DIFF
--- a/website_sale_checkout_skip_payment/controllers/main.py
+++ b/website_sale_checkout_skip_payment/controllers/main.py
@@ -33,7 +33,7 @@ class CheckoutSkipPayment(WebsiteSale):
         )
         order.action_confirm()
         try:
-            order._send_order_confirmation_mail()
+            order.with_context(mark_so_as_sent=True)._send_order_confirmation_mail()
         except Exception:
             return request.render(
                 "website_sale_checkout_skip_payment.confirmation_order_error"


### PR DESCRIPTION
Some extensions might add an extra validation layer in the sale.order.action_confirm() method (e.g.: sale_financial_risk when the
partner exceeds the risk).

We want to ensure then that although the order might not be confirmed it will be at least be marked as sent and thus the cart will be closed as well.

This recovers the behavior in previous versions, which indirectly achieved the same.

cc @Tecnativa TT34253

please review @pedrobaeza @carlosdauden 