### PR TITLE
[16.0][ADD] website_sale_product_contract_restrict_cart: add new module

### DIFF
--- a/setup/website_sale_product_contract_restrict_cart/odoo/addons/website_sale_product_contract_restrict_cart
+++ b/setup/website_sale_product_contract_restrict_cart/odoo/addons/website_sale_product_contract_restrict_cart
@@ -1,0 +1,1 @@
+../../../../website_sale_product_contract_restrict_cart

--- a/setup/website_sale_product_contract_restrict_cart/setup.py
+++ b/setup/website_sale_product_contract_restrict_cart/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/website_sale_product_contract_restrict_cart/__init__.py
+++ b/website_sale_product_contract_restrict_cart/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/website_sale_product_contract_restrict_cart/__manifest__.py
+++ b/website_sale_product_contract_restrict_cart/__manifest__.py
@@ -1,0 +1,19 @@
+# Copyright 2023 Onestein- Anjeel Haria
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+
+{
+    "name": "Website Sale Product Contract Cart",
+    "summary": "Restricts contracted products from being added with other products in the cart",
+    "version": "16.0.1.0.0",
+    "category": "Website",
+    "website": "https://github.com/OCA/e-commerce",
+    "author": "Onestein, Odoo Community Association (OCA)",
+    "license": "LGPL-3",
+    "installable": True,
+    "depends": ["website_sale", "product_contract"],
+    "assets": {
+        "web.assets_frontend": [
+            "website_sale_product_contract_restrict_cart/static/src/js/website_sale_utils.js",
+        ],
+    },
+}

--- a/website_sale_product_contract_restrict_cart/models/__init__.py
+++ b/website_sale_product_contract_restrict_cart/models/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_order

--- a/website_sale_product_contract_restrict_cart/models/sale_order.py
+++ b/website_sale_product_contract_restrict_cart/models/sale_order.py
@@ -1,0 +1,90 @@
+# Copyright 2023 Onestein - Anjeel Haria
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import _, models
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    def _get_contract_product_in_cart(self):
+        return self.order_line.product_id.filtered(lambda product: product.is_contract)
+
+    def _cart_update(
+        self, product_id=None, line_id=None, add_qty=0, set_qty=0, **kwargs
+    ):
+        """Remove unwanted order lines from cart."""
+        values = super(SaleOrder, self)._cart_update(
+            product_id, line_id, add_qty, set_qty, **kwargs
+        )
+        product = self.env["product.product"].browse(product_id)
+        order_line = self.env["sale.order.line"]
+        if product:
+            contract_product_in_order_line = self._get_contract_product_in_cart()
+            if (
+                product.is_contract
+                and contract_product_in_order_line
+                and product != contract_product_in_order_line[0]
+            ):
+                # If contracted products are available in the cart, remove other
+                # contract products from the cart
+                order_line = self.order_line.filtered(lambda x: x.product_id == product)
+            elif (
+                contract_product_in_order_line and not product.is_contract
+            ) or product.is_contract:
+                # If any non-contracted products available in the cart, remove those
+                # products from the cart
+                order_line = self.order_line.filtered(
+                    lambda x: not x.product_id.is_contract
+                )
+        if order_line:
+            order_line.unlink()
+        return values
+
+    def _verify_updated_quantity(self, order_line, product_id, new_qty, **kwargs):
+        """Forbid quantity update on contract product lines and restrict purchase of
+        non contract products with contract products and allow purchase of only a
+        single contract product at a time."""
+        product = self.env["product.product"].browse(product_id)
+        contract_product_in_order_line = self._get_contract_product_in_cart()
+        if contract_product_in_order_line and not product.is_contract and new_qty > 0:
+            return 0, _(
+                "Important Notice: It is not possible to make a purchase that includes"
+                " both a contract and a regular product simultaneously.Please purchase"
+                " these separately."
+            )
+        elif product.is_contract:
+            if (
+                contract_product_in_order_line
+                and product != contract_product_in_order_line[0]
+            ):
+                return 0, _(
+                    "Important Notice: There's already another contract product in the"
+                    " cart, you can purchase only one contract product at a time"
+                )
+            else:
+                warning_msg = ""
+                if new_qty > 1:
+                    warning_msg = (
+                        "Important Notice: You cannot have quantity more than 1 for "
+                        "contract product in the cart!"
+                    )
+                order_line = self.order_line.filtered(
+                    lambda x: not x.product_id.is_contract
+                )
+                if order_line:
+                    if warning_msg:
+                        warning_msg += (
+                            "Also,your previous cart items are removed from your cart"
+                            " as you are buying a contract product!"
+                        )
+                    else:
+                        warning_msg = (
+                            "Important Notice: Your previous cart items are removed "
+                            "from your cart as you are buying a contract product!"
+                        )
+                if warning_msg:
+                    return 1, _(warning_msg)
+        return super()._verify_updated_quantity(
+            order_line, product_id, new_qty, **kwargs
+        )

