### PR TITLE
12.0 [FIX] add o_payment_form_pay id on confirm button

### DIFF
--- a/website_sale_checkout_skip_payment/views/website_sale_template.xml
+++ b/website_sale_checkout_skip_payment/views/website_sale_template.xml
@@ -13,7 +13,7 @@
             <div class="js_skip_payment mt-3" t-if="website.checkout_skip_payment" id="skip_payment_method">
                 <form target="_self" action="/shop/confirmation" method="post" class="float-right">
                     <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()" />
-                    <a role="button" class="btn btn-primary a-submit" href="#">
+                    <a role="button" id="o_payment_form_pay" class="btn btn-primary a-submit" href="#">
                         <span>Confirm Order <span class="fa fa-chevron-right"></span></span>
                     </a>
                 </form>


### PR DESCRIPTION
This id is necessary for the website_sale_delivery.js to run and update carriers

fix https://github.com/OCA/e-commerce/issues/741

@sergio-teruel 
@chienandalu 
@vdewulf 