### PR TITLE
[16.0][DOC] website_sale_hide_price: message

### DIFF
--- a/website_sale_hide_price/README.rst
+++ b/website_sale_hide_price/README.rst
@@ -65,6 +65,9 @@ If you want to hide prices at website level
 #. Go to *Website > Configuration > Settings* and choose the website to hide the prices.
 #. In the *Shop - Products* section you have the option *Hide prices on website*
 
+Both *Default Hidden price message* field at website level and *Hidden price message*
+at product level are only shown on product page when price is hidden at product level.
+
 Usage
 =====
 

--- a/website_sale_hide_price/models/product_template.py
+++ b/website_sale_hide_price/models/product_template.py
@@ -9,8 +9,9 @@ class ProductTemplate(models.Model):
     website_hide_price = fields.Boolean(string="Hide prices on website")
     website_hide_price_message = fields.Text(
         string="Hidden price message",
-        help="When the price is hidden on the website we can give the customer"
-        "some tips on how to find it out.",
+        help="When the price is hidden on the website because of product "
+        "configuration we can give the customer some tips on how to find it"
+        " out.",
         translate=True,
     )
 

--- a/website_sale_hide_price/models/website.py
+++ b/website_sale_hide_price/models/website.py
@@ -16,8 +16,9 @@ class Website(models.Model):
     website_show_price = fields.Boolean(compute="_compute_website_show_price")
     website_hide_price_default_message = fields.Char(
         string="Default Hidden price message",
-        help="When the price is hidden on the website we can give the customer"
-        "some tips on how to find it out.",
+        help="When the price is hidden on the website because of product "
+        "configuration we can give the customer some tips on how to find it "
+        "out.",
         translate=True,
     )
 

--- a/website_sale_hide_price/readme/CONFIGURE.rst
+++ b/website_sale_hide_price/readme/CONFIGURE.rst
@@ -24,3 +24,6 @@ If you want to hide prices at website level
 
 #. Go to *Website > Configuration > Settings* and choose the website to hide the prices.
 #. In the *Shop - Products* section you have the option *Hide prices on website*
+
+Both *Default Hidden price message* field at website level and *Hidden price message*
+at product level are only shown on product page when price is hidden at product level.

--- a/website_sale_hide_price/static/description/index.html
+++ b/website_sale_hide_price/static/description/index.html
@@ -414,6 +414,8 @@ hidden.</li>
 <li>Go to <em>Website &gt; Configuration &gt; Settings</em> and choose the website to hide the prices.</li>
 <li>In the <em>Shop - Products</em> section you have the option <em>Hide prices on website</em></li>
 </ol>
+<p>Both <em>Default Hidden price message</em> field at website level and <em>Hidden price message</em>
+at product level are only shown on product page when price is hidden at product level.</p>
 </div>
 <div class="section" id="usage">
 <h1><a class="toc-backref" href="#toc-entry-2">Usage</a></h1>

--- a/website_sale_hide_price/views/res_config_settings_views.xml
+++ b/website_sale_hide_price/views/res_config_settings_views.xml
@@ -24,14 +24,14 @@
                 <div
                     class="col-12 col-lg-6 o_setting_box"
                     id="website_sale_hide_price_message"
-                    title="Set a default text when hiding prices"
+                    title="Set a default text when hiding prices at product level"
                 >
                     <div class="o_setting_left_pane">
                     </div>
                     <div class="o_setting_right_pane">
                         <label for="website_hide_price_default_message" />
                         <div class="text-muted">
-                            Set a default text when hiding prices
+                            Set a default text when hiding prices at product level
                         </div>
                         <field name="website_hide_price_default_message" />
                     </div>


### PR DESCRIPTION
Helps and readme for message fields are clarified, as it can seem that message is shown on every case of hiding prices.

Anyway, this message is used in two places:
- In [product page](https://github.com/OCA/e-commerce/blob/b0ac4991e6809f2504f684da8763fb131edffd63/website_sale_hide_price/views/website_sale_template.xml#L23), where it is shown only when prices are hidden because of product configuration, not customer o website checks.
- In [search results](https://github.com/OCA/e-commerce/blob/828ce541fe6e5ea2c1b6ad08436e46d74e5a0529/website_sale_hide_price/models/product_template.py#L54-L55), on every case

What would be the right thing to do? This PR is focused on the first case.

FL-556-3533