### PR TITLE
[15.0][MIG] website_sale_credit_point

### DIFF
--- a/setup/website_sale_credit_point/odoo/addons/website_sale_credit_point
+++ b/setup/website_sale_credit_point/odoo/addons/website_sale_credit_point
@@ -1,0 +1,1 @@
+../../../../website_sale_credit_point

--- a/setup/website_sale_credit_point/setup.cfg
+++ b/setup/website_sale_credit_point/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal=1

--- a/setup/website_sale_credit_point/setup.cfg
+++ b/setup/website_sale_credit_point/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1

--- a/setup/website_sale_credit_point/setup.py
+++ b/setup/website_sale_credit_point/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/website_sale_credit_point/README.rst
+++ b/website_sale_credit_point/README.rst
@@ -1,0 +1,51 @@
+.. image:: https://img.shields.io/badge/license-AGPL--3-blue.png
+   :target: https://www.gnu.org/licenses/agpl
+   :alt: License: AGPL-3
+
+=========================
+website_sale_credit_point
+=========================
+
+Integrate `sale_credit_point` within Odoo e-shop.
+
+Sale credit point module allows you to buy things based on fixed credit.
+This module integrates the latter with the ecommerce
+and prevents users to complete checkout in case credit's amount is not ok.
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/e-commerce/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smash it by providing detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://odoo-community.org/logo.png>`_.
+
+Contributors
+------------
+
+* Simone Orsi <simone.orsi@camptocamp.com>
+
+Do not contact contributors directly about support or help with technical issues.
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/website_sale_credit_point/__init__.py
+++ b/website_sale_credit_point/__init__.py
@@ -1,0 +1,1 @@
+from . import controllers

--- a/website_sale_credit_point/__manifest__.py
+++ b/website_sale_credit_point/__manifest__.py
@@ -1,0 +1,18 @@
+# Copyright 2017 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+{
+    'name': 'Ecommerce Sale Credit Point',
+    'version': '11.0.1.0.0',
+    'category': 'Sales',
+    'license': 'AGPL-3',
+    'author': 'Camptocamp, Odoo Community Association (OCA)',
+    'website': 'https://github.com/OCA/e-commerce/',
+    'depends': [
+        'website_sale',
+        'sale_credit_point',
+    ],
+    'data': [
+        'templates/cart.xml',
+    ],
+}

--- a/website_sale_credit_point/__manifest__.py
+++ b/website_sale_credit_point/__manifest__.py
@@ -2,17 +2,17 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 {
-    'name': 'Ecommerce Sale Credit Point',
-    'version': '11.0.1.0.0',
-    'category': 'Sales',
-    'license': 'AGPL-3',
-    'author': 'Camptocamp, Odoo Community Association (OCA)',
-    'website': 'https://github.com/OCA/e-commerce/',
-    'depends': [
-        'website_sale',
-        'sale_credit_point',
+    "name": "Ecommerce Sale Credit Point",
+    "version": "11.0.1.0.0",
+    "category": "Sales",
+    "license": "AGPL-3",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "website": "https://github.com/OCA/e-commerce",
+    "depends": [
+        "website_sale",
+        "sale_credit_point",
     ],
-    'data': [
-        'templates/cart.xml',
+    "data": [
+        "templates/cart.xml",
     ],
 }

--- a/website_sale_credit_point/__manifest__.py
+++ b/website_sale_credit_point/__manifest__.py
@@ -1,9 +1,9 @@
-# Copyright 2017 Camptocamp SA
+# Copyright 2017-2022 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 {
     "name": "Ecommerce Sale Credit Point",
-    "version": "11.0.1.0.0",
+    "version": "15.0.1.0.0",
     "category": "Sales",
     "license": "AGPL-3",
     "author": "Camptocamp, Odoo Community Association (OCA)",

--- a/website_sale_credit_point/__manifest__.py
+++ b/website_sale_credit_point/__manifest__.py
@@ -14,5 +14,6 @@
     ],
     "data": [
         "templates/cart.xml",
+        "templates/navbar_points.xml",
     ],
 }

