### PR TITLE
[16.0][FIX] website_sale_product_attribute_value_filter_existing: Hide attribute parent container

### DIFF
--- a/website_sale_product_attribute_value_filter_existing/views/templates.xml
+++ b/website_sale_product_attribute_value_filter_existing/views/templates.xml
@@ -23,7 +23,7 @@
         </xpath>
     </template>
     <template id="o_wsale_offcanvas" inherit_id="website_sale.o_wsale_offcanvas">
-        <xpath expr="//div[@t-foreach='a.value_ids']/div" position="attributes">
+        <xpath expr="//div[@t-foreach='a.value_ids']" position="attributes">
             <attribute name="t-if">attr_values_used &amp; v</attribute>
         </xpath>
         <xpath


### PR DESCRIPTION
If only the attribute container is hidden, the parent container still occupies a space that is visible in the attribute list. To avoid this, apply the condition to the parent container and hide it completely.

This occurs in the filtering of attributes in the mobile view.

Attributes defined for the test:
![image](https://github.com/user-attachments/assets/986b6ec8-93bf-4ccb-8583-efe3b45954e8)

Attributes 2, 3 and 4 will remain hidden as no product has been assigned to them.

Before the fix:
![image](https://github.com/user-attachments/assets/8696de1a-8ec1-45f2-9b7c-d09009935b3e)

After the fix:
![image](https://github.com/user-attachments/assets/5535daae-36e8-4795-99e5-aee76a49208a)

@chienandalu @carlos-lopez-tecnativa please review

ping @pedrobaeza 

cc @Tecnativa TT50704