### PR TITLE
[13.0][IMP] website_sale_secondary_unit: mobile UX

### DIFF
--- a/website_sale_secondary_unit/views/templates.xml
+++ b/website_sale_secondary_unit/views/templates.xml
@@ -166,10 +166,10 @@
             </t>
         </xpath>
         <xpath expr="//th[hasclass('td-qty')]" position="after">
-            <th class="text-center td-qty">Quantity</th>
+            <th class="text-center td-qty d-none d-md-table-cell">Quantity</th>
         </xpath>
         <xpath expr="//td[hasclass('td-qty')]" position="after">
-            <td class="text-center td-qty">
+            <td class="text-center td-qty d-none d-md-table-cell">
                 <span
                     t-esc="int(line.product_uom_qty) == line.product_uom_qty and int(line.product_uom_qty) or line.product_uom_qty"
                 />


### PR DESCRIPTION
For mobile users adding an extra column in the cart summary makes that the others content won't fit very well, specially for products with long names. As we can infer the sale line information without the secondary units computation computation column we choose to hide it if the screen is too small as Odoo does with the product image column:

![Peek 20-12-2022 16-55](https://user-images.githubusercontent.com/5040182/208709989-9f806bf6-9eda-4369-b243-a97f777a79ef.gif)


cc @Tecnativa TT37137

please review @sergio-teruel @pedrobaeza 