### PR TITLE
[16.0][IMP] website_sale_product_assortment

### DIFF
--- a/website_sale_product_assortment/__manifest__.py
+++ b/website_sale_product_assortment/__manifest__.py
@@ -23,6 +23,7 @@
             "website_sale_product_assortment/static/src/js/no_purchase_tour.js",
             "website_sale_product_assortment/static/src/js/no_restriction_tour.js",
             "website_sale_product_assortment/static/src/js/no_show_tour.js",
+            "website_sale_product_assortment/static/src/js/no_restriction_no_show_tour.js",
         ],
     },
 }

--- a/website_sale_product_assortment/controllers/website_sale.py
+++ b/website_sale_product_assortment/controllers/website_sale.py
@@ -17,15 +17,19 @@ class WebsiteSale(WebsiteSale):
             .search(
                 [
                     ("is_assortment", "=", True),
-                    ("website_availability", "=", "no_show"),
                     "|",
                     ("website_ids", "=", False),
                     ("website_ids", "=", website_id),
                 ]
             )
         )
+        no_restriction_assortments = any(
+            assortment.website_availability == "no_show" for assortment in assortments
+        )
         assortment_restriction = False
         allowed_product_ids = set()
+        if not no_restriction_assortments:
+            return allowed_product_ids, assortment_restriction
         for assortment in assortments:
             if (
                 # Set active_test to False to allow filtering by partners

--- a/website_sale_product_assortment/models/product_template.py
+++ b/website_sale_product_assortment/models/product_template.py
@@ -16,19 +16,24 @@ class ProductTemplate(models.Model):
             .search(
                 [
                     ("is_assortment", "=", True),
-                    ("website_availability", "in", ["no_purchase", "no_show"]),
                     "|",
                     ("website_ids", "=", website.id),
                     ("website_ids", "=", False),
                 ]
             )
         )
-        assortment_dict = {}
+        partner_assortments = self.env["ir.filters"].sudo()
+        allowed_product_ids = set()
         for assortment in assortments:
             if partner & assortment.with_context(active_test=False).all_partner_ids:
-                allowed_product_ids = assortment.all_product_ids.ids
-                for product in product_ids:
-                    if product not in allowed_product_ids:
+                if assortment.website_availability != "no_restriction":
+                    partner_assortments |= assortment
+                allowed_product_ids.update(assortment.all_product_ids.ids)
+        assortment_dict = {}
+        for product in product_ids:
+            if product not in allowed_product_ids:
+                for assortment in partner_assortments:
+                    if product not in assortment.all_product_ids.ids:
                         assortment_dict.setdefault(product, self.env["ir.filters"])
                         assortment_dict[product] |= assortment
         return assortment_dict

--- a/website_sale_product_assortment/static/description/index.html
+++ b/website_sale_product_assortment/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -9,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -442,7 +442,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/website_sale_product_assortment/static/src/js/no_restriction_no_show_tour.js
+++ b/website_sale_product_assortment/static/src/js/no_restriction_no_show_tour.js
@@ -1,0 +1,49 @@
+/* Copyright 2021 Tecnativa - Carlos Roca
+   License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). */
+odoo.define(
+    "website_sale_product_assortment.no_restriction_no_show_tour",
+    function (require) {
+        "use strict";
+
+        var tour = require("web_tour.tour");
+
+        var steps = [
+            {
+                trigger: "a:contains('Test Product 1')",
+            },
+            {
+                trigger: "a#add_to_cart",
+            },
+            {
+                trigger: "a[href='/shop/cart']",
+                extra_trigger: "sup.my_cart_quantity:contains('1')",
+            },
+            {
+                content: "go back to the store",
+                trigger: "a[href='/shop']",
+            },
+            {
+                trigger: "a:contains('Test Product 2')",
+            },
+            {
+                trigger: "a#add_to_cart",
+            },
+            {
+                trigger: "a[href='/shop/cart']",
+                extra_trigger: "sup.my_cart_quantity:contains('1')",
+            },
+        ];
+
+        tour.register(
+            "test_assortment_with_no_restriction_no_show",
+            {
+                url: "/shop",
+                test: true,
+            },
+            steps
+        );
+        return {
+            steps: steps,
+        };
+    }
+);

--- a/website_sale_product_assortment/tests/test_ui.py
+++ b/website_sale_product_assortment/tests/test_ui.py
@@ -16,6 +16,14 @@ class TestUI(HttpCase):
                 "type": "consu",
             }
         )
+        self.product2 = self.env["product.template"].create(
+            {
+                "name": "Test Product 2",
+                "is_published": True,
+                "website_sequence": 2,
+                "type": "consu",
+            }
+        )
 
     def test_01_ui_no_restriction(self):
         self.env["ir.filters"].create(
@@ -26,6 +34,7 @@ class TestUI(HttpCase):
                 "domain": [("id", "!=", self.product.product_variant_id.id)],
                 "partner_domain": "[('id', '=', %s)]"
                 % self.env.ref("base.partner_admin").id,
+                "website_availability": "no_restriction",
             }
         )
         self.start_tour("/shop", "test_assortment_with_no_restriction", login="admin")
@@ -62,3 +71,30 @@ class TestUI(HttpCase):
             }
         )
         self.start_tour("/shop", "test_assortment_with_no_purchase", login="admin")
+
+    def test_04_ui_no_restriction_no_show(self):
+        self.env["ir.filters"].create(
+            {
+                "name": "Test Assortment",
+                "model_id": "product.product",
+                "is_assortment": True,
+                "domain": [("id", "!=", self.product.product_variant_id.id)],
+                "partner_domain": "[('id', '=', %s)]"
+                % self.env.ref("base.partner_admin").id,
+                "website_availability": "no_show",
+            }
+        )
+        self.env["ir.filters"].create(
+            {
+                "name": "Test Assortment 2",
+                "model_id": "product.product",
+                "is_assortment": True,
+                "domain": [("id", "!=", self.product2.product_variant_id.id)],
+                "partner_domain": "[('id', '=', %s)]"
+                % self.env.ref("base.partner_admin").id,
+                "website_availability": "no_restriction",
+            }
+        )
+        self.start_tour(
+            "/shop", "test_assortment_with_no_restriction_no_show", login="admin"
+        )


### PR DESCRIPTION
Description:

When more than one assortment is applied to the customer on e-commerce, the functionality doesn't work correctly, and the configurations are not applied properly, for example, when combining "no restriction" with "no show" or "no purchase."

This PR is essential for the functionality of this module because the products are not shown or cannot be bought when they should.

Cases covered with this improvement:

1. Assortment A with product 1 and configuration "Avoid to show non available products" and assortment B with product 2 and configuration "Avoid to show non available products". Before, both products were displayed with the label "Not available". With this PR both products are displayed and they are allowed to be purchased.
2. Assorment A with product 1 and configuration "Avoid to show non available products" and assortment B with product 2 and configuration "No restrictions". Before, only the products from de assortment A were displayed, restricting the products from de B assortment. With this PR, the restrictions are not applied to the assortments with the configuration "No restrictions" when simultaneous assortments are applied to the same client or website.

Solution:
To resolve this problem, we have made the following modifications:

1. The method that returns the products to display is adjusted so that, in the absence of restrictive stock, it correctly returns the values.
3. Additionally, the method that returns the products and their restrictions is adjusted to make the assortments compatible.



