### PR TITLE
[16.0][FIX] website_sale_product_attribute_value_filter_existing: fix test to check the real functionality of the module

### DIFF
--- a/website_sale_product_attribute_value_filter_existing/static/src/js/website_sale_product_attribute_value_filter_existing_tour.esm.js
+++ b/website_sale_product_attribute_value_filter_existing/static/src/js/website_sale_product_attribute_value_filter_existing_tour.esm.js
@@ -8,26 +8,36 @@ tour.register(
         test: true,
         url: "/shop",
     },
+    // No product has the yellow colour attribute defined.
+    // When enter to "/shop" the attribute "test yellow" should not appear in the list of filters by attribute.
     [
+        // For the following steps it is checked that the attribute "test yellow" is
+        // not present in the list but the attributes "test red", "test blue" and
+        // "test green" must be present.
         {
-            content: "1: browse shop page",
+            content:
+                "Search a product. Ensure 'test red', 'test blue' and 'test green' attributes are present while 'Test yellow' is not.",
+            trigger: "form input[name=search]",
+            run: "text desk",
+            extra_trigger:
+                ".js_attributes:not(:contains('Test yellow')):has(label:contains('Test red')), .js_attributes:not(:contains('Test yellow')):has(label:contains('Test blue')), .js_attributes:not(:contains('Test yellow')):has(label:contains('Test green'))",
+        },
+        {
+            content:
+                "Submit search button. Ensure 'test red', 'test blue' and 'test green' attributes are present while 'Test yellow' is not.",
+            trigger: 'form:has(input[name="search"]) .oe_search_button',
+            extra_trigger:
+                ".js_attributes:not(:contains('Test yellow')):has(label:contains('Test red')), .js_attributes:not(:contains('Test yellow')):has(label:contains('Test blue')), .js_attributes:not(:contains('Test yellow')):has(label:contains('Test green'))",
+        },
+        // After searching, the attributes "test red" and "test green" must be present.
+        // "Test yelow" should not be present as it is not used in any product and
+        // "test blue" should not be present as it is not used in the products shown.
+        {
+            content:
+                "Go to /shop after the search. Ensure 'test red' and 'test green' attributes are present while 'Test yellow' and 'test blue' are not.",
             trigger: "a[href='/shop']",
-        },
-        {
-            content: "2: search a product",
-            trigger: "input[name=search]",
-            run: "text Ipod",
-            extra_trigger: ".js_attributes:has(label:contains('Test blue'))",
-        },
-        {
-            content: "3: submit search button",
-            trigger: ".oe_search_button",
-            extra_trigger: ".js_attributes:has(label:contains('Test blue'))",
-        },
-        {
-            content: "4: browse shop page after search",
-            trigger: "a[href='/shop']",
-            extra_trigger: ".js_attributes:not(:has(label:contains('Test blue')))",
+            extra_trigger:
+                ".js_attributes:not(:contains('Test blue'), :contains('Test yellow')):has(label:contains('Test green')), .js_attributes:not(:contains('Test blue'), :contains('Test yellow')):has(label:contains('Test red'))",
         },
     ]
 );

--- a/website_sale_product_attribute_value_filter_existing/tests/test_website_sale_product_attribute_value_filter_existing.py
+++ b/website_sale_product_attribute_value_filter_existing/tests/test_website_sale_product_attribute_value_filter_existing.py
@@ -23,6 +23,9 @@ class WebsiteSaleHttpCase(HttpCase):
         self.product_attribute_value_blue = ProductAttributeValue.create(
             {"name": "Test blue", "attribute_id": self.product_attribute.id}
         )
+        self.product_attribute_value_yelow = ProductAttributeValue.create(
+            {"name": "Test yellow", "attribute_id": self.product_attribute.id}
+        )
         self.product_template = self.env.ref(
             "product.product_product_4_product_template"
         )


### PR DESCRIPTION
The functionality of the module is that in the filters the attributes that are not being used in the products remain hidden.
The test should check that if 4 attributes have been defined and 1 is not used in any product, when entering /shop, the attribute that is not used in any product does not appear in the filters.

Right now the test defines 3 attributes and assigns them to two products, so all the attributes are being used, then performs a search for a product that does not exist and therefore the filters disappear completely, there are no products, there is nothing to filter.

The odoo functionality already incorporates that when a search is performed, the filters that do not correspond to the products shown are hidden and that is the functionality that is really being tested and that does not correspond to that of our module in question.

A more precise test is simpler, define 4 attributes or whatever, use for example 3 and when entering /shop check that the one that is not being used in any product is not present in the filters, without searching or going around more than necessary checking functionalities that do not correspond.

cc @Tecnativa TT45590

@chienandalu @pedrobaeza please review