### PR TITLE
[13.0][FIX] website_sale_resource_booking: calendar context

### DIFF
--- a/website_sale_resource_booking/controllers/main.py
+++ b/website_sale_resource_booking/controllers/main.py
@@ -62,7 +62,9 @@ class WebsiteSale(main.WebsiteSale):
         except IndexError:
             return request.redirect("/shop/checkout")
         count = len(bookings)
-        values = booking._get_calendar_context(year, month)
+        values = booking.with_context(
+            tz=booking.type_id.resource_calendar_id.tz
+        )._get_calendar_context(year, month)
         values.update(
             {
                 "booking_index": index,


### PR DESCRIPTION
The eCommerce customers should see the calendar available appointments
in the calendar tz context. Otherwise it could lead to confussions.

cc @Tecnativa TT36661

please review @pedrobaeza @victoralmau 