### PR TITLE
[FIX] website_sale_product_sort: README

### DIFF
--- a/website_sale_product_sort/readme/CONFIGURE.rst
+++ b/website_sale_product_sort/readme/CONFIGURE.rst
@@ -12,5 +12,6 @@ this:
 
     @api.model
     def _get_product_sort_criterias(self):
-      res = super()._get_product_sort_criterias()
-      return res.append(("default_code asc", _("Reference - A to Z")))
+        res = super()._get_product_sort_criterias()
+        res.append(("default_code asc", _("Reference - A to Z")))
+        return res


### PR DESCRIPTION
Quick fix in the example python code of the readme.

Append function does not return the list that it modifies in place.

If I remember well, the OCABot will update the Readme file when merging the PR, isn't it ?