### PR TITLE
Improve '/page/product_brands' search domain

### DIFF
--- a/website_sale_product_brand/controllers/main.py
+++ b/website_sale_product_brand/controllers/main.py
@@ -47,7 +47,10 @@ class WebsiteSale(WebsiteSale):
     @http.route(["/page/product_brands"], type="http", auth="public", website=True)
     def product_brands(self, **post):
         b_obj = request.env["product.brand"]
-        domain = [("website_published", "=", True)]
+        domain = [
+            ("website_published", "=", True),
+            ("product_ids.is_published", "=", True),
+        ]
         if post.get("search"):
             domain += [("name", "ilike", post.get("search"))]
         brand_rec = b_obj.sudo().search(domain)


### PR DESCRIPTION
Before commit:

All published brands are loaded in '/page/product_brands' route

After commit:

Publish brands are loaded in '/page/product_brands' only if they have at least one published product (we apply the same behaviour applied in '/shop')

Performance time increase a bit, search time goes up from 0,001s to 0,01s. It shouldn't be an issue since this search() is only used on '/page/product_brands' route (doesn't affect shop or other routes)

Perf sample (5 exec before/after) - tested on a DB with 16'000 products and 370 brands 

```
before:

Time taken: 0.00055665199943177867680788040161132812500000000000 seconds
Time taken: 0.00081052499990619253367185592651367187500000000000 seconds
Time taken: 0.00106807800057140411809086799621582031250000000000 seconds
Time taken: 0.00066884600073535693809390068054199218750000000000 seconds
Time taken: 0.00151757000003271969035267829895019531250000000000 seconds

after adding ("product_ids.is_published", "=", True) to domain

Time taken: 0.01136246300029597477987408638000488281250000000000 seconds
Time taken: 0.00896999799988407175987958908081054687500000000000 seconds
Time taken: 0.01567319999958272092044353485107421875000000000000 seconds
Time taken: 0.01054079599998658522963523864746093750000000000000 seconds
Time taken: 0.01098039499993319623172283172607421875000000000000 seconds
```