### PR TITLE
[15.0][FIX] website_sale_product_attribute_filter_collapse: fix test error

### DIFF
--- a/website_sale_product_attribute_filter_collapse/tests/test_tour.py
+++ b/website_sale_product_attribute_filter_collapse/tests/test_tour.py
@@ -9,7 +9,7 @@ class WebsiteSaleProductAttributeFilterCollapseHttpCase(HttpCase):
     def setUp(self):
         super().setUp()
         self.attribute_category = self.env["product.attribute.category"].create(
-            {"name": "Test category", "website_folded": False}
+            {"name": "Test category"}
         )
         self.product_attribute = self.env["product.attribute"].create(
             {


### PR DESCRIPTION
website_folded is a field of the product.attribute.category model that is added in the website_sale_product_attribute_filter_category module.
website_sale_product_attribute_filter_collapse is an independent module and gives an error in this field, so the solution is to remove it when creating an attribute category in the tests.

cc @Tecnativa TT41385

@pedrobaeza @chienandalu please review this :)