### PR TITLE
[15.0][FIX]website_account_fiscal_position_partner_type: Translated account fiscal positions in portal

### DIFF
--- a/website_account_fiscal_position_partner_type/controllers/main.py
+++ b/website_account_fiscal_position_partner_type/controllers/main.py
@@ -78,7 +78,9 @@ class WebsiteSale(WebsiteSale):
                     {
                         "def_fiscpostype": def_fiscpostype,
                         "fiscpostypevalues": dict(
-                            afp_obj._fields["fiscal_position_type"].selection
+                            afp_obj._fields[
+                                "fiscal_position_type"
+                            ]._description_selection(request.env)
                         ),
                     }
                 )
@@ -93,7 +95,7 @@ class AuthSignupHome(AuthSignupHome):
         )
         afp_obj = request.env["account.fiscal.position"].sudo()
         qcontext["fiscpostypevalues"] = dict(
-            afp_obj._fields["fiscal_position_type"].selection
+            afp_obj._fields["fiscal_position_type"]._description_selection(request.env)
         )
         if not qcontext.get("fiscal_position_type_selected"):
             def_fiscpostype = (

--- a/website_account_fiscal_position_partner_type/controllers/portal.py
+++ b/website_account_fiscal_position_partner_type/controllers/portal.py
@@ -36,7 +36,9 @@ class CustomerPortal(CustomerPortal):
         vals.update(
             {
                 "fiscpostypevalues": dict(
-                    afp_obj._fields["fiscal_position_type"].selection
+                    afp_obj._fields["fiscal_position_type"]._description_selection(
+                        request.env
+                    )
                 ),
                 "fiscal_position_type_selected": partner.fiscal_position_type,
             }


### PR DESCRIPTION
With the current module, the account fiscal positions are not translated in portal. This fix sorts this issue out.