### PR TITLE
[15.0][FIX] website_sale_hide_price: hide the price in the add_to_cart option

### DIFF
--- a/website_sale_hide_price/README.rst
+++ b/website_sale_hide_price/README.rst
@@ -76,6 +76,8 @@ Known issues / Roadmap
   along every website. It could be modified the boolean field on the partner to a many2many
   relation between res_partner and website_website, so that this price-hiding feature might
   be made website-dependant.
+- This module is incompatible with the website_sale_stock_force_block module because it
+  makes changes to the same attributes in the website_sale.products_add_to_cart template.
 
 Bug Tracker
 ===========
@@ -101,6 +103,7 @@ Contributors
 * `Tecnativa <https://www.tecnativa.com>`__:
 
   * David Vidal
+  * Pilar Vargas
 
 * Abraham González <abraham@trey.es>
 * Juanjo Algaz  <jalgaz@gmail.com>

--- a/website_sale_hide_price/readme/CONTRIBUTORS.rst
+++ b/website_sale_hide_price/readme/CONTRIBUTORS.rst
@@ -1,6 +1,7 @@
 * `Tecnativa <https://www.tecnativa.com>`__:
 
   * David Vidal
+  * Pilar Vargas
 
 * Abraham González <abraham@trey.es>
 * Juanjo Algaz  <jalgaz@gmail.com>

--- a/website_sale_hide_price/readme/ROADMAP.rst
+++ b/website_sale_hide_price/readme/ROADMAP.rst
@@ -2,3 +2,5 @@
   along every website. It could be modified the boolean field on the partner to a many2many
   relation between res_partner and website_website, so that this price-hiding feature might
   be made website-dependant.
+- This module is incompatible with the website_sale_stock_force_block module because it
+  makes changes to the same attributes in the website_sale.products_add_to_cart template.

--- a/website_sale_hide_price/static/description/index.html
+++ b/website_sale_hide_price/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Website Sale Hide Price</title>
 <style type="text/css">
 
@@ -427,6 +427,8 @@ hidden.</li>
 along every website. It could be modified the boolean field on the partner to a many2many
 relation between res_partner and website_website, so that this price-hiding feature might
 be made website-dependant.</li>
+<li>This module is incompatible with the website_sale_stock_force_block module because it
+makes changes to the same attributes in the website_sale.products_add_to_cart template.</li>
 </ul>
 </div>
 <div class="section" id="bug-tracker">
@@ -450,6 +452,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <ul class="simple">
 <li><a class="reference external" href="https://www.tecnativa.com">Tecnativa</a>:<ul>
 <li>David Vidal</li>
+<li>Pilar Vargas</li>
 </ul>
 </li>
 <li>Abraham González &lt;<a class="reference external" href="mailto:abraham&#64;trey.es">abraham&#64;trey.es</a>&gt;</li>

--- a/website_sale_hide_price/views/website_sale_template.xml
+++ b/website_sale_hide_price/views/website_sale_template.xml
@@ -40,6 +40,22 @@
                 </attribute>
         </xpath>
     </template>
+    <!-- Hide buy now button if "Buy Now Button" option is enabled and not website_show_price -->
+    <template id="product_buy_now" inherit_id="website_sale.product_buy_now">
+        <xpath expr="//a[hasclass('o_we_buy_now')]" position="attributes">
+            <attribute name="t-if">
+                website.website_show_price and not product.website_hide_price
+            </attribute>
+        </xpath>
+    </template>
+    <!-- Hide add to cart button if "Add to cart" option is enabled and not website_show_price -->
+    <template id="products_add_to_cart" inherit_id="website_sale.products_add_to_cart">
+        <xpath expr="//a[hasclass('a-submit')]" position="attributes">
+            <attribute name="t-if">
+                website.website_show_price and not product.website_hide_price
+            </attribute>
+        </xpath>
+    </template>
     <template id="website_search_box" inherit_id="website.website_search_box">
         <xpath expr="//input[@name='search']" position="attributes">
             <attribute


### PR DESCRIPTION
When the "add_to_cart" option was activated, the add to cart button was not hidden and the product could be added and this functionality has been corrected.
The same applies to the "Buy Now Button" option.
Fix made in version 13 and brought to version 15:
- https://github.com/OCA/e-commerce/pull/764

cc @tecnativca TT41911

@chienandalu @CarlosRoca13 please review