### PR TITLE
[16.0][FIX] website_sale_checkout_skip_payment: Fix wrong confirmation method.

### DIFF
--- a/website_sale_checkout_skip_payment/static/tests/tours/website_sale_checkout_skip_payment_tour.js
+++ b/website_sale_checkout_skip_payment/static/tests/tours/website_sale_checkout_skip_payment_tour.js
@@ -37,6 +37,11 @@ odoo.define("website_sale_checkout_skip_payment.tour", function (require) {
                 trigger: "a[href='/shop']",
                 extra_trigger: "strong:contains('Payment Information:')",
             },
+            {
+                content: "Check confirmation and that the cart has been left empty",
+                trigger: "a:has(.my_cart_quantity:containsExact(0))",
+                extra_trigger: "strong:contains('Payment Information:')",
+            },
         ]
     );
 });


### PR DESCRIPTION
When an order is confirmed and goes to the path ‘/shop/confirmation’, the driver method involved is ‘shop_payment_confirmation’ from websitesale. With the migration, the wrong method was involved as it was a portal method and its path is ‘/payment/confirmation’, which has nothing to do with the confirmation of an order.

cc @tecnativa TT50360

@CarlosRoca13 @carlos-lopez-tecnativa please review :)

ping @pedrobaeza 