### PR TITLE
[14.0][IMP] website_sale_checkout_skip_payment: hide new payment message

### DIFF
--- a/website_sale_checkout_skip_payment/readme/CONTRIBUTORS.rst
+++ b/website_sale_checkout_skip_payment/readme/CONTRIBUTORS.rst
@@ -2,3 +2,6 @@
 * David Vidal <david.vidal@tecnativa.com>
 * Martin Wilderoth <martin.wilderoth@linserv.se>
 * Alexandre Díaz <alexandre.diaz@tecnativa.com>
+* `Studio73 <https://www.studio73.es>`_:
+
+  * Miguel Gandia <miguel@studio73.es>

--- a/website_sale_checkout_skip_payment/views/website_sale_template.xml
+++ b/website_sale_checkout_skip_payment/views/website_sale_template.xml
@@ -42,6 +42,13 @@
                 name="t-if"
             >not website_sale_order.amount_total and not website.checkout_skip_payment</attribute>
         </xpath>
+        <xpath expr="//div[@t-if='not (acquirers or tokens)']" position="attributes">
+            <attribute
+                name="t-if"
+                separator=" "
+                add="and not website.checkout_skip_payment"
+            />
+        </xpath>
     </template>
     <template id="confirmation" inherit_id="website_sale.confirmation">
         <xpath


### PR DESCRIPTION
Odoo has recently added a new alert message in the payment section of the web payment gateway so it is convenient for this module to hide this message when `skip_website_checkout_payment` is enabled.
https://github.com/odoo/odoo/commit/3c43edcb0fe4dddd06b0cac93a71b965fd1028ce