### PR TITLE
[IMP]website_sale_product_assortment: Apply assortments to accessory & alternative products

### DIFF
--- a/website_sale_product_assortment/__manifest__.py
+++ b/website_sale_product_assortment/__manifest__.py
@@ -12,7 +12,7 @@
     "maintainers": ["CarlosRoca13"],
     "installable": True,
     "depends": ["product_assortment", "website_sale"],
-    "data": ["views/ir_filters_views.xml"],
+    "data": ["views/ir_filters_views.xml", "views/suggested_products_list.xml"],
     "assets": {
         "web.assets_frontend": [
             "website_sale_product_assortment/static/src/xml/*.xml",

--- a/website_sale_product_assortment/models/__init__.py
+++ b/website_sale_product_assortment/models/__init__.py
@@ -1,2 +1,4 @@
 from . import ir_filters
 from . import product_template
+from . import website_snippet_filter
+from . import product_product

--- a/website_sale_product_assortment/models/product_product.py
+++ b/website_sale_product_assortment/models/product_product.py
@@ -1,0 +1,15 @@
+from odoo import models
+
+
+class ProductProduct(models.Model):
+    _inherit = "product.product"
+
+    def _show_quick_add_accesory_assortments(self):
+        res = self._website_show_quick_add()
+        if not res:
+            return res
+        return not bool(
+            self.env["product.template"].get_product_assortment_restriction_info(
+                self.ids
+            )
+        )

--- a/website_sale_product_assortment/models/product_template.py
+++ b/website_sale_product_assortment/models/product_template.py
@@ -85,3 +85,31 @@ class ProductTemplate(models.Model):
             domain.append(allowed_product_domain)
         res["base_domain"] = domain
         return res
+
+    def _get_allowed_show_products(self, products):
+        if not products:
+            return products
+        restricted_products_dict = self.get_product_assortment_restriction_info(
+            products.ids
+        )
+        if not restricted_products_dict:
+            return products
+
+        allowed_show_products = products.filtered(
+            lambda p: p.id not in restricted_products_dict
+            or not any(
+                assortment.website_availability == "no_show"
+                for assortment in restricted_products_dict[p.id]
+            )
+        )
+        return allowed_show_products
+
+    def _get_website_accessory_product(self):
+        res = super()._get_website_accessory_product()
+        visible_products = self._get_allowed_show_products(res)
+        return visible_products
+
+    def _get_website_alternative_product(self):
+        res = super()._get_website_alternative_product()
+        visible_products = self._get_allowed_show_products(res)
+        return visible_products

--- a/website_sale_product_assortment/models/website_snippet_filter.py
+++ b/website_sale_product_assortment/models/website_snippet_filter.py
@@ -1,0 +1,22 @@
+from odoo import models
+
+
+class WebsiteSnippetFilter(models.Model):
+    _inherit = "website.snippet.filter"
+
+    def _get_products_alternative_products(self, *args):
+        products = super()._get_products_alternative_products(*args)
+        if not products:
+            return products
+        restricted_products_dict = self.env[
+            "product.template"
+        ].get_product_assortment_restriction_info(products.ids)
+        if not restricted_products_dict:
+            return products
+        return products.filtered(
+            lambda p: p.id not in restricted_products_dict
+            or not any(
+                assortment.website_availability == "no_show"
+                for assortment in restricted_products_dict[p.id]
+            )
+        )

--- a/website_sale_product_assortment/views/suggested_products_list.xml
+++ b/website_sale_product_assortment/views/suggested_products_list.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <template
+        id="suggested_products_assortment_restriction"
+        inherit_id="website_sale.suggested_products_list"
+        name="Accessories with Assortment Restrictions"
+    >
+        <xpath
+            expr="//a[@t-if='product._website_show_quick_add()']"
+            position="attributes"
+        >
+            <attribute
+                name="t-if"
+            >product._show_quick_add_accesory_assortments()</attribute>
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
Issue

- Previously, product assortment restrictions were not correctly applied to accessory and alternative products displayed in website carousels. This created inconsistencies in product visibility and allowed users to add restricted products to their cart from the accessories section.

Solution

- Implemented proper filtering for accessory products based on assortment restrictions
- Extended the same restriction logic to alternative products in website carousels
- Fixed cart view to prevent purchasing restricted products

Reproduction Steps (in Runboat)

1. Configure product assortments with visibility and/or sale restrictions
2. Add accessory and alternative products to a main product
3. Visit the website and observe product carousels and cart behavior

Before fix: Restricted products remained visible in carousels, and accessory products could be added to cart despite restrictions.

After fix: Products are properly filtered according to assortment rules across all website sections, ensuring consistent visibility and purchasing restrictions.

Technical Approach

- Created helper method _get_allowed_show_products in product.template to ensure consistent filtering logic
- Enhanced the existing accessory/alternative product methods to incorporate assortment restrictions:
_get_website_accessory_product
_get_website_alternative_product
_get_products_alternative_products (website snippet filter)
- Added _show_quick_add_accesory_assortments method in product.product specifically for controlling "Add to cart" button visibility in the cart view for accessory products
- Modified cart template view to use this new method, preventing addition of restricted accessory products

FL-556-4432
