### PR TITLE
[14.0][ADD] website_sale_payment_term_acquirer

### DIFF
--- a/setup/website_sale_payment_term_acquirer/odoo/addons/website_sale_payment_term_acquirer
+++ b/setup/website_sale_payment_term_acquirer/odoo/addons/website_sale_payment_term_acquirer
@@ -1,0 +1,1 @@
+../../../../website_sale_payment_term_acquirer

--- a/setup/website_sale_payment_term_acquirer/setup.py
+++ b/setup/website_sale_payment_term_acquirer/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/website_sale_payment_term_acquirer/__init__.py
+++ b/website_sale_payment_term_acquirer/__init__.py
@@ -1,0 +1,2 @@
+from . import controllers
+from . import models

--- a/website_sale_payment_term_acquirer/__manifest__.py
+++ b/website_sale_payment_term_acquirer/__manifest__.py
@@ -1,0 +1,17 @@
+{
+    "name": "eCommerce Payment Term Acquirer",
+    "summary": "eCommerce Payment Term Acquirer",
+    "author": "Ooops, Cetmix, Odoo Community Association (OCA)",
+    "version": "14.0.1.0.0",
+    "category": "Website",
+    "website": "https://github.com/OCA/e-commerce",
+    "maintainers": ["geomer198", "CetmixGitDrone"],
+    "license": "AGPL-3",
+    "depends": ["website_sale"],
+    "data": [
+        "views/payment_acquirer_views.xml",
+        "views/payment_templates.xml",
+    ],
+    "demo": ["demo/demo.xml"],
+    "installable": True,
+}

--- a/website_sale_payment_term_acquirer/controllers/__init__.py
+++ b/website_sale_payment_term_acquirer/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import main

--- a/website_sale_payment_term_acquirer/controllers/main.py
+++ b/website_sale_payment_term_acquirer/controllers/main.py
@@ -1,0 +1,21 @@
+from odoo.http import request
+
+from odoo.addons.website_sale.controllers.main import WebsiteSale
+
+
+class WebsiteSale(WebsiteSale):
+    def _get_shop_payment_values(self, order, **kwargs):
+        values = super(WebsiteSale, self)._get_shop_payment_values(order, **kwargs)
+        # Get Customer Payment Term
+        user_payment_term = request.env.user.partner_id.property_payment_term_id
+        if not user_payment_term:
+            # Skip acquirers with active 'display_main_payment_term' key
+            values.update(
+                acquirers=list(
+                    filter(
+                        lambda acq: not acq.display_main_payment_term,
+                        values.get("acquirers", []),
+                    )
+                )
+            )
+        return values

--- a/website_sale_payment_term_acquirer/demo/demo.xml
+++ b/website_sale_payment_term_acquirer/demo/demo.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo noupdate="1">
+
+    <record id="payment_acquirer_partners_pt" model="payment.acquirer">
+        <field name="name">Partner's PT</field>
+        <field name="sequence">3</field>
+        <field name="state">enabled</field>
+        <field name="view_template_id" ref="payment.default_acquirer_button" />
+        <field name="display_main_payment_term" eval="True" />
+    </record>
+
+    <record id="base.user_admin" model="res.users">
+        <field
+            name="property_payment_term_id"
+            ref="account.account_payment_term_end_following_month"
+        />
+    </record>
+
+</odoo>

--- a/website_sale_payment_term_acquirer/models/__init__.py
+++ b/website_sale_payment_term_acquirer/models/__init__.py
@@ -1,0 +1,2 @@
+from . import payment_acquirer
+from . import sale_order

--- a/website_sale_payment_term_acquirer/models/payment_acquirer.py
+++ b/website_sale_payment_term_acquirer/models/payment_acquirer.py
@@ -1,0 +1,13 @@
+from odoo import fields, models
+
+
+class PaymentAcquirer(models.Model):
+    _inherit = "payment.acquirer"
+    _order = "display_main_payment_term desc"
+
+    payment_term_id = fields.Many2one(
+        comodel_name="account.payment.term",
+    )
+    display_main_payment_term = fields.Boolean(
+        string="Display as partner's main payment term"
+    )

--- a/website_sale_payment_term_acquirer/models/sale_order.py
+++ b/website_sale_payment_term_acquirer/models/sale_order.py
@@ -1,0 +1,15 @@
+from odoo import models
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    def _create_payment_transaction(self, vals):
+        transactions = super()._create_payment_transaction(vals)
+        for transaction in transactions:
+            acquirer = transaction.acquirer_id
+            if not acquirer.display_main_payment_term and acquirer.payment_term_id:
+                transaction.sale_order_ids.write(
+                    {"payment_term_id": acquirer.payment_term_id}
+                )
+        return transactions

