### PR TITLE
[17.0][FIX] website_sale_hide_price: qweb cache

### DIFF
--- a/website_sale_hide_price/views/website_sale_template.xml
+++ b/website_sale_hide_price/views/website_sale_template.xml
@@ -1,20 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
-    <template id="products" inherit_id="website_sale.products">
-        <!-- adding website and website.website_show_price to t-cache in order to update cache if parameter modified
-             this is needed if you connect with a different user that should not see the prices
-             see https://github.com/OCA/e-commerce/issues/818 -->
-        <xpath
-            expr="//div[hasclass('o_wsale_products_grid_table_wrapper')]"
-            position="attributes"
-        >
-            <attribute
-                name="t-cache"
-                add="website,website.website_show_price"
-                separator=","
-            />
-        </xpath>
-    </template>
     <template id="product_price" inherit_id="website_sale.product_price">
         <xpath expr="//div[@itemprop='offers']" position="attributes">
             <attribute name="t-if">


### PR DESCRIPTION
Fix caching of the website_sale.products view override.

Before this commit, this module added a view that added two price website related cache keys to the products grid wrapper. In Odoo 17.0, caching was removed for this element. In combination with this module, this resulted in re-rendering this portion of the view, only depending on the cache keys added by this module. Because of it, searched products didn't update when changing any of the search parameters.

This commit fixes it, by removing that override, and leaving the elements cache disabled.