### PR TITLE
[17.0][FIX]website_sale_hide_price: improve button visibility logic

### DIFF
--- a/website_sale_hide_price/models/product_template.py
+++ b/website_sale_hide_price/models/product_template.py
@@ -55,3 +55,11 @@ class ProductTemplate(models.Model):
                     }
                 )
         return results_data
+
+    def _website_show_quick_add(self):
+        website_show_price = (
+            self.env["website"].get_current_website().website_show_price
+        )
+        return (
+            website_show_price and not self.website_hide_price
+        ) and super()._website_show_quick_add()

--- a/website_sale_hide_price/views/website_sale_template.xml
+++ b/website_sale_hide_price/views/website_sale_template.xml
@@ -67,14 +67,6 @@
             </attribute>
         </xpath>
     </template>
-    <!-- Hide add to cart button if "Add to cart" option is enabled and not website_show_price -->
-    <template id="products_add_to_cart" inherit_id="website_sale.products_add_to_cart">
-        <xpath expr="//a[hasclass('a-submit')]" position="attributes">
-            <attribute name="t-if">
-                website.website_show_price and not product.website_hide_price
-            </attribute>
-        </xpath>
-    </template>
     <template id="website_search_box" inherit_id="website.website_search_box">
         <xpath expr="//input[@name='search']" position="attributes">
             <attribute


### PR DESCRIPTION
Forward port of https://github.com/OCA/e-commerce/pull/986  @pilarvargas-tecnativa 

Description:

Replaced view inheritance with Python logic in _website_show_quick_add
to fix an issue where the "Add to Cart" button visibility was
incorrectly overridden by this module. This update restores the
expected behavior by ensuring the inherited logic determines button
visibility.