--- a/website_sale_payment_term_acquirer/readme/CONTRIBUTORS.rst
+++ b/website_sale_payment_term_acquirer/readme/CONTRIBUTORS.rst
@@ -1,0 +1,2 @@
+* Ooops404 <https://ooops404.com>
+* Cetmix <https://cetmix.com>

--- a/website_sale_payment_term_acquirer/readme/DESCRIPTION.rst
+++ b/website_sale_payment_term_acquirer/readme/DESCRIPTION.rst
@@ -1,0 +1,4 @@
+This module allows:
+
+1. To relate payment acquirers used in checkout to payment terms: if a payment acquirer is related to a payment term, when the payment acquirer is selected the payment term is selected in the corresponding SO.
+2. To display the name of a specific payment acquirer in checkout with the name of the payment term set in partner related to the user completing the ecommerce order. This payment acquirer is not displayed during the checkout if partner related to user does not have a payment term set.

--- a/website_sale_payment_term_acquirer/readme/USAGE.rst
+++ b/website_sale_payment_term_acquirer/readme/USAGE.rst
@@ -1,0 +1,7 @@
+Go to **Website** > **Configuration** > **Payment Acquirer**
+
+
+You will find field **Payment Term** to relate a payment term to payment acquirer
+alternatively, you can use flag **Display as partner's main payment term** to:
+make this payment acquirer name appear in checkout with partner’s default payment term name
+hide this payment acquirer from checkout if partner’s default payment term is not set.

--- a/website_sale_payment_term_acquirer/tests/__init__.py
+++ b/website_sale_payment_term_acquirer/tests/__init__.py
@@ -1,0 +1,2 @@
+from . import test_sale_order
+from . import test_website_sale

--- a/website_sale_payment_term_acquirer/tests/test_sale_order.py
+++ b/website_sale_payment_term_acquirer/tests/test_sale_order.py
@@ -1,0 +1,118 @@
+from odoo.tests import tagged
+
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+
+
+@tagged("post_install", "-at-install")
+class TestSaleOrder(AccountTestInvoicingCommon):
+    @classmethod
+    def setUpClass(cls, chart_template_ref=None):
+        super().setUpClass(chart_template_ref=chart_template_ref)
+        PaymentAcquirer = cls.env["payment.acquirer"]
+
+        cls.payment_term_end_following_month = cls.env.ref(
+            "account.account_payment_term_end_following_month"
+        )
+        cls.payment_term_30days = cls.env.ref("account.account_payment_term_30days")
+
+        cls.company_data["company"].country_id = cls.env.ref("base.us")
+
+        cls.order = cls.env["sale.order"].create(
+            {
+                "partner_id": cls.partner_a.id,
+                "order_line": [
+                    (
+                        0,
+                        False,
+                        {
+                            "product_id": cls.product_a.id,
+                            "name": "1 Product",
+                            "price_unit": 100.0,
+                        },
+                    ),
+                ],
+            }
+        )
+
+        cls.acquirer_transfer_test = PaymentAcquirer.create(
+            {
+                "name": "Test Transfer",
+                "sequence": 10,
+            }
+        )
+        cls.acquirer_transfer_test.journal_id = cls.company_data["default_journal_cash"]
+
+        PaymentAcquirer.search([]).write({"display_main_payment_term": False})
+        cls.partner_payment_term = cls.env.user.partner_id.property_payment_term_id
+
+    def test_default_order_acquirer_position(self):
+        """
+        This test covers the behavior when a messages
+        search have default ordering
+        """
+        first_acquirer = self.env["payment.acquirer"].search([], limit=1)
+        self.assertNotEqual(first_acquirer, self.acquirer_transfer_test)
+
+    def test_order_acquirer_with_flag(self):
+        """
+        This test covers the behavior when a message with key
+        'display_main_payment_term' at search
+        has a first position in the recordset
+        """
+        self.acquirer_transfer_test.write({"display_main_payment_term": True})
+        first_acquirer = self.env["payment.acquirer"].search([], limit=1)
+        self.assertEqual(first_acquirer, self.acquirer_transfer_test)
+
+    def test_default_acquirer_behavior(self):
+        """
+        This test covers the behavior when a transaction creates by default. by default.
+        """
+        self.order._create_payment_transaction(
+            {"acquirer_id": self.acquirer_transfer_test.id}
+        )
+        self.assertEqual(self.order.payment_term_id, self.partner_payment_term)
+
+    def test_acquirer_behavior_with_tag(self):
+        """
+        This test covers the behavior when a transaction creates
+        with the acquirer that has 'display_main_payment_term' key
+        """
+        self.acquirer_transfer_test.write({"display_main_payment_term": True})
+
+        self.order._create_payment_transaction(
+            {"acquirer_id": self.acquirer_transfer_test.id}
+        )
+        self.assertEqual(self.order.payment_term_id, self.partner_payment_term)
+
+    def test_acquirer_behavior_with_tag_and_payment_term(self):
+        """
+        This test covers the behavior when a transaction creates
+        with the acquirer that has 'display_main_payment_term'
+        key and has payment term
+        """
+        self.acquirer_transfer_test.write(
+            {
+                "display_main_payment_term": True,
+                "payment_term_id": self.payment_term_30days.id,
+            }
+        )
+        self.order._create_payment_transaction(
+            {"acquirer_id": self.acquirer_transfer_test.id}
+        )
+        self.assertEqual(self.order.payment_term_id, self.partner_payment_term)
+
+    def test_acquirer_bevavior_with_payment_term(self):
+        """This test covers the behavior when a transaction creates
+        with the acquirer that hasn't 'display_main_payment_term'
+        key and has payment term
+        """
+        self.acquirer_transfer_test.write(
+            {
+                "payment_term_id": self.payment_term_30days.id,
+            }
+        )
+        self.order._create_payment_transaction(
+            {"acquirer_id": self.acquirer_transfer_test.id}
+        )
+        self.assertNotEqual(self.order.payment_term_id, self.partner_payment_term)
+        self.assertEqual(self.order.payment_term_id, self.payment_term_30days)

