### PR TITLE
[16.0][FIX] website_sale_product_attachment: product template view ad…

### DIFF
--- a/website_sale_product_attachment/views/product_template.xml
+++ b/website_sale_product_attachment/views/product_template.xml
@@ -10,13 +10,13 @@
         <field name="arch" type="xml">
             <group name="shop" position="after">
                 <group name="website_attachments" string="Website Attachments">
-                    <div class="alert alert-info" colspan="4" role="alert">
+                    <div class="alert alert-info" colspan="2" role="alert">
                         <i class="fa fa-info-circle" />
                         Only public attachments can be used or created here.
                         Removing one attachment from this list does not delete
                         or unpublish it from your database.
                     </div>
-                    <field name="website_attachment_ids" nolabel="1">
+                    <field name="website_attachment_ids" nolabel="1" colspan="2">
                         <tree default_order="website_name,name,id">
                             <field name="website_name" />
                             <field name="name" string="File Name" />


### PR DESCRIPTION
This solution fixes a bug  incorpored at https://github.com/OCA/e-commerce/commit/7f6d3e53bd0b33c98bff8fd239ed3a7f491851c0 which produces that the alert and table introduced for product templete view didn't show properly.
![image](https://github.com/OCA/e-commerce/assets/98310383/a1a39530-c2c1-4a62-b2c6-3f62e37d1202)

With this adjustment, both of them are restricted using a colspan, making them fill the correct grid boxes.

FL-556-3020