### PR TITLE
[16.0][FIX] website_sale_product_attribute_value_filter_existing: match signature

### DIFF
--- a/website_sale_product_attribute_value_filter_existing/controllers/main.py
+++ b/website_sale_product_attribute_value_filter_existing/controllers/main.py
@@ -9,8 +9,25 @@ from odoo.addons.website_sale.controllers.main import WebsiteSale
 
 class ProductAttributeValues(WebsiteSale):
     @http.route()
-    def shop(self, page=0, category=None, search="", ppg=False, **post):
-        res = super().shop(page=page, category=category, search=search, ppg=ppg, **post)
+    def shop(
+        self,
+        page=0,
+        category=None,
+        search="",
+        min_price=0.0,
+        max_price=0.0,
+        ppg=False,
+        **post
+    ):
+        res = super().shop(
+            page=page,
+            category=category,
+            search=search,
+            min_price=min_price,
+            max_price=max_price,
+            ppg=ppg,
+            **post
+        )
 
         # getting existing templates by "search_product" in qcontext
         # without searching again


### PR DESCRIPTION
match the function signature of shop with the original one from website_sale, to avoid potential issues with other modules overwriting the function and passing unexpected parameters