### PR TITLE
[12.0][ADD] website_sale_product_availability

### DIFF
--- a/website_sale_product_availability/__init__.py
+++ b/website_sale_product_availability/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2022 Coop IT Easy SC
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).

--- a/website_sale_product_availability/__manifest__.py
+++ b/website_sale_product_availability/__manifest__.py
@@ -1,0 +1,25 @@
+# Copyright 2022 Coop IT Easy SC
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Website Sale Product Availability",
+    "summary": """
+        Display the quantity of products available on the product overview.""",
+    "version": "12.0.1.0.0",
+    "category": "Website",
+    "website": "https://github.com/OCA/e-commerce",
+    "author": "Coop IT Easy SC",
+    "maintainers": ["carmenbianca"],
+    "license": "AGPL-3",
+    "application": False,
+    "depends": [
+        "website_sale",
+        "website_sale_stock",
+    ],
+    "excludes": [],
+    "data": [
+        "views/templates.xml",
+    ],
+    "demo": [],
+    "qweb": [],
+}

--- a/website_sale_product_availability/readme/CONTRIBUTORS.rst
+++ b/website_sale_product_availability/readme/CONTRIBUTORS.rst
@@ -1,0 +1,3 @@
+* `Coop IT Easy SC <https://coopiteasy.be>`_:
+
+  * Carmen Bianca BAKKER

--- a/website_sale_product_availability/readme/DESCRIPTION.rst
+++ b/website_sale_product_availability/readme/DESCRIPTION.rst
@@ -1,0 +1,1 @@
+Display the quantity of products available on the e-commerce product overview.

--- a/website_sale_product_availability/readme/USAGE.rst
+++ b/website_sale_product_availability/readme/USAGE.rst
@@ -1,0 +1,4 @@
+After installing the module, go to the 'eCommerce' tab on your products. Change
+the 'Availability' setting from 'Sell regardless of inventory' to 'Show
+inventory [...]' if you want to show the availability on the product overview
+page in the e-commerce.

--- a/website_sale_product_availability/views/templates.xml
+++ b/website_sale_product_availability/views/templates.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+Copyright 2022 Coop IT Easy SC
+License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+    <template id="products_item" inherit_id="website_sale.products_item">
+        <xpath
+            expr="//div[@itemscope='itemscope']//div[hasclass('product_price')]//b"
+            position="after"
+        >
+            <span t-if="product.inventory_availability == 'always'">
+                <!--
+                    FIXME: This doesn't seem like good i18n practice to me. What
+                    if another language says e.g. 'available $qty $uom'?
+
+                    However, it's also done like this in
+                    website_sale_stock.product_availability, so it's probably
+                    fine.
+                -->
+                <t t-esc="product.sudo().virtual_available" /> <t t-esc="product.uom_name" /> available
+            </span>
+            <span t-if="product.inventory_availability == 'threshold'">
+                <t t-if="product.sudo().virtual_available &lt;= product.available_threshold">
+                        <i class="fa fa-exclamation-triangle" title="Warning" role="img" aria-label="Warning"/>
+                        <t t-esc="product.sudo().virtual_available" /> <t t-esc="product.uom_name" /> available
+                </t>
+                <t t-if="product.sudo().virtual_available &gt; product.available_threshold">In stock</t>
+            </span>
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
Replaces #700, which was pushed to the wrong branch.

Simple module that adds availability to the /shop overview.

Internal task: https://gestion.coopiteasy.be/web#id=9377&action=479&model=project.task&view_type=form&menu_id=536