### PR TITLE
[16.0][FIX] website_sale_hide_price: change of priority in product view

### DIFF
--- a/website_sale_hide_price/views/website_sale_template.xml
+++ b/website_sale_hide_price/views/website_sale_template.xml
@@ -30,7 +30,7 @@
         </xpath>
     </template>
     <!-- Hide Add To Cart Button and quantity selector if not website_show_price -->
-    <template id="product" inherit_id="website_sale.product">
+    <template id="product" inherit_id="website_sale.product" priority="18">
         <!-- adding website, website.website_show_price and product.website_hide_price to t-cache in order to update cache if parameter modified
              this is needed if you connect with a different user that should not see the prices
              see https://github.com/OCA/e-commerce/issues/818 -->


### PR DESCRIPTION
When you first install website_sale_hide_price and then want to install website_sale_subscription (enterprise) it gives error because it does not find t-cache since it was modified in this module.

Steps to reproduce:
1. Install website_sale_sale_hide_price
2. Install website_sale_subscription

![image](https://github.com/user-attachments/assets/264abce3-4c01-4b50-96fd-55e4b75dce8f)
