### PR TITLE
[16.0][FIX] website_sale_order_type: fix test

### DIFF
--- a/website_sale_order_type/README.rst
+++ b/website_sale_order_type/README.rst
@@ -90,16 +90,13 @@ OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.
 
-.. |maintainer-stefan-tecnativa| image:: https://github.com/stefan-tecnativa.png?size=40px
-    :target: https://github.com/stefan-tecnativa
-    :alt: stefan-tecnativa
 .. |maintainer-pilarvargas-tecnativa| image:: https://github.com/pilarvargas-tecnativa.png?size=40px
     :target: https://github.com/pilarvargas-tecnativa
     :alt: pilarvargas-tecnativa
 
-Current `maintainers <https://odoo-community.org/page/maintainer-role>`__:
+Current `maintainer <https://odoo-community.org/page/maintainer-role>`__:
 
-|maintainer-stefan-tecnativa| |maintainer-pilarvargas-tecnativa| 
+|maintainer-pilarvargas-tecnativa| 
 
 This module is part of the `OCA/e-commerce <https://github.com/OCA/e-commerce/tree/16.0/website_sale_order_type>`_ project on GitHub.
 

--- a/website_sale_order_type/__manifest__.py
+++ b/website_sale_order_type/__manifest__.py
@@ -8,7 +8,7 @@
     "development_status": "Beta",
     "category": "Website",
     "website": "https://github.com/OCA/e-commerce",
-    "maintainers": ["stefan-tecnativa", "pilarvargas-tecnativa"],
+    "maintainers": ["pilarvargas-tecnativa"],
     "author": "Agile Business Group, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "depends": ["website_sale", "sale_order_type"],

--- a/website_sale_order_type/static/description/index.html
+++ b/website_sale_order_type/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -434,8 +433,8 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>
-<p>Current <a class="reference external" href="https://odoo-community.org/page/maintainer-role">maintainers</a>:</p>
-<p><a class="reference external image-reference" href="https://github.com/stefan-tecnativa"><img alt="stefan-tecnativa" src="https://github.com/stefan-tecnativa.png?size=40px" /></a> <a class="reference external image-reference" href="https://github.com/pilarvargas-tecnativa"><img alt="pilarvargas-tecnativa" src="https://github.com/pilarvargas-tecnativa.png?size=40px" /></a></p>
+<p>Current <a class="reference external" href="https://odoo-community.org/page/maintainer-role">maintainer</a>:</p>
+<p><a class="reference external image-reference" href="https://github.com/pilarvargas-tecnativa"><img alt="pilarvargas-tecnativa" src="https://github.com/pilarvargas-tecnativa.png?size=40px" /></a></p>
 <p>This module is part of the <a class="reference external" href="https://github.com/OCA/e-commerce/tree/16.0/website_sale_order_type">OCA/e-commerce</a> project on GitHub.</p>
 <p>You are welcome to contribute. To learn how please visit <a class="reference external" href="https://odoo-community.org/page/Contribute">https://odoo-community.org/page/Contribute</a>.</p>
 </div>

--- a/website_sale_order_type/static/src/js/website_sale_order_type_tour.js
+++ b/website_sale_order_type/static/src/js/website_sale_order_type_tour.js
@@ -8,13 +8,14 @@ odoo.define("website_sale_order_type.tour", function (require) {
 
     var steps = [
         {
-            trigger: ".oe_product_cart a:contains('Customizable')",
+            trigger: ".oe_product_cart a:contains('Test Product SO Type')",
         },
         {
             trigger: "#add_to_cart",
         },
         {
-            trigger: "button:contains('Proceed to Checkout')",
+            trigger: "a[href='/shop/cart']",
+            extra_trigger: "sup.my_cart_quantity:contains('1')",
         },
         {
             trigger: ".btn:contains('Process Checkout')",

--- a/website_sale_order_type/tests/test_website_sale_order_type.py
+++ b/website_sale_order_type/tests/test_website_sale_order_type.py
@@ -8,7 +8,14 @@ class TestFrontend(HttpCase):
     def setUp(self):
         super(TestFrontend, self).setUp()
         self.sale_type_model = self.env["sale.order.type"]
-
+        self.product_template = self.env["product.template"].create(
+            {
+                "name": "Test Product SO Type",
+                "is_published": True,
+                "website_sequence": 1,
+                "type": "consu",
+            }
+        )
         self.partner = self.env.ref("base.partner_admin")
         self.sale_type = self.create_sale_type()
 


### PR DESCRIPTION
When using the demo product "Customizable Desk" in the standard behaviour there is an intermediate step in which the variant of the product to be added to the cart is chosen. This step may not be there if
there are no variants really because some module has modified this and to avoid errors in the tests it is better to create a product in which we are sure that there are no variants and the step of selecting the variant before adding to the cart does not exist.

cc @tecnativa 

@chienandalu @CarlosRoca13 please review