### PR TITLE
[13.0] [FIX] website_sale_cart_expire: possible cron crash

### DIFF
--- a/website_sale_cart_expire/models/website.py
+++ b/website_sale_cart_expire/models/website.py
@@ -45,7 +45,8 @@ class Website(models.Model):
         # Expire carts
         for cart in carts_to_expire:
             try:
-                cart.action_cancel()
-                cart.message_post(body=_("Cart expired"))
-            except exceptions.except_orm:
+                with self.env.cr.savepoint():
+                    cart.action_cancel()
+                    cart.message_post(body=_("Cart expired"))
+            except Exception:
                 _logger.exception("Unable to cancel expired cart id %s", cart.id)


### PR DESCRIPTION
Some modules may raise exceptions when a sale.order is canceled, and
a single order in this case will make the entire cron run rollback
and fail, causing an accumulation of expired carts.

I recently faced this situation with sale events where a miconfiguration
of an event caused the cancelation of sale orders to fail because the
remaining number of seats was negative.

This patch fixes the situation by calling action_cancel() individually
on each cart and checking for an ORM exception, which is logged together
with the cart database id, but not re-raised which allow other carts to
be processed by the cron.