### PR TITLE
[13.0][IMP] website_sale_stock_list_preview: Set context to compute as website_sale_stock_available

### DIFF
--- a/website_sale_stock_list_preview/controllers/main.py
+++ b/website_sale_stock_list_preview/controllers/main.py
@@ -26,11 +26,13 @@ class WebsiteSaleVariantController(VariantController):
         templates = (
             request.env["product.template"]
             .sudo()
-            .with_context(warehouse=current_website.warehouse_id.id)
+            .with_context(
+                warehouse=current_website.warehouse_id.id,
+                website_sale_stock_available=True,
+            )
             .browse(product_template_ids)
         )
         for template in templates.filtered(lambda t: t.is_published):
-
             res.append(
                 {
                     "id": template.id,


### PR DESCRIPTION
When website_sale_stock_available is installed, the grid view is showing
different allowed quantities than when we access to the products sheet.

With this changes we add compatibility with this module and if
stock_available_immediately is installed we will get same value.

cc @Tecnativa TT38689

please @victoralmau @pedrobaeza review this