### PR TITLE
[16.0][FIX] website_sale_product_attribute_filter_collapse: fix test_tour

### DIFF
--- a/website_sale_product_attribute_filter_collapse/static/src/js/website_sale_product_attribute_filter_collapse.js
+++ b/website_sale_product_attribute_filter_collapse/static/src/js/website_sale_product_attribute_filter_collapse.js
@@ -14,13 +14,14 @@ odoo.define("website_sale_product_attribute_filter_collapse.tour", function (req
             trigger: "div:contains('Test v1')",
         },
         {
-            trigger: "a:contains('Customizable')",
+            trigger: "a:contains('Test Product Filter Collapse')",
         },
         {
             trigger: "#add_to_cart",
         },
         {
-            trigger: "button:contains('Proceed to Checkout')",
+            trigger: "a[href='/shop/cart']",
+            extra_trigger: "sup.my_cart_quantity:contains('1')",
         },
         {
             trigger: ".btn-primary:contains('Process Checkout')",

--- a/website_sale_product_attribute_filter_collapse/tests/test_tour.py
+++ b/website_sale_product_attribute_filter_collapse/tests/test_tour.py
@@ -19,8 +19,13 @@ class WebsiteSaleProductAttributeFilterCollapseHttpCase(HttpCase):
         self.product_attribute_value_2 = self.env["product.attribute.value"].create(
             {"name": "Test v2", "attribute_id": self.product_attribute.id}
         )
-        self.product_template = self.env.ref(
-            "product.product_product_4_product_template"
+        self.product_template = self.env["product.template"].create(
+            {
+                "name": "Test Product Filter Collapse",
+                "is_published": True,
+                "website_sequence": 1,
+                "type": "consu",
+            }
         )
         self.product_attribute_line = self.env[
             "product.template.attribute.line"


### PR DESCRIPTION
When using the demo product "Customizable Desk" in the standard behaviour there is an intermediate step in which the variant of the product to be added to the cart is chosen. This step may not be there if there are no variants really because some module has modified this and to avoid errors in the tests it is better to create a product in which we are sure that there are no variants and the step of selecting the variant before adding to the cart does not exist.

cc @Tecnativa

@chienandalu @CarlosRoca13 please review
