### PR TITLE
[FIX] website_sale_hide_price: change manifest

### DIFF
--- a/website_sale_hide_price/__manifest__.py
+++ b/website_sale_hide_price/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "Website Sale Hide Price",
-    "version": "17.0.1.1.2",
+    "version": "17.0.1.2.2",
     "category": "Website",
     "author": "Tecnativa, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/e-commerce",


### PR DESCRIPTION
Some Odoo databases with this module installed display this error. This is because a change was made to the view without modifying the manifest version.
PR without the change in manifest https://github.com/OCA/e-commerce/pull/1040

Error: psycopg2.errors.UndefinedColumn: column res_partner.website_show_price does not exist
LINE 1: ...", "res_partner"."require_purchase_order_number", "res_partn...