### PR TITLE
[18.0][FIX] website_sale_product_attribute_value_filter_existing: Hide attibute container

### DIFF
--- a/website_sale_product_attribute_value_filter_existing/views/templates.xml
+++ b/website_sale_product_attribute_value_filter_existing/views/templates.xml
@@ -20,7 +20,7 @@
         <xpath expr="//t[@t-foreach='a.value_ids']" position="attributes">
             <attribute name="t-if">attr_values_used &amp; v</attribute>
         </xpath>
-        <xpath expr="//input[@name='attribute_value']/.." position="attributes">
+        <xpath expr="//input[@name='attribute_value']/../.." position="attributes">
             <attribute name="t-if">attr_values_used &amp; v</attribute>
         </xpath>
     </template>


### PR DESCRIPTION
If the entire container is not hidden, it still takes up space and the space is visible in the attribute list.

Before:
![image](https://github.com/user-attachments/assets/4f92ace2-d72a-42bb-a652-130797a9616d)

After:
![image](https://github.com/user-attachments/assets/6ac37a91-69e1-4001-bf2f-3d52d274beb9)


cc @Tecnativa TT51372

@pedrobaeza @CarlosRoca13 please review