### PR TITLE
 [16.0][FIX] website_sale_product_minimal_price: Retrieve the correct pricelist for price computation

### DIFF
--- a/website_sale_product_minimal_price/models/product_template.py
+++ b/website_sale_product_minimal_price/models/product_template.py
@@ -92,14 +92,11 @@ class ProductTemplate(models.Model):
             parent_combination=parent_combination, necessary_values=necessary_values
         )
         context = self.env.context
-        if (
-            context.get("website_id")
-            and context.get("pricelist")
-            and self.product_variant_count > 1
-        ):
+        if context.get("website_id") and self.product_variant_count > 1:
             # It only makes sense to change the default one when there are
             # more than one variants and we know the pricelist
-            pricelist = self.env["product.pricelist"].browse(context["pricelist"])
+            current_website = self.env["website"].get_current_website()
+            pricelist = current_website.get_current_pricelist()
             product_id = self._get_cheapest_info(pricelist)[0]
             product = self.env["product.product"].browse(product_id)
             # Rebuild the combination in the expected order


### PR DESCRIPTION

During the migration to V16, this code stopped working because Odoo no longer passes the pricelist through the context. Instead, it must be retrieved from the website. This commit restores the expected behavior, ensuring the first variant with the minimal price is displayed correctly.

TT52394
@Tecnativa @pedrobaeza @sergio-teruel @pilarvargas-tecnativa cloud you pleas review this?