--- a/website_sale_payment_term_acquirer/tests/test_website_sale.py
+++ b/website_sale_payment_term_acquirer/tests/test_website_sale.py
@@ -1,0 +1,147 @@
+from odoo.tests import SavepointCase, tagged
+
+from odoo.addons.website.tools import MockRequest
+from odoo.addons.website_sale_payment_term_acquirer.controllers.main import WebsiteSale
+
+
+@tagged("post_install", "-at_install")
+class TestWebsiteSale(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TestWebsiteSale, cls).setUpClass()
+        PaymentAcquirer = cls.env["payment.acquirer"]
+
+        cls.payment_term_end_following_month = cls.env.ref(
+            "account.account_payment_term_end_following_month"
+        )
+        cls.payment_term_30days = cls.env.ref("account.account_payment_term_30days")
+
+        cls.website = cls.env["website"].browse(1)
+        cls.WebsiteSaleController = WebsiteSale()
+        cls.demo_user = cls.env.ref("base.user_demo")
+        PaymentAcquirer.search([]).unlink()
+        cls.acquirer_transfer_test_1 = PaymentAcquirer.create(
+            {
+                "name": "Test Transfer #1",
+                "sequence": 10,
+                "state": "test",
+            }
+        )
+        cls.acquirer_transfer_test_2 = PaymentAcquirer.create(
+            {
+                "name": "Test Transfer #1",
+                "sequence": 11,
+                "state": "test",
+            }
+        )
+
+        cls.product = cls.env["product.product"].create(
+            {
+                "name": "Test Product",
+                "sale_ok": True,
+            }
+        )
+
+        cls.order = (
+            cls.env["sale.order"]
+            .with_user(cls.demo_user)
+            .create(
+                {
+                    "partner_id": cls.demo_user.partner_id.id,
+                    "order_line": [
+                        (
+                            0,
+                            False,
+                            {
+                                "product_id": cls.product.id,
+                                "name": cls.product.name,
+                                "price_unit": 100.0,
+                            },
+                        ),
+                    ],
+                }
+            )
+        )
+
+    def test_show_all_acquirers_with_display_main_payment_term_key(self):
+        """
+        This test covers the scenario when all acquirers have
+        'display_main_payment_term' key and the customer have payment term
+        """
+        expected_acquirers = [
+            self.acquirer_transfer_test_1,
+            self.acquirer_transfer_test_2,
+        ]
+        self.acquirer_transfer_test_1.display_main_payment_term = True
+        self.acquirer_transfer_test_2.display_main_payment_term = True
+        self.demo_user.partner_id.write(
+            {
+                "property_payment_term_id": self.payment_term_30days.id,
+            }
+        )
+        with MockRequest(
+            self.product.with_user(self.demo_user).env, website=self.website
+        ):
+            values = self.WebsiteSaleController._get_shop_payment_values(self.order)
+            self.assertListEqual(expected_acquirers, values.get("acquirers"))
+
+    def test_skip_all_acquirers_with_display_main_payment_term_key(self):
+        """
+        This test covers the scenario when all acquirers have
+        'display_main_payment_term' key and the customer doesn't have payment term
+        """
+        self.acquirer_transfer_test_1.display_main_payment_term = True
+        self.acquirer_transfer_test_2.display_main_payment_term = True
+        with MockRequest(
+            self.product.with_user(self.demo_user).env, website=self.website
+        ):
+            values = self.WebsiteSaleController._get_shop_payment_values(self.order)
+            self.assertListEqual([], values.get("acquirers"))
+
+    def test_skip_acquirers_with_display_main_payment_term_key(self):
+        """
+        This test covers the scenario when 'Test Transfer #1' acquirer have
+        'display_main_payment_term' key and the customer doesn't have payment term
+        """
+        expected_acquirers = [self.acquirer_transfer_test_2]
+        self.acquirer_transfer_test_1.display_main_payment_term = True
+        with MockRequest(
+            self.product.with_user(self.demo_user).env, website=self.website
+        ):
+            values = self.WebsiteSaleController._get_shop_payment_values(self.order)
+            self.assertListEqual(expected_acquirers, values.get("acquirers"))
+
+    def test_show_default_acquirer_by_payment_term(self):
+        """
+        This test covers the scenario when all acquirers doesn't have
+        'display_main_payment_term' key and the customer doesn't have payment term
+        """
+        expected_acquirers = [
+            self.acquirer_transfer_test_1,
+            self.acquirer_transfer_test_2,
+        ]
+        with MockRequest(
+            self.product.with_user(self.demo_user).env, website=self.website
+        ):
+            values = self.WebsiteSaleController._get_shop_payment_values(self.order)
+            self.assertListEqual(expected_acquirers, values.get("acquirers"))
+
+    def test_show_acquirer_with_default_partner_term(self):
+        """
+        This test covers the scenario when all acquirers doesn't have
+        'display_main_payment_term' key and the customer have payment term
+        """
+        expected_acquirers = [
+            self.acquirer_transfer_test_1,
+            self.acquirer_transfer_test_2,
+        ]
+        self.demo_user.partner_id.write(
+            {
+                "property_payment_term_id": self.payment_term_30days.id,
+            }
+        )
+        with MockRequest(
+            self.product.with_user(self.demo_user).env, website=self.website
+        ):
+            values = self.WebsiteSaleController._get_shop_payment_values(self.order)
+            self.assertListEqual(expected_acquirers, values.get("acquirers"))

