### PR TITLE
[15.0][IMP] website_sale_secondary_unit: mobile UX

### DIFF
--- a/website_sale_secondary_unit/views/templates.xml
+++ b/website_sale_secondary_unit/views/templates.xml
@@ -166,10 +166,10 @@
             </t>
         </xpath>
         <xpath expr="//th[hasclass('td-qty')]" position="after">
-            <th class="text-center td-qty">Quantity</th>
+            <th class="text-center td-qty d-none d-md-table-cell">Quantity</th>
         </xpath>
         <xpath expr="//td[hasclass('td-qty')]" position="after">
-            <td class="text-center td-qty">
+            <td class="text-center td-qty d-none d-md-table-cell">
                 <span
                     t-esc="int(line.product_uom_qty) == line.product_uom_qty and int(line.product_uom_qty) or line.product_uom_qty"
                 />


### PR DESCRIPTION
Fw of #712 

For mobile users adding an extra column in the cart summary makes that the others content won't fit very well, specially for products with long names. As we can infer the sale line information without the secondary units computation computation column we choose to hide it if the screen is too small as Odoo does with the product image column.

cc @Tecnativa TT37137

please review @CarlosRoca13 @pedrobaeza 