### PR TITLE
[15.0][FIX] website_sale_require_legal: remove dependency to website_legal_page

### DIFF
--- a/website_sale_require_legal/__manifest__.py
+++ b/website_sale_require_legal/__manifest__.py
@@ -12,7 +12,7 @@
     "license": "AGPL-3",
     "application": False,
     "installable": True,
-    "depends": ["website_legal_page", "website_sale"],
+    "depends": ["website_sale"],
     "data": ["templates/website_sale.xml"],
     "assets": {
         "web.assets_frontend": [

--- a/website_sale_require_legal/templates/website_sale.xml
+++ b/website_sale_require_legal/templates/website_sale.xml
@@ -4,7 +4,7 @@
      License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
 <odoo>
     <template id="accept_input">
-        <div class="col-lg-12">
+        <div class="col-lg-12 mb-2">
             <input
                 t-attf-class="form-check-input position-relative ml-0 mr-1 #{'is-invalid' if error and error.get('accepted_legal_terms') else ''}"
                 type="checkbox"
@@ -13,7 +13,10 @@
                 required="required"
             />
             <label for="accepted_legal_terms" class="control-label form-check-label">
-                <t t-call="website_legal_page.acceptance_full" />
+                I agree to the <a
+                    target="_BLANK"
+                    href="/terms"
+                >terms &amp; conditions</a>
             </label>
         </div>
     </template>


### PR DESCRIPTION
The dependency on website_legal_page has been removed so that they can be used independently.
website_legal_page merged into account https://github.com/OCA/OpenUpgrade/pull/3728

cc @Tecnativa TT41842

@chienandalu @CarlosRoca13 please review