### PR TITLE
[15.0][FIX]website_sale_invoice_address: One of the elements in the tour test cannot be found using the current repository

### DIFF
--- a/website_sale_invoice_address/static/src/js/website_sale_invoice_address_tour.js
+++ b/website_sale_invoice_address/static/src/js/website_sale_invoice_address_tour.js
@@ -24,7 +24,7 @@ odoo.define("website_sale_invoice_address.tour", function (require) {
     tour.register(
         "website_sale_invoice_address_tour",
         {
-            url: "/shop",
+            url: "/shop?search=Large%20Meeting%20Table",
             test: true,
         },
         steps


### PR DESCRIPTION
With the current modules in this repository, the <a> element containing "Large Meeting Table" cannot be found, as it is placed in page /shop/2 (and not in page /shop).

With this fix, a different product placed in page /shop is used in the test tour.