### PR TITLE
[15.0][FIX] website_sale_product_description: Move the product description text closer to the image carousel

### DIFF
--- a/website_sale_product_description/views/website_sale_template.xml
+++ b/website_sale_product_description/views/website_sale_template.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
-    <template id="product" inherit_id="website_sale.product">
-        <xpath expr="//div[@id='product_details']/.." position="after">
+    <template
+        id="shop_product_carousel"
+        inherit_id="website_sale.shop_product_carousel"
+    >
+        <xpath expr="//div[@id='o-carousel-product']" position="inside">
             <div class="o_not_editable">
                 <p
                     t-field="product.public_description"


### PR DESCRIPTION
Forward-port from #709 