### PR TITLE
[FIX] product_template_multi_link: image link USAGE.md

### DIFF
--- a/product_template_multi_link/readme/USAGE.md
+++ b/product_template_multi_link/readme/USAGE.md
@@ -1,19 +1,17 @@
 - To mass edit or create links between products templates, Go to Sale \>
   Configuration \> Products \> Product Links
 
-![](/product_template_multi_link/static/description/product_template_link_tree.png)
+![Product link list](/../static/description/product_template_link_tree.png)
 
 A kanban view is also available
 
-![](/product_template_multi_link/static/description/product_template_link_kanban.png)
+![Product link kanban](/../static/description/product_template_link_kanban.png)
 
 - You can manage links by product, Go to Sales \> Sales \> Products and
   select a product
 
-![](/product_template_multi_link/static/description/product_template_form.png)
+![Product form](/../static/description/product_template_form.png)
 
 - You can so add new item, line by line, via an editable tree view
 
-![](/product_template_multi_link/static/description/product_template_link_tree_edit.png)
-
-[![Try me on Runbot](https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas)](https://runbot.odoo-community.org/runbot/113/14.0)
+![Product link list edit](/../static/description/product_template_link_tree_edit.png)


### PR DESCRIPTION
Images don't appear in https://github.com/OCA/e-commerce/blob/18.0/product_template_multi_link/README.rst

Apply the same shortcuts than in successful readme https://github.com/OCA/server-auth/blob/18.0/auth_oidc/README.rst

https://raw.githubusercontent.com/OCA/server-auth/refs/heads/18.0/auth_oidc/readme/CONFIGURE.md


cc @legalsylvain @lmignon @thienvh332 