--- a/website_sale_product_contract_restrict_cart/readme/CONTRIBUTORS.rst
+++ b/website_sale_product_contract_restrict_cart/readme/CONTRIBUTORS.rst
@@ -1,0 +1,3 @@
+* `Onestein <https://www.onestein.nl>`_:
+
+  * Anjeel Haria

--- a/website_sale_product_contract_restrict_cart/readme/DESCRIPTION.rst
+++ b/website_sale_product_contract_restrict_cart/readme/DESCRIPTION.rst
@@ -1,0 +1,9 @@
+This module restricts users from adding contract products along with other regular products.
+
+When a contract product is already present in cart and users try to add other regular products,the regular products would not be added to the cart and a warning would be shown that you cannot purchase contract and regular products together on product page.
+
+When a regular product is already present in the cart and users try to add contract products, then the regular products would be removed from the cart and a warning would be displayed on product page.
+
+When you try to buy more than 1 quantity of a contract product,the quantity would be set to 1 and a warning would be shown that you cannot buy more than 1 quantity of contract products on product or cart page.
+
+When a contract product is already present in cart and users try to add other contract products,the other contract products would not be added to the cart and a warning would be shown that there's already another contract product in the cart, you can purchase only one contract product at a time on product page.

--- a/website_sale_product_contract_restrict_cart/static/src/js/website_sale_utils.js
+++ b/website_sale_product_contract_restrict_cart/static/src/js/website_sale_utils.js
@@ -1,0 +1,46 @@
+/* Copyright 2023 Onestein - Anjeel Haria
+ * License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl). */
+odoo.define(
+    "website_sale_product_contract_cart.website_sale_utils",
+    function (require) {
+        "use strict";
+
+        const wsUtils = require("website_sale.utils");
+        const cartHandlerMixin = {
+            _addToCartInPage(params) {
+                params.force_create = true;
+                return this._rpc({
+                    route: "/shop/cart/update_json",
+                    params: params,
+                }).then(async (data) => {
+                    sessionStorage.setItem(
+                        "website_sale_cart_quantity",
+                        data.cart_quantity
+                    );
+                    if (
+                        data.cart_quantity &&
+                        data.cart_quantity !== parseInt($(".my_cart_quantity").text())
+                    ) {
+                        if ($("div[data-image_width]").data("image_width") !== "none") {
+                            await wsUtils.animateClone(
+                                $("header .o_wsale_my_cart").first(),
+                                this.$itemImgContainer,
+                                25,
+                                40
+                            );
+                        }
+                        wsUtils.updateCartNavBar(data);
+                    }
+                    if (data.warning) {
+                        wsUtils.showWarning(data.warning);
+                    }
+                });
+            },
+        };
+
+        wsUtils.cartHandlerMixin = {
+            ...wsUtils.cartHandlerMixin,
+            ...cartHandlerMixin,
+        };
+    }
+);

--- a/website_sale_product_contract_restrict_cart/tests/__init__.py
+++ b/website_sale_product_contract_restrict_cart/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_website_sale_product_contract_restrict_cart

