### PR TITLE
[16.0][IMP] website_sale_tax_toggle: Add default tax toggle configuration at website level

### DIFF
--- a/website_sale_tax_toggle/README.rst
+++ b/website_sale_tax_toggle/README.rst
@@ -36,6 +36,14 @@ button to allow to user selects view prices with taxes included or without taxes
 .. contents::
    :local:
 
+Configuration
+=============
+
+A default value is set to show taxes at website level. To set this value, go to
+website > configuration and select the website on which to change the default value.
+The field Toggle default tax will be unchecked by default, to make the default value
+active when entering the website, check the field.
+
 Usage
 =====
 
@@ -68,6 +76,7 @@ Contributors
 
     * Carlos Dauden <carlos.dauden@tecnativa.com>
     * Sergio Teruel <sergio.teruel@tecnativa.com>
+    * Pilar Vargas
 
 Maintainers
 ~~~~~~~~~~~

--- a/website_sale_tax_toggle/__manifest__.py
+++ b/website_sale_tax_toggle/__manifest__.py
@@ -12,7 +12,7 @@
     "application": False,
     "installable": True,
     "depends": ["website_sale"],
-    "data": ["views/templates.xml"],
+    "data": ["views/templates.xml", "views/website_views.xml"],
     "assets": {
         "web.assets_frontend": [
             "/website_sale_tax_toggle/static/src/js/website_sale_tax_toggle.esm.js",

--- a/website_sale_tax_toggle/controllers/main.py
+++ b/website_sale_tax_toggle/controllers/main.py
@@ -1,4 +1,5 @@
 # Copyright 2020 Tecnativa - Sergio Teruel
+# Copyright 2025 Tecnativa - Pilar Vargas
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import http
@@ -8,10 +9,35 @@ from odoo.addons.website_sale.controllers.main import WebsiteSale
 
 
 class WebsiteSaleTaxToggle(WebsiteSale):
+    @http.route()
+    def shop(
+        self,
+        page=0,
+        category=None,
+        search="",
+        min_price=0.0,
+        max_price=0.0,
+        ppg=False,
+        **post
+    ):
+        res = super().shop(
+            page=page,
+            category=category,
+            search=search,
+            min_price=min_price,
+            max_price=max_price,
+            ppg=ppg,
+            **post
+        )
+        if request.session.get("tax_toggle_taxed") is None:
+            tax_toggle_preactivated = request.website.tax_toggle_preactivated
+            request.session["tax_toggle_taxed"] = tax_toggle_preactivated
+        return res
+
     @http.route(["/website/tax_toggle"], type="json", auth="public", website=True)
     def tax_toggle(self):
-        # Create a session variable
-        request.session["tax_toggle_taxed"] = not request.session.get(
-            "tax_toggle_taxed", False
-        )
+        if request.session.get("tax_toggle_taxed") is None:
+            tax_toggle_preactivated = request.website.tax_toggle_preactivated
+            request.session["tax_toggle_taxed"] = tax_toggle_preactivated
+        request.session["tax_toggle_taxed"] = not request.session["tax_toggle_taxed"]
         return request.session["tax_toggle_taxed"]

--- a/website_sale_tax_toggle/i18n/ca.po
+++ b/website_sale_tax_toggle/i18n/ca.po
@@ -6,15 +6,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: 2021-01-20 20:45+0000\n"
+"POT-Creation-Date: 2025-04-09 20:29+0000\n"
+"PO-Revision-Date: 2025-04-09 22:35+0200\n"
 "Last-Translator: claudiagn <claudia.gargallo@qubiq.es>\n"
 "Language-Team: none\n"
 "Language: ca\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.3.2\n"
+"X-Generator: Poedit 3.4.2\n"
 
 #. module: website_sale_tax_toggle
 #: model_terms:ir.ui.view,arch_db:website_sale_tax_toggle.tax_toggle_template
@@ -26,6 +27,27 @@ msgstr ""
 "                <span>Mostra preus amb taxes incloses</span>"
 
 #. module: website_sale_tax_toggle
+#: model:ir.model.fields,field_description:website_sale_tax_toggle.field_website__tax_toggle_preactivated
+msgid "Tax Toggle Preactivated"
+msgstr "Impostos activats per defecte"
+
+#. module: website_sale_tax_toggle
+#: model:ir.model.fields,help:website_sale_tax_toggle.field_website__tax_toggle_preactivated
+msgid ""
+"If enabled, the tax toggle will be active by default when entering the "
+"website."
+msgstr ""
+"Si s'activa, l'opció d'impostos estarà activada per defecte en entrar "
+"al lloc web.\""
+
+#. module: website_sale_tax_toggle
 #: model:ir.model,name:website_sale_tax_toggle.model_res_users
-msgid "Users"
+#, fuzzy
+#| msgid "Users"
+msgid "User"
 msgstr "Usuaris"
+
+#. module: website_sale_tax_toggle
+#: model:ir.model,name:website_sale_tax_toggle.model_website
+msgid "Website"
+msgstr ""

--- a/website_sale_tax_toggle/i18n/es.po
+++ b/website_sale_tax_toggle/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-07 14:17+0000\n"
-"PO-Revision-Date: 2020-07-07 16:19+0200\n"
+"POT-Creation-Date: 2025-04-09 20:29+0000\n"
+"PO-Revision-Date: 2025-04-09 22:33+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: es\n"
@@ -15,7 +15,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 2.0.6\n"
+"X-Generator: Poedit 3.4.2\n"
 
 #. module: website_sale_tax_toggle
 #: model_terms:ir.ui.view,arch_db:website_sale_tax_toggle.tax_toggle_template
@@ -27,6 +27,27 @@ msgstr ""
 "                <span>Mostrar precios con impuestos incluidos</span>"
 
 #. module: website_sale_tax_toggle
+#: model:ir.model.fields,field_description:website_sale_tax_toggle.field_website__tax_toggle_preactivated
+msgid "Tax Toggle Preactivated"
+msgstr "Impuestos activados por defecto"
+
+#. module: website_sale_tax_toggle
+#: model:ir.model.fields,help:website_sale_tax_toggle.field_website__tax_toggle_preactivated
+msgid ""
+"If enabled, the tax toggle will be active by default when entering the "
+"website."
+msgstr ""
+"Si se activa, la opción de impuestos se activará por defecto al entrar "
+"en el sitio web."
+
+#. module: website_sale_tax_toggle
 #: model:ir.model,name:website_sale_tax_toggle.model_res_users
-msgid "Users"
+#, fuzzy
+#| msgid "Users"
+msgid "User"
 msgstr "Usuarios"
+
+#. module: website_sale_tax_toggle
+#: model:ir.model,name:website_sale_tax_toggle.model_website
+msgid "Website"
+msgstr "Sitio web"

--- a/website_sale_tax_toggle/i18n/fr.po
+++ b/website_sale_tax_toggle/i18n/fr.po
@@ -6,15 +6,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: 2020-11-23 15:36+0000\n"
+"POT-Creation-Date: 2025-04-09 20:29+0000\n"
+"PO-Revision-Date: 2025-04-09 22:36+0200\n"
 "Last-Translator: Yann Papouin <y.papouin@dec-industrie.com>\n"
 "Language-Team: none\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
-"X-Generator: Weblate 3.10\n"
+"X-Generator: Poedit 3.4.2\n"
 
 #. module: website_sale_tax_toggle
 #: model_terms:ir.ui.view,arch_db:website_sale_tax_toggle.tax_toggle_template
@@ -26,6 +27,25 @@ msgstr ""
 "                <span>Afficher les prix TTC</span>"
 
 #. module: website_sale_tax_toggle
+#: model:ir.model.fields,field_description:website_sale_tax_toggle.field_website__tax_toggle_preactivated
+msgid "Tax Toggle Preactivated"
+msgstr "Taxes activées par défaut"
+
+#. module: website_sale_tax_toggle
+#: model:ir.model.fields,help:website_sale_tax_toggle.field_website__tax_toggle_preactivated
+msgid ""
+"If enabled, the tax toggle will be active by default when entering the "
+"website."
+msgstr ""
+
+#. module: website_sale_tax_toggle
 #: model:ir.model,name:website_sale_tax_toggle.model_res_users
-msgid "Users"
+#, fuzzy
+#| msgid "Users"
+msgid "User"
 msgstr "Utilisateurs"
+
+#. module: website_sale_tax_toggle
+#: model:ir.model,name:website_sale_tax_toggle.model_website
+msgid "Website"
+msgstr ""

--- a/website_sale_tax_toggle/i18n/it.po
+++ b/website_sale_tax_toggle/i18n/it.po
@@ -6,15 +6,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: 2024-08-26 12:06+0000\n"
+"POT-Creation-Date: 2025-04-09 20:29+0000\n"
+"PO-Revision-Date: 2025-04-09 22:36+0200\n"
 "Last-Translator: mymage <stefano.consolaro@mymage.it>\n"
 "Language-Team: none\n"
 "Language: it\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.6.2\n"
+"X-Generator: Poedit 3.4.2\n"
 
 #. module: website_sale_tax_toggle
 #: model_terms:ir.ui.view,arch_db:website_sale_tax_toggle.tax_toggle_template
@@ -26,6 +27,23 @@ msgstr ""
 "                <span>Visualizza prezzi con le imposte incluse</span>"
 
 #. module: website_sale_tax_toggle
+#: model:ir.model.fields,field_description:website_sale_tax_toggle.field_website__tax_toggle_preactivated
+msgid "Tax Toggle Preactivated"
+msgstr "Tasse attivate per impostazione predefinita"
+
+#. module: website_sale_tax_toggle
+#: model:ir.model.fields,help:website_sale_tax_toggle.field_website__tax_toggle_preactivated
+msgid ""
+"If enabled, the tax toggle will be active by default when entering the "
+"website."
+msgstr ""
+
+#. module: website_sale_tax_toggle
 #: model:ir.model,name:website_sale_tax_toggle.model_res_users
 msgid "User"
 msgstr "Utente"
+
+#. module: website_sale_tax_toggle
+#: model:ir.model,name:website_sale_tax_toggle.model_website
+msgid "Website"
+msgstr ""

--- a/website_sale_tax_toggle/i18n/nl.po
+++ b/website_sale_tax_toggle/i18n/nl.po
@@ -6,15 +6,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: 2021-04-05 18:46+0000\n"
-"Last-Translator: Bosd <c5e2fd43-d292-4c90-9d1f-74ff3436329a@anonaddy.me>\n"
+"POT-Creation-Date: 2025-04-09 20:29+0000\n"
+"PO-Revision-Date: 2025-04-09 22:36+0200\n"
+"Last-Translator: Bosd <c5e2fd43-d292-4c90-9d1f-74ff3436329a@anonaddy."
+"me>\n"
 "Language-Team: none\n"
 "Language: nl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.3.2\n"
+"X-Generator: Poedit 3.4.2\n"
 
 #. module: website_sale_tax_toggle
 #: model_terms:ir.ui.view,arch_db:website_sale_tax_toggle.tax_toggle_template
@@ -26,6 +28,25 @@ msgstr ""
 "                <span>Prijzen weergeven inclusief BTW</span>"
 
 #. module: website_sale_tax_toggle
+#: model:ir.model.fields,field_description:website_sale_tax_toggle.field_website__tax_toggle_preactivated
+msgid "Tax Toggle Preactivated"
+msgstr "Standaard ingeschakelde belastingen"
+
+#. module: website_sale_tax_toggle
+#: model:ir.model.fields,help:website_sale_tax_toggle.field_website__tax_toggle_preactivated
+msgid ""
+"If enabled, the tax toggle will be active by default when entering the "
+"website."
+msgstr ""
+
+#. module: website_sale_tax_toggle
 #: model:ir.model,name:website_sale_tax_toggle.model_res_users
-msgid "Users"
+#, fuzzy
+#| msgid "Users"
+msgid "User"
 msgstr "Gebruikers"
+
+#. module: website_sale_tax_toggle
+#: model:ir.model,name:website_sale_tax_toggle.model_website
+msgid "Website"
+msgstr ""

--- a/website_sale_tax_toggle/i18n/website_sale_tax_toggle.pot
+++ b/website_sale_tax_toggle/i18n/website_sale_tax_toggle.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-04-09 20:29+0000\n"
+"PO-Revision-Date: 2025-04-09 20:29+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -21,6 +23,23 @@ msgid ""
 msgstr ""
 
 #. module: website_sale_tax_toggle
+#: model:ir.model.fields,field_description:website_sale_tax_toggle.field_website__tax_toggle_preactivated
+msgid "Tax Toggle Preactivated"
+msgstr ""
+
+#. module: website_sale_tax_toggle
+#: model:ir.model.fields,help:website_sale_tax_toggle.field_website__tax_toggle_preactivated
+msgid ""
+"If enabled, the tax toggle will be active by default when entering the "
+"website."
+msgstr ""
+
+#. module: website_sale_tax_toggle
 #: model:ir.model,name:website_sale_tax_toggle.model_res_users
 msgid "User"
+msgstr ""
+
+#. module: website_sale_tax_toggle
+#: model:ir.model,name:website_sale_tax_toggle.model_website
+msgid "Website"
 msgstr ""

--- a/website_sale_tax_toggle/models/__init__.py
+++ b/website_sale_tax_toggle/models/__init__.py
@@ -1,3 +1,4 @@
 # Copyright 2020 Tecnativa - Sergio Teruel
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from . import res_users
+from . import website

--- a/website_sale_tax_toggle/models/website.py
+++ b/website_sale_tax_toggle/models/website.py
@@ -1,0 +1,13 @@
+# Copyright 2025 Tecnativa - Pilar Vargas
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class Website(models.Model):
+    _inherit = "website"
+
+    tax_toggle_preactivated = fields.Boolean(
+        default=False,
+        help="If enabled, the tax toggle will be active by default when entering the website.",
+    )

--- a/website_sale_tax_toggle/readme/CONFIGURE.rst
+++ b/website_sale_tax_toggle/readme/CONFIGURE.rst
@@ -1,0 +1,4 @@
+A default value is set to show taxes at website level. To set this value, go to
+website > configuration and select the website on which to change the default value.
+The field Toggle default tax will be unchecked by default, to make the default value
+active when entering the website, check the field.

--- a/website_sale_tax_toggle/readme/CONTRIBUTORS.rst
+++ b/website_sale_tax_toggle/readme/CONTRIBUTORS.rst
@@ -2,3 +2,4 @@
 
     * Carlos Dauden <carlos.dauden@tecnativa.com>
     * Sergio Teruel <sergio.teruel@tecnativa.com>
+    * Pilar Vargas

--- a/website_sale_tax_toggle/static/description/index.html
+++ b/website_sale_tax_toggle/static/description/index.html
@@ -375,18 +375,26 @@ button to allow to user selects view prices with taxes included or without taxes
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
-<li><a class="reference internal" href="#usage" id="toc-entry-1">Usage</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-2">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-3">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-4">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-5">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-6">Maintainers</a></li>
+<li><a class="reference internal" href="#configuration" id="toc-entry-1">Configuration</a></li>
+<li><a class="reference internal" href="#usage" id="toc-entry-2">Usage</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-3">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-4">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-5">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-6">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-7">Maintainers</a></li>
 </ul>
 </li>
 </ul>
 </div>
+<div class="section" id="configuration">
+<h1><a class="toc-backref" href="#toc-entry-1">Configuration</a></h1>
+<p>A default value is set to show taxes at website level. To set this value, go to
+website &gt; configuration and select the website on which to change the default value.
+The field Toggle default tax will be unchecked by default, to make the default value
+active when entering the website, check the field.</p>
+</div>
 <div class="section" id="usage">
-<h1><a class="toc-backref" href="#toc-entry-1">Usage</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-2">Usage</a></h1>
 <ol class="arabic simple">
 <li>Go to Website Shop.</li>
 <li>Now you can see a taxes toggle button to select prices with taxes included or
@@ -394,7 +402,7 @@ without taxes.</li>
 </ol>
 </div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#toc-entry-2">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-3">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/e-commerce/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -402,28 +410,29 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#toc-entry-3">Credits</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-4">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#toc-entry-4">Authors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-5">Authors</a></h2>
 <ul class="simple">
 <li>Tecnativa</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#toc-entry-5">Contributors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-6">Contributors</a></h2>
 <ul>
 <li><p class="first"><a class="reference external" href="https://www.tecnativa.com">Tecnativa</a>:</p>
 <blockquote>
 <ul class="simple">
 <li>Carlos Dauden &lt;<a class="reference external" href="mailto:carlos.dauden&#64;tecnativa.com">carlos.dauden&#64;tecnativa.com</a>&gt;</li>
 <li>Sergio Teruel &lt;<a class="reference external" href="mailto:sergio.teruel&#64;tecnativa.com">sergio.teruel&#64;tecnativa.com</a>&gt;</li>
+<li>Pilar Vargas</li>
 </ul>
 </blockquote>
 </li>
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org">
 <img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />

--- a/website_sale_tax_toggle/views/website_views.xml
+++ b/website_sale_tax_toggle/views/website_views.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="view_website_sale_website_form" model="ir.ui.view">
+        <field name="model">website</field>
+        <field name="inherit_id" ref="website.view_website_form" />
+        <field name="arch" type="xml">
+            <field name="default_lang_id" position="after">
+                <field name="tax_toggle_preactivated" />
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Implemented a new setting `default_tax_toggle` at the website level to control the default state of the tax toggle on the website. This allows the tax toggle to be set to active or inactive by default when a user first visits the website.

cc @Tecnativa TT55895

@carlosdauden @CarlosRoca13 @pedrobaeza please review