### PR TITLE
[15.0][FIX] website_sale_checkout_skip_payment: translate payment message

### DIFF
--- a/website_sale_checkout_skip_payment/i18n/es.po
+++ b/website_sale_checkout_skip_payment/i18n/es.po
@@ -82,6 +82,13 @@ msgid "Message shown to the user when the purchase is finished"
 msgstr "Mensaje mostrado al usuario cuando finaliza la compra"
 
 #. module: website_sale_checkout_skip_payment
+#. odoo-python
+#: code:addons/website_sale_checkout_skip_payment/models/website.py:0
+#, python-format
+msgid "Our team will check your order and send you payment information soon."
+msgstr "Nuestro equipo revisará su pedido y pronto le enviará información sobre el pago."
+
+#. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.res_config_settings_view_form
 msgid "Sale Checkout Skip Message"
 msgstr "Mensaje de omisión de pago y venta"

--- a/website_sale_checkout_skip_payment/i18n/website_sale_checkout_skip_payment.pot
+++ b/website_sale_checkout_skip_payment/i18n/website_sale_checkout_skip_payment.pot
@@ -70,6 +70,13 @@ msgid "Message shown to the user when the purchase is finished"
 msgstr ""
 
 #. module: website_sale_checkout_skip_payment
+#. odoo-python
+#: code:addons/website_sale_checkout_skip_payment/models/website.py:0
+#, python-format
+msgid "Our team will check your order and send you payment information soon."
+msgstr ""
+
+#. module: website_sale_checkout_skip_payment
 #: model_terms:ir.ui.view,arch_db:website_sale_checkout_skip_payment.res_config_settings_view_form
 msgid "Sale Checkout Skip Message"
 msgstr ""

--- a/website_sale_checkout_skip_payment/models/website.py
+++ b/website_sale_checkout_skip_payment/models/website.py
@@ -1,7 +1,7 @@
 # Copyright 2017 Sergio Teruel <sergio.teruel@tecnativa.com>
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
-from odoo import fields, models
+from odoo import _, fields, models
 from odoo.http import request
 
 
@@ -11,7 +11,10 @@ class Website(models.Model):
     website_sale_checkout_skip_message = fields.Text(
         string="Website Sale SKip Message",
         required=True,
-        default="Our team will check your order and send you payment information soon.",
+        translate=True,
+        default=lambda s: _(
+            "Our team will check your order and send you payment information soon."
+        ),
     )
     checkout_skip_payment = fields.Boolean(compute="_compute_checkout_skip_payment")
 


### PR DESCRIPTION
- The default option in the field isn't detected as term to translate.
- Also, in a multilingual site we should provide that message in each language.

cc @Tecnativa TT50516

please review @pedrobaeza @victoralmau 

fw of 
- #964 