### PR TITLE
[FIX] website_sale_checkout_skip_payment: modify xpath to new core ch…

### DIFF
--- a/website_sale_checkout_skip_payment/views/website_sale_template.xml
+++ b/website_sale_checkout_skip_payment/views/website_sale_template.xml
@@ -34,10 +34,7 @@
                 </div>
             </div>
         </xpath>
-        <xpath
-            expr="//t[@t-if='website_sale_order.amount_total']"
-            position="attributes"
-        >
+        <xpath expr="//t[@name='website_sale_non_free_cart']" position="attributes">
           <attribute
                 name="t-if"
                 separator=" "
@@ -47,7 +44,9 @@
         <xpath expr="//div[hasclass('js_payment')]" position="attributes">
             <attribute
                 name="t-if"
-            >not website_sale_order.amount_total and not website.checkout_skip_payment</attribute>
+                separator=" "
+                add="and not website.checkout_skip_payment"
+            />
         </xpath>
     </template>
     <template id="confirmation" inherit_id="website_sale.confirmation">


### PR DESCRIPTION
Previously, a modification was made to a view in the website_sale module within the core.

Commit --> https://github.com/odoo/odoo/pull/144232

The issue arises when in our module, we make our XPath query to this 'if' statement that no longer matches.

![image](https://github.com/OCA/e-commerce/assets/91630334/a219d12f-5737-4709-be2b-b412764a23b0)