--- a/website_sale_payment_term_acquirer/views/payment_acquirer_views.xml
+++ b/website_sale_payment_term_acquirer/views/payment_acquirer_views.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <record id="acquirer_view_form" model="ir.ui.view">
+        <field name="name">payment.acquirer.inherit.form</field>
+        <field name="model">payment.acquirer</field>
+        <field name="inherit_id" ref="payment.acquirer_form" />
+        <field name="arch" type="xml">
+            <group name="payment_form" position="inside">
+                <field name="display_main_payment_term" />
+                <field
+                    name="payment_term_id"
+                    attrs="{'invisible': [('display_main_payment_term', '=', True)]}"
+                />
+            </group>
+        </field>
+    </record>
+
+</odoo>

--- a/website_sale_payment_term_acquirer/views/payment_templates.xml
+++ b/website_sale_payment_term_acquirer/views/payment_templates.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <template
+        id="payment_tokens_list_custom"
+        inherit_id="payment.payment_tokens_list"
+        name="Payment Trace"
+        priority="100"
+    >
+        <span class="payment_option_name" position="replace">
+            <t
+                t-if="acq.display_main_payment_term"
+                t-esc="user_id.partner_id.property_payment_term_id.display_name"
+            />
+            <t t-else="" t-esc="acq.display_as or acq.name" />
+            <div
+                t-if="acq.state == 'test'"
+                class="badge-pill badge-warning float-right"
+                style="margin-left:5px"
+            >
+                Test Mode
+            </div>
+        </span>
+    </template>
+
+</odoo>


### PR DESCRIPTION
This module allows:

1. To relate payment acquirers used in checkout to payment terms: if a payment acquirer is related to a payment term, when the payment acquirer is selected the payment term is selected in the corresponding SO.
2. To display the name of a specific payment acquirer in checkout with the name of the payment term set in partner related to the user completing the ecommerce order. This payment acquirer is not displayed during the checkout if partner related to user does not have a payment term set.
