### PR TITLE
[14.0][IMP][FIX] website_sale_product_assortment: handle multiple assortments

### DIFF
--- a/website_sale_product_assortment/controllers/variant.py
+++ b/website_sale_product_assortment/controllers/variant.py
@@ -21,21 +21,21 @@ class WebsiteSaleVariantController(VariantController):
         """
         res = []
         templates = request.env["product.template"].sudo().browse(product_template_ids)
-        not_allowed_product_dict = templates.get_product_assortment_restriction_info(
-            templates.mapped("product_variant_ids.id")
+        (
+            assortments,
+            restricted_product_ids,
+        ) = templates.get_product_assortment_restriction_info(
+            templates.product_variant_ids.ids
         )
+        if not assortments:
+            return res
         for template in templates:
             variant_ids = set(template.product_variant_ids.ids)
-            if (
-                variant_ids
-                and variant_ids & set(not_allowed_product_dict.keys()) == variant_ids
-            ):
+            if variant_ids and variant_ids & restricted_product_ids == variant_ids:
                 res.append(
                     {
                         "id": template.id,
-                        "message_unavailable": not_allowed_product_dict[
-                            variant_ids.pop()
-                        ][0].message_unavailable
+                        "message_unavailable": assortments[0].message_unavailable
                         or _("Not available"),
                     }
                 )

--- a/website_sale_product_assortment/readme/CONTRIBUTORS.rst
+++ b/website_sale_product_assortment/readme/CONTRIBUTORS.rst
@@ -5,3 +5,6 @@
 
 * `Ooops <https://www.ooops404.com>`_:
     * Ashish Hirpara (https://ashish-hirpara.com)
+
+* `PyTech SRL <https://www.pytech.it>`_:
+    * Alessandro Uffreduzzi

--- a/website_sale_product_assortment/static/src/js/no_show_multifilter_tour.js
+++ b/website_sale_product_assortment/static/src/js/no_show_multifilter_tour.js
@@ -1,0 +1,36 @@
+/* Copyright 2021 Tecnativa - Carlos Roca
+   License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). */
+odoo.define("website_sale_product_assortment.tour_no_show_multifilter", function (
+    require
+) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+    var base = require("web_editor.base");
+
+    var steps = [
+        {
+            trigger: "a[href='/shop']",
+            extra_trigger:
+                ".o_wsale_product_grid_wrapper:has(a:contains('Test Product 1'))",
+        },
+        {
+            trigger: "a[href='/shop']",
+            extra_trigger:
+                ".o_wsale_product_grid_wrapper:has(a:contains('Test Product 2'))",
+        },
+    ];
+
+    tour.register(
+        "test_assortment_with_no_show_multifilter",
+        {
+            url: "/shop",
+            test: true,
+            wait_for: base.ready(),
+        },
+        steps
+    );
+    return {
+        steps: steps,
+    };
+});

--- a/website_sale_product_assortment/templates/assets.xml
+++ b/website_sale_product_assortment/templates/assets.xml
@@ -28,6 +28,10 @@
                 type="text/javascript"
                 src="/website_sale_product_assortment/static/src/js/no_show_tour.js"
             />
+            <script
+                type="text/javascript"
+                src="/website_sale_product_assortment/static/src/js/no_show_multifilter_tour.js"
+            />
         </xpath>
     </template>
 </odoo>

--- a/website_sale_product_assortment/tests/__init__.py
+++ b/website_sale_product_assortment/tests/__init__.py
@@ -1,1 +1,2 @@
+from . import test_product_assortment
 from . import test_ui

--- a/website_sale_product_assortment/tests/test_product_assortment.py
+++ b/website_sale_product_assortment/tests/test_product_assortment.py
@@ -1,0 +1,121 @@
+from odoo.tests import SavepointCase
+
+
+class TestProductAssortment(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.admin_user = cls.env.ref("base.user_admin")
+        cls.assortment_model = cls.env["ir.filters"]
+        cls.product = cls.env["product.template"].create(
+            {
+                "name": "Test Product 1",
+                "is_published": True,
+                "website_sequence": 1,
+                "type": "consu",
+            }
+        )
+
+    def get_product_combination_info(self):
+        return (
+            self.product.with_user(self.admin_user)
+            .with_context(website_id=1)
+            ._get_combination_info(product_id=self.product.id)
+        )
+
+    def test_combination_info_no_assortment(self):
+        info = self.get_product_combination_info()
+        self.assertFalse(info.get("product_avoid_purchase"))
+        self.assertFalse(info.get("product_assortment_type"))
+        self.assertFalse(info.get("message_unavailable"))
+        self.assertFalse(info.get("assortment_information"))
+
+    def test_combination_info_assortment_includes_product(self):
+        self.assortment_model.create(
+            {
+                "name": "Test Assortment",
+                "model_id": "product.product",
+                "is_assortment": True,
+                "domain": [("type", "=", "consu")],
+                "partner_domain": [("id", "=", self.admin_user.partner_id.id)],
+                "website_availability": "no_show",
+            }
+        )
+
+        info = self.get_product_combination_info()
+        self.assertFalse(info.get("product_avoid_purchase"))
+        self.assertFalse(info.get("product_assortment_type"))
+        self.assertFalse(info.get("message_unavailable"))
+        self.assertFalse(info.get("assortment_information"))
+
+    def test_combination_info_assortment_excludes_product_no_show(self):
+        self.assortment_model.create(
+            {
+                "name": "Test Assortment",
+                "model_id": "product.product",
+                "is_assortment": True,
+                "domain": [("type", "=", "service")],
+                "partner_domain": [("id", "=", self.admin_user.partner_id.id)],
+                "website_availability": "no_show",
+            }
+        )
+
+        info = self.get_product_combination_info()
+        self.assertEqual(info.get("product_avoid_purchase"), True)
+        self.assertEqual(info.get("product_assortment_type"), "no_show")
+        self.assertFalse(info.get("message_unavailable"))
+        self.assertFalse(info.get("assortment_information"))
+
+    def test_combination_info_assortment_excludes_product_no_purchase(self):
+        message_unavailable = "<p>My Message Unavailable</p>"
+        assortment_information = "<p>My Assortment Info</p>"
+        self.assortment_model.create(
+            {
+                "name": "Test Assortment",
+                "model_id": "product.product",
+                "is_assortment": True,
+                "domain": [("type", "=", "service")],
+                "partner_domain": [("id", "=", self.admin_user.partner_id.id)],
+                "website_availability": "no_purchase",
+                "message_unavailable": message_unavailable,
+                "assortment_information": assortment_information,
+            }
+        )
+
+        info = self.get_product_combination_info()
+        self.assertEqual(info.get("product_avoid_purchase"), True)
+        self.assertEqual(info.get("product_assortment_type"), "no_purchase")
+        self.assertEqual(info.get("message_unavailable"), message_unavailable)
+        self.assertEqual(info.get("assortment_information"), assortment_information)
+
+    def test_combination_info_multiple_assortment_exclude_product(self):
+        message_unavailable = "<p>My Message Unavailable</p>"
+        assortment_information = "<p>My Assortment Info</p>"
+        self.assortment_model.create(
+            {
+                "name": "Test Assortment 1",
+                "model_id": "product.product",
+                "is_assortment": True,
+                "domain": [("id", "=", 1)],
+                "partner_domain": [("id", "=", self.admin_user.partner_id.id)],
+                "website_availability": "no_show",
+            }
+        )
+        self.assortment_model.create(
+            {
+                "name": "Test Assortment 2",
+                "model_id": "product.product",
+                "is_assortment": True,
+                "domain": [("type", "=", "service")],
+                "partner_domain": [("id", "=", self.admin_user.partner_id.id)],
+                "website_availability": "no_purchase",
+                "message_unavailable": message_unavailable,
+                "assortment_information": assortment_information,
+            }
+        )
+
+        info = self.get_product_combination_info()
+        self.assertEqual(info.get("product_avoid_purchase"), True)
+        self.assertEqual(info.get("product_assortment_type"), "no_show")
+        self.assertFalse(info.get("message_unavailable"))
+        self.assertFalse(info.get("assortment_information"))

--- a/website_sale_product_assortment/tests/test_ui.py
+++ b/website_sale_product_assortment/tests/test_ui.py
@@ -1,8 +1,9 @@
 # Copyright 2021 Tecnativa - Carlos Roca
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-from odoo.tests.common import HttpCase
+from odoo.tests import HttpCase, tagged
 
 
+@tagged("post_install", "-at_install")
 class TestUI(HttpCase):
     def setUp(self):
         super().setUp()
@@ -12,6 +13,14 @@ class TestUI(HttpCase):
                 "is_published": True,
                 "website_sequence": 1,
                 "type": "consu",
+            }
+        )
+        self.product_service = self.env["product.template"].create(
+            {
+                "name": "Test Product 2",
+                "is_published": True,
+                "website_sequence": 1,
+                "type": "service",
             }
         )
 
@@ -60,3 +69,30 @@ class TestUI(HttpCase):
             }
         )
         self.start_tour("/shop", "test_assortment_with_no_purchase", login="admin")
+
+    def test_04_ui_no_show_multifilter(self):
+        self.env["ir.filters"].create(
+            {
+                "name": "Assortment Service",
+                "model_id": "product.product",
+                "is_assortment": True,
+                "domain": [("type", "=", "service")],
+                "partner_domain": "[('id', '=', %s)]"
+                % self.env.ref("base.partner_admin").id,
+                "website_availability": "no_show",
+            }
+        )
+        self.env["ir.filters"].create(
+            {
+                "name": "Assortment Consu",
+                "model_id": "product.product",
+                "is_assortment": True,
+                "domain": [("type", "=", "consu")],
+                "partner_domain": "[('id', '=', %s)]"
+                % self.env.ref("base.partner_admin").id,
+                "website_availability": "no_show",
+            }
+        )
+        self.start_tour(
+            "/shop", "test_assortment_with_no_show_multifilter", login="admin"
+        )


### PR DESCRIPTION
This commit changes the way multiple assortments are handled and fixes a couple of bugs in the process.

The current version of the module is not able to handle multiple assortments, especially ones that are exclusive (e.g. one assortment with all consumable products and one with all services) and the module seemingly breaks, ignoring the selected rule (e.g. no_show)

With these changes, that behaviour is fixed, and additionally assortments for the same website and partner are merged in a logical OR.