### PR TITLE
[16.0][IMP]website_sale_product_item_cart_custom_qty: add visibility management

### DIFF
--- a/website_sale_product_item_cart_custom_qty/views/templates.xml
+++ b/website_sale_product_item_cart_custom_qty/views/templates.xml
@@ -6,7 +6,7 @@
             <div
                 class="css_quantity input-group"
                 style="display: inline-flex;"
-                t-if="product.visible_qty_configurator"
+                t-if="product.visible_qty_configurator and product._website_show_quick_add()"
             >
                 <div class="input-group-prepend">
                     <a


### PR DESCRIPTION
Description:

In this PR, the visibility of the quantity configurator in the ecommerce product list (Kanban or List View) has been improved by adding a condition to the corresponding view template. The enhancement ensures that the quantity selector is only displayed when the "Quick Add to Cart" button is visible.

Cases covered with this improvement:

- Ensures the quantity configurator is only shown when the product is eligible for quick addition to the cart.
- Provides better alignment between product visibility logic and the display of interactive elements in the frontend.

Reproduction Steps:

1. Create a product in the Sales > Products menu and set the stock to 0.
2. Make sure the "Allow out of stock order" option is unchecked.
3. Enable website_sale_product_item_cart_custom_qty module.
4. In the ecommerce frontend, go to the product listing or Kanban view.
5. Verify that the "Quantity selector" is hidden when stock is zero

Solution:

The issue was addressed by modifying the view template to include the following condition:
"product._website_show_quick_add()"
This change integrates the logic for visibility of the quantity configurator with the existing _website_show_quick_add method in the product.template model that is modified in website_sale_hide_price.

By introducing this template condition, the visibility of the quantity selector is dynamically managed based on product settings, ensuring consistency and improved user experience.

Here in this example I used Office design software as the product with 0 stock:

![image](https://github.com/user-attachments/assets/159f2986-c8c1-4141-af7f-d6920543d7cb)


FL-556-4816