--- a/website_sale_credit_point/__manifest__.py
+++ b/website_sale_credit_point/__manifest__.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Camptocamp SA
+# Copyright 2017 Camptocamp
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 {

--- a/website_sale_credit_point/controllers/__init__.py
+++ b/website_sale_credit_point/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import website_sale

--- a/website_sale_credit_point/controllers/website_sale.py
+++ b/website_sale_credit_point/controllers/website_sale.py
@@ -1,15 +1,13 @@
-# -*- coding: utf-8 -*-
 # Copyright 2016-2017 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
-
-from odoo.addons.website_sale.controllers.main import WebsiteSale
 
 from odoo.exceptions import UserError
 from odoo.http import request
 
+from odoo.addons.website_sale.controllers.main import WebsiteSale
+
 
 class WebsiteSale(WebsiteSale):
-
     def checkout_redirection(self, order):
         """Don't process checkout if credit check is not satisfied."""
         redirection = super(WebsiteSale, self).checkout_redirection(order)
@@ -20,5 +18,5 @@ class WebsiteSale(WebsiteSale):
                 order.credit_point_check()
             except UserError as exc:
                 # error msg if not enought points
-                request.session['credit_point_limit_error'] = exc.name
-                return request.redirect('/shop/cart/')
+                request.session["credit_point_limit_error"] = exc.name
+                return request.redirect("/shop/cart/")

--- a/website_sale_credit_point/controllers/website_sale.py
+++ b/website_sale_credit_point/controllers/website_sale.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016-2017 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo.addons.website_sale.controllers.main import WebsiteSale
+
+from odoo.exceptions import UserError
+from odoo.http import request
+
+
+class WebsiteSale(WebsiteSale):
+
+    def checkout_redirection(self, order):
+        """Don't process checkout if credit check is not satisfied."""
+        redirection = super(WebsiteSale, self).checkout_redirection(order)
+        if redirection:
+            return redirection
+        else:
+            try:
+                order.credit_point_check()
+            except UserError as exc:
+                # error msg if not enought points
+                request.session['credit_point_limit_error'] = exc.name
+                return request.redirect('/shop/cart/')

--- a/website_sale_credit_point/controllers/website_sale.py
+++ b/website_sale_credit_point/controllers/website_sale.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Camptocamp SA
+# Copyright 2016-2022 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo.exceptions import UserError
@@ -18,5 +18,5 @@ class WebsiteSale(WebsiteSale):
                 order.credit_point_check()
             except UserError as exc:
                 # error msg if not enought points
-                request.session["credit_point_limit_error"] = exc.name
+                request.session["credit_point_limit_error"] = exc.args[0]
                 return request.redirect("/shop/cart/")

--- a/website_sale_credit_point/controllers/website_sale.py
+++ b/website_sale_credit_point/controllers/website_sale.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 Camptocamp SA
+# Copyright 2016 Camptocamp
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo.exceptions import UserError

--- a/website_sale_credit_point/templates/cart.xml
+++ b/website_sale_credit_point/templates/cart.xml
@@ -1,11 +1,17 @@
 <odoo>
     <template id="cart" inherit_id="website_sale.cart">
-        <xpath expr="//div[hasclass('oe_website_sale')]/div[hasclass('row')][1]" position="before">
-            <t t-set="credit_point_limit_error" t-value="request.session.pop('credit_point_limit_error', None)"/>
+        <xpath
+            expr="//div[hasclass('oe_website_sale')]/div[hasclass('row')][1]"
+            position="before"
+        >
+            <t
+                t-set="credit_point_limit_error"
+                t-value="request.session.pop('credit_point_limit_error', None)"
+            />
             <div class="row">
                 <div class="col-md-12">
                     <div class="alert alert-danger" t-if="credit_point_limit_error">
-                        <t t-esc="credit_point_limit_error"/>
+                        <t t-esc="credit_point_limit_error" />
                     </div>
                 </div>
             </div>

--- a/website_sale_credit_point/templates/cart.xml
+++ b/website_sale_credit_point/templates/cart.xml
@@ -1,0 +1,14 @@
+<odoo>
+    <template id="cart" inherit_id="website_sale.cart">
+        <xpath expr="//div[hasclass('oe_website_sale')]/div[hasclass('row')][1]" position="before">
+            <t t-set="credit_point_limit_error" t-value="request.session.pop('credit_point_limit_error', None)"/>
+            <div class="row">
+                <div class="col-md-12">
+                    <div class="alert alert-danger" t-if="credit_point_limit_error">
+                        <t t-esc="credit_point_limit_error"/>
+                    </div>
+                </div>
+            </div>
+        </xpath>
+    </template>
+</odoo>

--- a/website_sale_credit_point/templates/navbar_points.xml
+++ b/website_sale_credit_point/templates/navbar_points.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" ?>
+<odoo>
+
+    <template id="navbar_points" inherit_id="website_sale.header_cart_link">
+        <xpath expr="//li[last()]" position="after">
+            <li t-if="user_id.partner_id" class="nav-item">
+                <!-- I use an empty <a> tag here to get the styles, used in top menu -->
+                <span class="nav-link">Credit balance: <span
+                        t-esc="user_id.partner_id.credit_point"
+                    /></span>
+            </li>
+        </xpath>
+    </template>
+
+</odoo>


### PR DESCRIPTION
From V11.0
https://github.com/OCA/e-commerce/pull/221
Depends on
https://github.com/OCA/sale-workflow/pull/2229

It takes back work done on -> https://github.com/OCA/e-commerce/pull/688

As we don't work with him anymore. We are not able to work on his PR and add new commits. This is why I'm opening a new one

The improvement added into the module is the display of the current balance into the shop
![credit-balance](https://github.com/user-attachments/assets/f81204c4-aeb2-498b-b546-a4f8a243ed4b)
