### PR TITLE
[16.0][FIX] website_sale_hide_price: show alert when price is hidden

### DIFF
--- a/website_sale_hide_price/views/website_sale_template.xml
+++ b/website_sale_hide_price/views/website_sale_template.xml
@@ -38,10 +38,10 @@
             >pricelist,product,website,website.website_show_price,product.website_hide_price</attribute>
         </xpath>
         <xpath expr="//a[@id='add_to_cart']" position="before">
-            <t t-set="user_authenticated" t-value="user_id != website.user_id" />
             <div
                 class="alert alert-info"
-                t-if="product.website_hide_price and (product.website_hide_price_message or website.website_hide_price_default_message) and user_authenticated"
+                t-if="(product.website_hide_price_message or website.website_hide_price_default_message)
+                 and not (website and website.website_show_price and not product.website_hide_price)"
             >
                 <i class="fa fa-info-circle" /> <span
                     t-esc="product.website_hide_price_message or website.website_hide_price_default_message"


### PR DESCRIPTION
When the price is hidden on the website, we have a field in both the `website` and `product.template` model about why it is hidden. But this alert is not visible in the frontend even if the price is hidden because it has the wrong condition.

To reproduce the error:
1- Hide prices to Public User.
2- Define a price hidden alert on the website in general settings.
3- Check the product price and the alert.


In this PR I believe I have solved the error, I am checking if the alert is defined and if the price is currently hidden.
