### PR TITLE
[17.0][FIX] website_sale_hide_price: Hide price in product carousel

### DIFF
--- a/website_sale_hide_price/data/product_snippet_template_data.xml
+++ b/website_sale_hide_price/data/product_snippet_template_data.xml
@@ -9,7 +9,7 @@
         <xpath expr="//span[hasclass('fw-bold')]" position="before">
             <div
                 id="website_hide_price"
-                t-if="user_id.partner_id.website_show_price and not data.get('website_hide_price')"
+                t-if="website.website_show_price and not data.get('website_hide_price')"
             />
         </xpath>
         <xpath expr="//div[@id='website_hide_price']" position="inside">


### PR DESCRIPTION
When the price of products was hidden at the website level, the product carousel continued to display it. To prevent this malfunction, the condition is adjusted to check at the website level whether it is permitted to display it.

@Tecnativa 

Before:

<img width="1202" height="364" alt="image" src="https://github.com/user-attachments/assets/ab1af102-c184-441e-b363-e0a7268344b2" />

After:

<img width="1202" height="364" alt="image" src="https://github.com/user-attachments/assets/b9ffc053-b9fa-4152-8238-9a1a30a2ae05" />


@carlos-lopez-tecnativa @juancarlosonate-tecnativa please review