### PR TITLE
[15.0][FIX] website_sale_cart_expire

### DIFF
--- a/website_sale_cart_expire/models/sale_order.py
+++ b/website_sale_cart_expire/models/sale_order.py
@@ -39,7 +39,11 @@ class SaleOrder(models.Model):
                 from_date = rec.write_date or fields.Datetime.now()
                 # In case or records with transactions, consider last tx date
                 if rec.transaction_ids:
-                    last_tx_date = max(rec.transaction_ids.mapped("last_state_change"))
+                    last_tx_date = max(
+                        rec.transaction_ids.mapped(
+                            lambda x: x.last_state_change or x.write_date
+                        )
+                    )
                     from_date = max(from_date, last_tx_date)
                 expire_delta = timedelta(hours=rec.website_id.cart_expire_delay)
                 rec.cart_expire_date = from_date + expire_delta


### PR DESCRIPTION
Before this commit, there are an issue the method raise an error if transaction_ids.last_state_change was false.
It's possible for last_state_change to be false as a result of migrating data from a past Odoo DB version.

@qrtl
qt:3322