### PR TITLE
[17.0][FIX] website_sale_hide_price: Don't make snippets noupdate

### DIFF
--- a/website_sale_hide_price/__manifest__.py
+++ b/website_sale_hide_price/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "Website Sale Hide Price",
-    "version": "17.0.1.1.3",
+    "version": "17.0.1.2.0",
     "category": "Website",
     "author": "Tecnativa, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/e-commerce",

--- a/website_sale_hide_price/data/product_snippet_template_data.xml
+++ b/website_sale_hide_price/data/product_snippet_template_data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<odoo noupdate="1">
+<odoo>
     <!-- Hide add to cart button and prices from dynamic product snippet templates if not
         website_show_price -->
     <template

--- a/website_sale_hide_price/migrations/17.0.1.2.0/pre-migration.py
+++ b/website_sale_hide_price/migrations/17.0.1.2.0/pre-migration.py
@@ -1,0 +1,19 @@
+# Copyright 2025 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.set_xml_ids_noupdate_value(
+        env,
+        "website_sale_hide_price",
+        [
+            "price_dynamic_filter_template_product_product",
+            "filter_template_dynamic_product_product_borderless_2",
+            "filter_template_dynamic_product_product_add_to_cart",
+            "filter_template_dynamic_product_product_horizontal_card",
+            "filter_template_dynamic_product_product_banner",
+        ],
+        False,
+    )


### PR DESCRIPTION
Forward-port of #1086 

They shouldn't be modified by users, and being noupdate complicates migrations due to version changes not auto-updated.

It includes the migration script to convert the noupdate flag of the involved templates to noupdate=0.

@Tecnativa 