### PR TITLE
[FIX] website_sale_suggest_create_account: changing the priority of a view

### DIFF
--- a/website_sale_suggest_create_account/views/website_sale.xml
+++ b/website_sale_suggest_create_account/views/website_sale.xml
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
-    <template id="cart" inherit_id="website_sale.cart" customize_show="True">
+    <template
+        id="cart"
+        inherit_id="website_sale.cart"
+        customize_show="True"
+        priority="18"
+    >
         <xpath expr="//div[@id='wrap']" position="before">
             <t t-set="user_authenticated" t-value="user_id != website.user_id" />
             <t
@@ -61,6 +66,7 @@
         id="short_cart_summary"
         inherit_id="website_sale.short_cart_summary"
         customize_show="True"
+        priority="18"
     >
         <xpath expr="//a[@t-attf-href='{{redirect_url}}']" position="attributes">
             <attribute name="class" />


### PR DESCRIPTION
I change the priority of the cart and short_cart_summary views because the website_sale_checkout_skip_payment module uses the same template and this produces an error.
[Template](https://github.com/OCA/e-commerce/blob/b9e397a6c79a4bdef07d1141ae549a36e37ff7fd/website_sale_checkout_skip_payment/views/website_sale_template.xml#L85C1-L103C16)

This video reproduces the error
[Video](https://drive.google.com/file/d/1k7MdI1FYSzFcBD7oF7MBzX-v2ZOK-kY7/view)

![image](https://github.com/OCA/e-commerce/assets/148369234/fae98739-7d39-48ee-988f-3d69901e36b7)
