### PR TITLE
[16.0][FIX] website_sale_cart_expire: Protect _setExpirationDate

### DIFF
--- a/website_sale_cart_expire/readme/CONTRIBUTORS.rst
+++ b/website_sale_cart_expire/readme/CONTRIBUTORS.rst
@@ -1,3 +1,4 @@
 * `Camptocamp <https://www.camptocamp.com>`_
 
      * Iván Todorovich <ivan.todorovich@gmail.com>
+     * Pablo De Andrés <pablo.deandres@factorlibre.com>

--- a/website_sale_cart_expire/static/src/js/website_sale_cart_expire.js
+++ b/website_sale_cart_expire/static/src/js/website_sale_cart_expire.js
@@ -44,8 +44,10 @@ odoo.define("website_sale_cart_expire", (require) => {
          * @param {String|Date} expireDate
          */
         _setExpirationDate: function (expireDate) {
-            if (typeof expireDate === "string") {
+            if (typeof expireDate === "string" && !isNaN(Date.parse(expireDate))) {
                 expireDate = time.str_to_datetime(expireDate);
+            } else {
+                expireDate = undefined;
             }
             this.expireDate = expireDate ? moment(expireDate) : false;
         },


### PR DESCRIPTION
Protect _setExpirationDate assignment error,  added format check before setting the datetime in _str_to_datetime_ in order to avoid error message in website.

It checks "/shop/cart/get_expire_date" url to retrieve the information, but when it's installed some module that restricts the access to some url (like website_require_login) it retrieves HTML from the redirection.

Function evaluates "expireDate" as string and tries to convert it to datetime, but it's not a date so raises throws error.

Now checks if the string has a valid format date before try to convert it otherwise sets "expireDate" to undefined.