### PR TITLE
[14.0][IMP] Query performance for shop route in website_sale_filter_p…

### DIFF
--- a/website_sale_filter_product_brand/controllers/website_sale.py
+++ b/website_sale_filter_product_brand/controllers/website_sale.py
@@ -90,6 +90,24 @@ class Website(WebsiteSale):
         )
         brands = self._remove_extra_brands(brands, search_products, attrib_values)
 
+        # use search() domain instead of mapped() for better performance:
+        # will basically search for product's related attribute values
+        attrib_valid_ids = (
+            request.env["product.attribute.value"]
+            .search(
+                [
+                    "&",
+                    (
+                        "pav_attribute_line_ids.product_tmpl_id",
+                        "in",
+                        search_products._ids,
+                    ),
+                    ("pav_attribute_line_ids.value_ids", "!=", False),
+                ]
+            )
+            .ids
+        )
+
         # keep selected brands in URL
         keep = QueryURL(
             "/shop",
@@ -105,9 +123,7 @@ class Website(WebsiteSale):
             {
                 "brands": brands,
                 "selected_brand_ids": selected_brand_ids,
-                "attr_valid": search_products.mapped(
-                    "attribute_line_ids.value_ids"
-                ).ids,
+                "attr_valid": attrib_valid_ids,
                 "keep": keep,
             }
         )


### PR DESCRIPTION
…roduct_brand

Fixes https://github.com/OCA/e-commerce/issues/792 in v14.0

## Additional context
   
Time difference between queries in our environments before and after commit
It's quite a big boost, I hope I am not missing something.

```
BEFORE COMMIT (using mapped)
INFO t1 odoo.addons.website_sale_filter_product_brand.controllers.website_sale: Time Perf Counter: 4.394335448043421

AFTER COMMIT (using search domain)
INFO t1 odoo.addons.website_sale_filter_product_brand.controllers.website_sale: Time Perf Counter: 0.10209001100156456
```