### PR TITLE
[17.0][FIX] website_sale_hide_price: repair regression as part of #1079

### DIFF
--- a/website_sale_hide_price/views/website_sale_template.xml
+++ b/website_sale_hide_price/views/website_sale_template.xml
@@ -47,7 +47,10 @@
         </xpath>
     </template>
     <template id="product_quantity" inherit_id="website_sale.product_quantity">
-        <xpath expr="//div[contains(@t-attf-class, '')]" position="attributes">
+        <xpath
+            expr="//div[contains(@t-attf-class, 'css_quantity')]"
+            position="attributes"
+        >
             <attribute name="t-if">
                     website and website.website_show_price and not product.website_hide_price
                 </attribute>


### PR DESCRIPTION
#1079 made a change to website_sale_hide_price, which appears at least in our use case to have made the module behave differently (no product page at all, rather than no price or buy options)

Fixes GH184666