### PR TITLE
[14.0][FIX] website_sale_invoice_address: fix failing test

### DIFF
--- a/website_sale_invoice_address/static/src/js/website_sale_invoice_address_tour.js
+++ b/website_sale_invoice_address/static/src/js/website_sale_invoice_address_tour.js
@@ -8,7 +8,7 @@ odoo.define("website_sale_invoice_address.tour", function (require) {
 
     var steps = [
         {
-            trigger: "a:contains('Large Meeting Table')",
+            trigger: "a:contains('Large Cabinet')",
         },
         {
             trigger: "a:contains('Add to Cart')",


### PR DESCRIPTION
Somehow over time the product "Large Meeting Table" fell into the second page, so it couldn't be found in the main page and the test failed, affecting all other v14 PRs