### PR TITLE
[13.0][FIX] website_sale_stock_provisioning_date: reception in two steps + website warehouse

### DIFF
--- a/website_sale_stock_provisioning_date/models/product_product.py
+++ b/website_sale_stock_provisioning_date/models/product_product.py
@@ -1,4 +1,5 @@
 # Copyright 2019 Tecnativa - Ernesto Tejeda
+# Copyright 2022 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from odoo import fields, models
 
@@ -11,7 +12,9 @@ class ProductProduct(models.Model):
             ("company_id", "=", company.id),
             ("product_id", "in", self.ids),
             ("state", "not in", ["draft", "done", "cancel"]),
+            "|",
             ("location_id.usage", "=", "supplier"),
+            ("move_orig_ids.location_id.usage", "=", "supplier"),
             ("location_dest_id.usage", "=", "internal"),
             ("date_provisioning", ">=", fields.Datetime.today()),
         ]

--- a/website_sale_stock_provisioning_date/models/product_template.py
+++ b/website_sale_stock_provisioning_date/models/product_template.py
@@ -43,6 +43,7 @@ class ProductTemplate(models.Model):
         else:
             product = self.sudo()
         provisioning_date = False
+        provisioning_date_formatted = False
         website = self.env["website"].browse(self.env.context.get("website_id"))
         product = product.with_context(warehouse=website._get_warehouse_available())
         if (
@@ -51,5 +52,11 @@ class ProductTemplate(models.Model):
         ):
             company = website.company_id
             provisioning_date = product._get_next_provisioning_date(company)
-        combination_info.update(provisioning_date=provisioning_date)
+            provisioning_date_formatted = self.env["ir.qweb.field.date"].value_to_html(
+                provisioning_date, {}
+            )
+        combination_info.update(
+            provisioning_date=provisioning_date,
+            provisioning_date_formatted=provisioning_date_formatted,
+        )
         return combination_info

--- a/website_sale_stock_provisioning_date/models/product_template.py
+++ b/website_sale_stock_provisioning_date/models/product_template.py
@@ -1,4 +1,5 @@
 # Copyright 2019 Tecnativa - Ernesto Tejeda
+# Copyright 2022 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from odoo import fields, models
 
@@ -42,12 +43,13 @@ class ProductTemplate(models.Model):
         else:
             product = self.sudo()
         provisioning_date = False
+        website = self.env["website"].browse(self.env.context.get("website_id"))
+        product = product.with_context(warehouse=website._get_warehouse_available())
         if (
             product.show_next_provisioning_date
             and product.qty_available - product.outgoing_qty <= 0
         ):
-            website_id = self.env.context.get("website_id")
-            company = self.env["website"].browse(website_id).company_id
+            company = website.company_id
             provisioning_date = product._get_next_provisioning_date(company)
         combination_info.update(provisioning_date=provisioning_date)
         return combination_info

--- a/website_sale_stock_provisioning_date/static/src/xml/website_sale_stock_product_availability.xml
+++ b/website_sale_stock_provisioning_date/static/src/xml/website_sale_stock_product_availability.xml
@@ -14,7 +14,7 @@
                 t-attf-class="availability_message_#{product_template} text-success mt16"
             >
                 <span>
-                    Next provisioning date: <t t-esc="provisioning_date" />
+                    Next provisioning date: <t t-esc="provisioning_date_formatted" />
                 </span>
             </div>
         </t>


### PR DESCRIPTION
2 fixes:

-----------------

[FIX] Cover reception in 2 steps

Steps to reproduce the problem:

- Configure your website warehouse to receipt in 2 steps.
- Do a purchase of an out of stock product and confirm it.
- Set the purchased product to show the provisioning date on your e-commerce.
- Navigate to the product e-commerce page.

Current behavior:

No provisioning date is shown.

Expected behavior:

The provisioning date of your reception is shown.

The problem comes from searching only moves with direct supplier location as source and internal location as destination. We search instead for chained moves that have original location in supplier ones.

-----------------

[FIX] Restrict website warehouse

If any warehouse is selected in your website, the condition to show or not the provisioning date should be restricted to such warehouse.

We use the provided method `_get_warehouse_available` to be consistent with what `website_sale_stock` performs to get the available stock.

@Tecnativa TT38566