--- a/website_sale_product_contract_restrict_cart/tests/test_website_sale_product_contract_restrict_cart.py
+++ b/website_sale_product_contract_restrict_cart/tests/test_website_sale_product_contract_restrict_cart.py
@@ -1,0 +1,126 @@
+# Copyright 2023 Onestein - Anjeel Haria
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo.tests.common import TransactionCase, tagged
+
+from odoo.addons.website.tools import MockRequest
+from odoo.addons.website_sale.controllers.main import WebsiteSale
+
+
+@tagged("post_install", "-at_install")
+class WebsiteSaleCart(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super(WebsiteSaleCart, cls).setUpClass()
+        cls.website = cls.env["website"].browse(1)
+        cls.WebsiteSaleController = WebsiteSale()
+        cls.contract = cls.env["contract.template"].create({"name": "Test"})
+        # Create two contract products
+        cls.product_A = cls.env["product.product"].create(
+            {
+                "name": "Product A",
+                "sale_ok": True,
+                "website_published": True,
+                "is_contract": True,
+                "type": "service",
+                "property_contract_template_id": cls.contract.id,
+            }
+        )
+
+        cls.product_B = cls.env["product.product"].create(
+            {
+                "name": "Product B",
+                "sale_ok": True,
+                "website_published": True,
+                "is_contract": True,
+                "type": "service",
+                "property_contract_template_id": cls.contract.id,
+            }
+        )
+        # Create Non contract product
+        cls.product_C = cls.env["product.product"].create(
+            {
+                "name": "Product B",
+                "sale_ok": True,
+                "website_published": True,
+            }
+        )
+
+    def test_add_cart_contract_product_with_multiple_quantity(self):
+        """When the users try to add contract product with quantity more than 1 to
+        their cart , a warning should be returned and the quantity updated to 0."""
+        with MockRequest(self.env, website=self.website):
+            values = self.WebsiteSaleController.cart_update_json(
+                product_id=self.product_A.id, add_qty=2
+            )
+            self.assertTrue(values.get("warning", False))
+            self.assertEqual(values.get("quantity"), 1)
+
+    def test_add_contract_product_to_cart_with_other_contract_product(self):
+        """When the users try to add more than one different contract products to
+        their cart , a warning should be returned and the quantity updated to 0."""
+        with MockRequest(self.env, website=self.website):
+            self.WebsiteSaleController.cart_update_json(
+                product_id=self.product_A.id, add_qty=1
+            )
+            values = self.WebsiteSaleController.cart_update_json(
+                product_id=self.product_B.id, add_qty=1
+            )
+            self.assertTrue(values.get("warning", False))
+            self.assertEqual(values.get("quantity"), 0)
+            sale_order = self.website.sale_get_order()
+            # Only one order line would be there in the cart
+            self.assertEqual(len(sale_order.order_line), 1)
+
+    def test_add_non_contract_product_to_cart_with_contract_product(self):
+        """When the users try to add non contract products to their cart which
+        already has contract products,a warning should be returned and the quantity
+        updated to 0."""
+        with MockRequest(self.env, website=self.website):
+            self.WebsiteSaleController.cart_update_json(
+                product_id=self.product_A.id, add_qty=1
+            )
+            values = self.WebsiteSaleController.cart_update_json(
+                product_id=self.product_C.id, add_qty=1
+            )
+            self.assertTrue(values.get("warning", False))
+            self.assertEqual(values.get("quantity"), 0)
+            sale_order = self.website.sale_get_order()
+            # Only one order line would be there in the cart
+            self.assertEqual(len(sale_order.order_line), 1)
+
+    def test_add_contract_product_to_cart_with_non_contract_product(self):
+        """When the users try to add contract products to their cart which already has
+        non contract products,a warning should be returned and the quantity updated
+        to 1."""
+        with MockRequest(self.env, website=self.website):
+            self.WebsiteSaleController.cart_update_json(
+                product_id=self.product_C.id, add_qty=1
+            )
+            values = self.WebsiteSaleController.cart_update_json(
+                product_id=self.product_A.id, add_qty=1
+            )
+            self.assertTrue(values.get("warning", False))
+            self.assertEqual(values.get("quantity"), 1)
+            sale_order = self.website.sale_get_order()
+            # Only one order line would be there in the cart
+            self.assertEqual(len(sale_order.order_line), 1)
+
+    def test_add_contract_product_with_multiple_qty_to_cart_with_non_contract_product(
+        self,
+    ):
+        """When the users try to add contract products with more than 1 quantity to
+        their cart which already has non contract products,a warning should be returned
+         and the quantity updated to 1."""
+        with MockRequest(self.env, website=self.website):
+            self.WebsiteSaleController.cart_update_json(
+                product_id=self.product_C.id, add_qty=1
+            )
+            values = self.WebsiteSaleController.cart_update_json(
+                product_id=self.product_A.id, add_qty=2
+            )
+            self.assertTrue(values.get("warning", False))
+            self.assertEqual(values.get("quantity"), 1)
+            sale_order = self.website.sale_get_order()
+            # Only one order line would be there in the cart
+            self.assertEqual(len(sale_order.order_line), 1)


### PR DESCRIPTION
This module restricts the use of contract products with other products so as to setup recurring payments with third party providers like mollie ,paypal etc. Without this module, it may cause problems while setting up mandates (for recurring payments)with third party providers