### PR TITLE
[15.0][FIX] website_sale_checkout_skip_payment: order confirmation

### DIFF
--- a/website_sale_checkout_skip_payment/__manifest__.py
+++ b/website_sale_checkout_skip_payment/__manifest__.py
@@ -20,8 +20,8 @@
         "views/res_config_settings_views.xml",
     ],
     "assets": {
-        "web.assets_frontend": [
-            "website_sale_checkout_skip_payment/static/src/js/*.js",
+        "web.assets_tests": [
+            "website_sale_checkout_skip_payment/static/src/tests/tours/**/*.js",
         ],
     },
 }

--- a/website_sale_checkout_skip_payment/controllers/main.py
+++ b/website_sale_checkout_skip_payment/controllers/main.py
@@ -1,19 +1,16 @@
 # Copyright 2017 Sergio Teruel <sergio.teruel@tecnativa.com>
 # Copyright 2017 David Vidal <david.vidal@tecnativa.com>
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+from odoo.http import request, route
 
-from odoo import http
-from odoo.http import request
-
-from odoo.addons.payment.controllers.portal import PaymentPortal
 from odoo.addons.website_sale.controllers.main import WebsiteSale
 
 
 class CheckoutSkipPaymentWebsite(WebsiteSale):
-    @http.route()
+    @route()
     def shop_payment_get_status(self, sale_order_id, **post):
-        # When skip payment step, the transaction not exists so only render
-        # the waiting message in ajax json call
+        """When skip payment step, the transaction not exists so only render the waiting
+        message in ajax json call"""
         if not request.website.checkout_skip_payment:
             return super().shop_payment_get_status(sale_order_id, **post)
         return {
@@ -23,23 +20,24 @@ class CheckoutSkipPaymentWebsite(WebsiteSale):
             ),
         }
 
-
-class CheckoutSkipPayment(PaymentPortal):
-    @http.route()
-    def payment_confirm(self, tx_id, access_token, **kwargs):
-        if not request.website.checkout_skip_payment:
-            return super().payment_confirm(tx_id, access_token, **kwargs)
-        order = (
-            request.env["sale.order"]
-            .sudo()
-            .browse(request.session.get("sale_last_order_id"))
-        )
-        order.action_confirm()
+    @route()
+    def shop_payment_confirmation(self, **post):
+        """When we skip the payment, we'll just confirm the order and send the proper
+        confirmation message"""
+        order_id = request.session.get("sale_last_order_id")
+        if not request.website.checkout_skip_payment or not order_id:
+            return super().shop_payment_confirmation(**post)
+        order = request.env["sale.order"].sudo().browse(order_id)
         try:
-            order._send_order_confirmation_mail()
+            order.with_context(mark_so_as_sent=True)._send_order_confirmation_mail()
         except Exception:
             return request.render(
                 "website_sale_checkout_skip_payment.confirmation_order_error"
             )
+        # This could not finish (e.g.: sale_financial_risk exceeded)
+        order.action_confirm()
         request.website.sale_reset()
-        return request.render("website_sale.confirmation", {"order": order})
+        return request.render(
+            "website_sale.confirmation",
+            {"order": order, "order_tracking_info": self.order_2_return_dict(order)},
+        )

--- a/website_sale_checkout_skip_payment/static/src/tests/tours/website_sale_checkout_skip_payment_tour.js
+++ b/website_sale_checkout_skip_payment/static/src/tests/tours/website_sale_checkout_skip_payment_tour.js
@@ -4,8 +4,7 @@
 odoo.define("website_sale_checkout_skip_payment.tour", function (require) {
     "use strict";
 
-    var tour = require("web_tour.tour");
-    var base = require("web_editor.base");
+    const tour = require("web_tour.tour");
 
     var steps = [
         {
@@ -35,7 +34,6 @@ odoo.define("website_sale_checkout_skip_payment.tour", function (require) {
         {
             url: "/shop",
             test: true,
-            wait_for: base.ready(),
         },
         steps
     );


### PR DESCRIPTION
The module wasn't working as expected and the orders weren't confirmed and the emails weren't sent notifying the salesmen.

Also we provide some compatibility with module like sale_financial_risk which will avoid confirming order when the partner risk is exceeded so we can just let them as sent.

cc @Tecnativa TT45113

please review @CarlosRoca13 @pilarvargas-tecnativa 