### PR TITLE
[16.0][FIX] website_sale_checkout_skip_payment: Fix test by adding the vat

### DIFF
--- a/website_sale_checkout_skip_payment/tests/test_checkout_skip_payment.py
+++ b/website_sale_checkout_skip_payment/tests/test_checkout_skip_payment.py
@@ -11,6 +11,8 @@ class WebsiteSaleHttpCase(odoo.tests.HttpCase):
         super().setUp()
         # Active skip payment for Mitchel Admin
         self.partner = self.env.ref("base.partner_admin")
+        # VAT required by the module website_sale_vat_required
+        self.partner.vat = "US01234567891"
         self.partner.with_context(**{"res_partner_search_mode": "customer"}).write(
             {"skip_website_checkout_payment": True}
         )


### PR DESCRIPTION
Tests for this module fail when website_sale_vat_requires is installed because VAT is required by this module.

cc @Tecnativa TT44388

@chienandalu @CarlosRoca13 please review :)