### PR TITLE
[16.0][FIX] website_sale_product_attribute_value_filter_existing: Add attribute ‘Test yellow'

### DIFF
--- a/website_sale_product_attribute_value_filter_existing/tests/test_website_sale_product_attribute_value_filter_existing.py
+++ b/website_sale_product_attribute_value_filter_existing/tests/test_website_sale_product_attribute_value_filter_existing.py
@@ -28,6 +28,9 @@ class WebsiteSaleHttpCase(HttpCase):
         cls.product_attribute_value_blue = ProductAttributeValue.create(
             {"name": "Test blue", "attribute_id": cls.product_attribute.id}
         )
+        cls.product_attribute_value_yellow = ProductAttributeValue.create(
+            {"name": "Test yellow", "attribute_id": cls.product_attribute.id}
+        )
         cls.product_template = cls.env.ref("product.product_product_4_product_template")
         cls.product_attribute_line = ProductAttributeLine.create(
             {


### PR DESCRIPTION
It is being checked that the attribute ‘Test yellow’ is not present in the filter panel as it is not being used in any product. Actually, no real check is being made if the attribute is not defined. It is a fact, if it is not defined, it does not exist and will not be present at all.

cc @Tecnativa 

@chienandalu @CarlosRoca13 please review