### PR TITLE
[14.0][FIX] website_sale_product_description: Move the product description text closer to the image carousel

### DIFF
--- a/website_sale_product_description/views/website_sale_template.xml
+++ b/website_sale_product_description/views/website_sale_template.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
-    <template id="product" inherit_id="website_sale.product">
-        <xpath
-            expr="//div[@id='product_details']/../div[hasclass('col-md-6', 'col-xl-4')]"
-            position="after"
-        >
+    <template
+        id="shop_product_carousel"
+        inherit_id="website_sale.shop_product_carousel"
+    >
+        <xpath expr="//div[@id='o-carousel-product']" position="inside">
             <div class="o_not_editable">
                 <p
                     t-field="product.public_description"


### PR DESCRIPTION
Replaces #621

Previously, if the product details panel was very long, the description
text would start at the very bottom of that panel. This created a big
empty space between the image carousel and the product description.

Before:

![Capture d’écran de 2022-03-03 15-31-29](https://user-images.githubusercontent.com/12065945/156586538-0fdcc511-bbbb-4142-8e70-26f55c4edc53.png)

After:

![Capture d’écran de 2022-03-03 15-35-22](https://user-images.githubusercontent.com/12065945/156586577-73665c2d-0495-419a-b07f-581875c4b4ba.png)

