### PR TITLE
[15.0][IMP] website_sale_checkout_skip_payment: hide payment message

### DIFF
--- a/website_sale_checkout_skip_payment/readme/CONTRIBUTORS.rst
+++ b/website_sale_checkout_skip_payment/readme/CONTRIBUTORS.rst
@@ -5,3 +5,6 @@
   * Alexandre Díaz
   * Carlos Roca
 * Martin Wilderoth <martin.wilderoth@linserv.se>
+* `Studio73 <https://www.studio73.es>`_:
+
+  * Miguel Gandia <miguel@studio73.es>

--- a/website_sale_checkout_skip_payment/views/website_sale_template.xml
+++ b/website_sale_checkout_skip_payment/views/website_sale_template.xml
@@ -32,10 +32,15 @@
                 </form>
             </div>
         </xpath>
-        <xpath expr="//div[@id='payment_method']" position="attributes">
-            <attribute
+        <xpath
+            expr="//t[@t-if='website_sale_order.amount_total']"
+            position="attributes"
+        >
+          <attribute
                 name="t-if"
-            >(acquirers or tokens) and website_sale_order.amount_total and not website.checkout_skip_payment</attribute>
+                separator=" "
+                add="and not website.checkout_skip_payment"
+            />
         </xpath>
         <xpath expr="//div[hasclass('js_payment')]" position="attributes">
             <attribute


### PR DESCRIPTION
Alert message in the payment section of the web payment gateway so it is convenient for this module to hide this message when skip_website_checkout_payment is enabled.

Detected in Odoo 14.0  OCA/e-commerce#752