### PR TITLE
[16.0][FIX] website_sale_vat_required: fix test

### DIFF
--- a/website_sale_vat_required/static/src/js/website_sale_vat_required.tour.js
+++ b/website_sale_vat_required/static/src/js/website_sale_vat_required.tour.js
@@ -7,7 +7,7 @@ odoo.define("website_sale_vat_required.tour", function (require) {
 
     var steps = [
         {
-            trigger: "a:contains('Chair floor protection')",
+            trigger: "a:contains('Test Product Vat Required')",
         },
         {
             trigger: "#add_to_cart",
@@ -17,7 +17,7 @@ odoo.define("website_sale_vat_required.tour", function (require) {
             extra_trigger: "sup.my_cart_quantity:contains('1')",
         },
         {
-            trigger: ".btn-primary:contains('Process Checkout')",
+            trigger: "a:contains('Process Checkout')",
         },
         {
             content: "Next",

--- a/website_sale_vat_required/tests/test_website_sale_vat_required.py
+++ b/website_sale_vat_required/tests/test_website_sale_vat_required.py
@@ -6,5 +6,16 @@ from odoo.tests.common import HttpCase
 
 @odoo.tests.tagged("post_install", "-at_install")
 class TestWebsiteSaleVatRequired(HttpCase):
+    def setUp(self):
+        super().setUp()
+        self.product = self.env["product.template"].create(
+            {
+                "name": "Test Product Vat Required",
+                "is_published": True,
+                "website_sequence": 1,
+                "type": "consu",
+            }
+        )
+
     def test_website_sale_vat_required(self):
         self.start_tour("/shop", "website_sale_vat_required_tour")


### PR DESCRIPTION
The tests were using a demo data product so if at any time this product does not exist the tests start to fail. To avoid this, a new product is created and used for testing. Also to locate the checkout button it is better to locate it by its container element as the classes can change depending on the configuration and modules used in the instance and it can be a problem to locate it.

Example screenshot where the checkout button has changed its classes and is not found:

![image](https://github.com/OCA/e-commerce/assets/118818446/61ad5939-2858-4e42-af6e-200b791d4f8e)

cc @Tecnativa

@CarlosRoca13 @chienandalu please review