### PR TITLE
[15.0][FIX] website_sale_checkout_skip_payment: Addapt changes set on payment template

### DIFF
--- a/website_sale_checkout_skip_payment/views/website_sale_template.xml
+++ b/website_sale_checkout_skip_payment/views/website_sale_template.xml
@@ -32,10 +32,7 @@
                 </form>
             </div>
         </xpath>
-        <xpath
-            expr="//t[@t-if='website_sale_order.amount_total']"
-            position="attributes"
-        >
+        <xpath expr="//t[@name='website_sale_non_free_cart']" position="attributes">
           <attribute
                 name="t-if"
                 separator=" "
@@ -45,7 +42,9 @@
         <xpath expr="//div[hasclass('js_payment')]" position="attributes">
             <attribute
                 name="t-if"
-            >not website_sale_order.amount_total and not website.checkout_skip_payment</attribute>
+                separator=" "
+                add="and not website.checkout_skip_payment"
+            />
         </xpath>
     </template>
     <template id="confirmation" inherit_id="website_sale.confirmation">


### PR DESCRIPTION
Yesterday this commit https://github.com/odoo/odoo/commit/48e40a6c1f449a4093fa2a172bf9b6f3c731ad48 was added to 15.0. It was breaking the heritage of this module. With this canges we recover the functionallity 

cc @Tecnativa TT46305

ping @pilarvargas-tecnativa @chienandalu 