### PR TITLE
[13.0][IMP] website_sale_b2x_alt_price: Add price without tax to the quotation in the portal

### DIFF
--- a/website_sale_b2x_alt_price/templates/product.xml
+++ b/website_sale_b2x_alt_price/templates/product.xml
@@ -42,4 +42,34 @@
             <p class="text-muted small" t-call="website_sale_b2x_alt_price.alt_price" />
         </xpath>
     </template>
+    <template
+        id="sale_order_portal_template"
+        inherit_id="sale.sale_order_portal_template"
+    >
+        <xpath expr="//t[@t-set='title']">
+            <t
+                t-if="env.user.has_group('account.group_show_line_subtotals_tax_included')"
+            >
+                <span
+                    id="b2c_alt_amount"
+                    t-field="sale_order.amount_untaxed"
+                    data-id="untaxed_amount"
+                /><small> (without taxes)</small>
+            </t>
+            <t t-else="">
+                 <h2 class="mb-0"><b
+                        t-field="sale_order.amount_untaxed"
+                        data-id="untaxed_amount"
+                    /> </h2>
+                 <span
+                    id="b2b_alt_amount"
+                    t-field="sale_order.amount_total"
+                    data-id="total_amount"
+                /><small> (with taxes)</small>
+            </t>
+        </xpath>
+        <xpath expr="//span[@id='b2c_alt_amount']" position="before">
+            <xpath expr="//t[@t-set='title']/h2" position="move" />
+        </xpath>
+    </template>
 </data>


### PR DESCRIPTION
When a customer accesses a quotation the first price they see is tax included. This can be commercially negative and therefore the option to display the price both with and without taxes is added. Highlighting one price or the other depending on the b2b or b2c options.

Default view:
![image](https://user-images.githubusercontent.com/118818446/234246639-726e1485-433a-484b-bcc9-2f486ceccc94.png)

Alternative (un)taxed price option enabled in customize:

b2b
![image](https://user-images.githubusercontent.com/118818446/234246958-8ca461dc-d0f7-4996-b682-e1e3990e53bb.png)

b2c
![image](https://user-images.githubusercontent.com/118818446/234247253-cde16110-785b-4709-b4aa-509cb97456a2.png)


cc @Tecnativa TT42540

@pedrobaeza @CarlosRoca13 please review