### PR TITLE
[16.0][FIX] website_sale_stock_list_preview: Error trying to formatQuantity

### DIFF
--- a/website_sale_stock_list_preview/controllers/main.py
+++ b/website_sale_stock_list_preview/controllers/main.py
@@ -45,6 +45,7 @@ class WebsiteSaleVariantController(VariantController):
                     "show_availability": template.show_availability,
                     "available_threshold": template.available_threshold,
                     "uom_name": template.uom_name,
+                    "uom_rounding": template.uom_id.rounding,
                 }
             )
         return res

--- a/website_sale_stock_list_preview/static/src/js/website_sale_stock_list_preview.js
+++ b/website_sale_stock_list_preview/static/src/js/website_sale_stock_list_preview.js
@@ -3,6 +3,7 @@ odoo.define("website_sale_stock_list_preview.shop_stock", function (require) {
 
     var publicWidget = require("web.public.widget");
     var core = require("web.core");
+    const field_utils = require("web.field_utils");
     const {Markup} = require("web.utils");
 
     publicWidget.registry.WebsiteSaleStockListPreview = publicWidget.Widget.extend({
@@ -71,6 +72,20 @@ odoo.define("website_sale_stock_list_preview.shop_stock", function (require) {
                                         available_threshold:
                                             product.available_threshold,
                                         uom_name: product.uom_name,
+                                        formatQuantity: (qty) => {
+                                            if (Number.isInteger(qty)) {
+                                                return qty;
+                                            }
+                                            const decimals = Math.max(
+                                                0,
+                                                Math.ceil(
+                                                    -Math.log10(product.uom_rounding)
+                                                )
+                                            );
+                                            return field_utils.format.float(qty, {
+                                                digits: [false, decimals],
+                                            });
+                                        },
                                     }
                                 )
                             ).get(0)


### PR DESCRIPTION
Since the changes introduced in https://github.com/odoo/odoo/commit/a8c73ebc3deb5b74789461c05e98a2daba7f2526 we need to pass to the template of the remaining units to the function formatQuantity. So we need to pass the function.

The steps to reproduce the error:
1. Edit some product, example Customizable Desk
2. Select the option Show Available Qty and set it to 999999
3. Go to /shop

You will see the error

cc @Tecnativa TT49272

ping @pedrobaeza @victoralmau 