### PR TITLE
[16.0][IMP] website_sale_product_attribute_value_filter_existing: adds filter extraction in mobile view

### DIFF
--- a/website_sale_product_attribute_value_filter_existing/views/templates.xml
+++ b/website_sale_product_attribute_value_filter_existing/views/templates.xml
@@ -22,4 +22,15 @@
             <attribute name="t-if">attr_values_used &amp; v</attribute>
         </xpath>
     </template>
+    <template id="o_wsale_offcanvas" inherit_id="website_sale.o_wsale_offcanvas">
+        <xpath expr="//div[@t-foreach='a.value_ids']/div" position="attributes">
+            <attribute name="t-if">attr_values_used &amp; v</attribute>
+        </xpath>
+        <xpath
+            expr="//div[@t-if=&quot;a.display_type == 'color'&quot;]//t[@t-foreach='a.value_ids']/label"
+            position="attributes"
+        >
+            <attribute name="t-if">attr_values_used &amp; v</attribute>
+        </xpath>
+    </template>
 </odoo>


### PR DESCRIPTION
The mobile view had not been taken into account and the filters appeared even though no product had this filter.