### PR TITLE
[16.0][FIX] website_sale_stock_available: respect args

### DIFF
--- a/website_sale_stock_available/models/sale_order.py
+++ b/website_sale_stock_available/models/sale_order.py
@@ -7,10 +7,6 @@ from odoo import models
 class SaleOrder(models.Model):
     _inherit = "sale.order"
 
-    def _cart_update(
-        self, product_id=None, line_id=None, add_qty=0, set_qty=0, **kwargs
-    ):
+    def _cart_update(self, *args, **kwargs):
         order = self.with_context(website_sale_stock_available=True)
-        return super(SaleOrder, order)._cart_update(
-            product_id, line_id, add_qty, set_qty, **kwargs
-        )
+        return super(SaleOrder, order)._cart_update(*args, **kwargs)


### PR DESCRIPTION
Keep args and kwargs as they are, given also that module's inheritance does not use them

This causes an error on cart updating with `website_sale_loyalty` at [this point](https://github.com/odoo/odoo/blob/15426677c65fab861ac28ff51752a6a97d6378f6/addons/website_sale_loyalty/models/sale_order.py#L160), since [this commit](https://github.com/odoo/odoo/commit/b121f8e1d3ca5b98e71e25710427e6210afe9ef6) was merged.

Steps to reproduce:
1. Use latest version of odoo branch 16.0
2. Install both `website_sale_stock_available` and `website_sale_loyalty`
3. Add a product to cart

FL-556-2768