### PR TITLE
[16.0][FIX] website_sale_order_type: Remove journal_id definition in tests to avoid side effects

### DIFF
--- a/website_sale_order_type/tests/test_website_sale_order_type.py
+++ b/website_sale_order_type/tests/test_website_sale_order_type.py
@@ -28,9 +28,6 @@ class TestFrontend(HttpCase):
                 "padding": 3,
             }
         )
-        self.journal = self.env["account.journal"].search(
-            [("type", "=", "sale")], limit=1
-        )
         self.warehouse = self.env.ref("stock.warehouse0")
         self.immediate_payment = self.env.ref("account.account_payment_term_immediate")
         self.sale_pricelist = self.env.ref("product.list0")
@@ -39,7 +36,6 @@ class TestFrontend(HttpCase):
             {
                 "name": "Test Sale Order Type",
                 "sequence_id": self.sequence.id,
-                "journal_id": self.journal.id,
                 "warehouse_id": self.warehouse.id,
                 "picking_policy": "one",
                 "payment_term_id": self.immediate_payment.id,


### PR DESCRIPTION
Remove `journal_id` definition in tests to avoid side effects.

```
odoo.exceptions.UserError: Incompatible companies on records:
- 'Test Sale Order Type' belongs to company 'My Company (San Francisco)' and 'Billing Journal' (journal_id: 'Customer Invoices') belongs to another company.
```

@Tecnativa