### PR TITLE
[15.0][IMP] website_sale_product_attribute_value_filter_existing: performance

### DIFF
--- a/website_sale_product_attribute_value_filter_existing/controllers/main.py
+++ b/website_sale_product_attribute_value_filter_existing/controllers/main.py
@@ -24,10 +24,10 @@ class ProductAttributeValues(WebsiteSale):
         domain = request.env.context.get("shop_search_domain", [])
         # Load all products without limit for the filter check on
         # attribute values
-        templates = request.env["product.template"].search(domain, limit=False)
+        templates = request.env["product.template"]._search(domain)
         ProductTemplateAttributeLine = request.env["product.template.attribute.line"]
         attribute_values = ProductTemplateAttributeLine.search(
-            [("product_tmpl_id", "in", templates.ids)]
+            [("product_tmpl_id", "in", templates)]
         )
         res.qcontext["attr_values_used"] = attribute_values.mapped("value_ids")
         return res


### PR DESCRIPTION


Use `_search` so we can improve the orm query with an `IN SELECT` instead of a bare set of ids.

In a database with lots of products before the change:

```
"GET /shop HTTP/1.1" 200 - 487 0.910 1.281
"GET /shop HTTP/1.1" 200 - 678 1.512 3.608
"GET /shop HTTP/1.1" 200 - 663 1.094 1.662
"GET /shop HTTP/1.1" 200 - 515 0.831 1.343
```

After the change:

```
"GET /shop HTTP/1.1" 200 - 248 0.462 0.767
"GET /shop HTTP/1.1" 200 - 375 0.578 0.970
"GET /shop HTTP/1.1" 200 - 245 0.626 0.714
"GET /shop HTTP/1.1" 200 - 293 0.608 0.822
```

Query plans compared:

- Using `IN (<ids>)`

  - **PLAN FOR QUERY 1** (fetch ids): https://explain.dalibo.com/plan/9383def674bc1666 *(execution time: 40,1ms, plan: 5,86 ms)*
  - **PLAN FOR QUERY 2** (select in ids): https://explain.dalibo.com/plan/3c9d5cah03g47123 *(execution time: 22,1ms, plan: 27 ms)*
total execution time: **62,2ms**


- Using `IN SELECT`

  - **PLAN FOR QUERY** (select in select): https://explain.dalibo.com/plan/g8c35f93f991dhff *(execution time: **38,2ms**,  plan: 3,09 ms)*


cc @Tecnativa

ping @carlosdauden @pedrobaeza 

(inspired by @nseinlet performance talk ;) (https://www.odoo.com/es_ES/event/odoo-experience-2023-3735/track/performance-python-5833))