### PR TITLE
[16.0][FIX]website_sale_hide_price: fix button visibility issue

### DIFF
--- a/website_sale_hide_price/models/product_template.py
+++ b/website_sale_hide_price/models/product_template.py
@@ -1,6 +1,7 @@
 # Copyright 2022 Tecnativa - David Vidal
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from odoo import fields, models
+from odoo.tools import config
 
 
 class ProductTemplate(models.Model):
@@ -58,3 +59,14 @@ class ProductTemplate(models.Model):
                     }
                 )
         return results_data
+
+    def _website_show_quick_add(self):
+        show_price = (
+            self.env["website"].get_current_website().website_show_price
+            and not self.website_hide_price
+        )
+        if config["test_enable"] and not self.env.context.get(
+            "website_sale_hide_price_test"
+        ):
+            return show_price
+        return show_price and super()._website_show_quick_add()

--- a/website_sale_hide_price/views/website_sale_template.xml
+++ b/website_sale_hide_price/views/website_sale_template.xml
@@ -82,14 +82,6 @@
             </attribute>
         </xpath>
     </template>
-    <!-- Hide add to cart button if "Add to cart" option is enabled and not website_show_price -->
-    <template id="products_add_to_cart" inherit_id="website_sale.products_add_to_cart">
-        <xpath expr="//a[hasclass('a-submit')]" position="attributes">
-            <attribute name="t-if">
-                website.website_show_price and not product.website_hide_price
-            </attribute>
-        </xpath>
-    </template>
     <template id="website_search_box" inherit_id="website.website_search_box">
         <xpath expr="//input[@name='search']" position="attributes">
             <attribute


### PR DESCRIPTION
Description:

In the website_sale_hide_price module, button visibility for the "Quick Add to Cart" button in the ecommerce product list (Kanban or List View) was not behaving as expected when the stock was zero and the "Allow out of stock order" option was unchecked. This PR resolves the issue by replacing view inheritance with logic in Python.

Cases covered with this improvement:

- Ensures that the "Quick Add to Cart" button disappears when stock is zero and "Allow out of stock order" is unchecked.
- Resolves compatibility issues with website_sale_hide_price module.

Reproduction Steps (in Runboat):

1. Create a product in the Sales > Products menu and set the stock to 0.
2. Make sure the "Allow out of stock order" option is unchecked.
3. Enable the website_sale_hide_price module.
4. In the ecommerce frontend, go to the product listing or Kanban view.
5. Verify that the "Quick Add to Cart" button is hidden when stock is zero.

Solution: 
The issue was fixed by modifying the _website_show_quick_add method in the product.template model to include logic for checking stock availability and the "Allow out of stock order" option in Python, instead of relying on view inheritance.

This approach ensures better maintainability and resolves the dependency issues that caused the button visibility error.
FL-556-4678