### PR TITLE
[16.0][FIX] website_sale_stock_available: depends_context

### DIFF
--- a/website_sale_stock_available/models/product_product.py
+++ b/website_sale_stock_available/models/product_product.py
@@ -1,7 +1,7 @@
 # Copyright 2020 Tecnativa - Ernesto Tejeda
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import models
+from odoo import api, models
 
 
 class Product(models.Model):
@@ -18,3 +18,7 @@ class Product(models.Model):
                 immediately = product.immediately_usable_qty
                 res[product.id]["free_qty"] = immediately
         return res
+
+    @api.depends_context("website_sale_stock_available")
+    def _compute_quantities(self):
+        return super()._compute_quantities()


### PR DESCRIPTION
It's necessary to add key `website_sale_stock_available` to `depends_context` of compute method of `free_qty`. This could lead to get invalid cached content instead of computing with updated key.

FL-556-2511