### PR TITLE
[16.0][IMP] website_sale_product_assortment: Implement restrictions on the cart in _cart_update and shop_payment 

### DIFF
--- a/website_sale_product_assortment/__manifest__.py
+++ b/website_sale_product_assortment/__manifest__.py
@@ -12,7 +12,7 @@
     "maintainers": ["CarlosRoca13"],
     "installable": True,
     "depends": ["product_assortment", "website_sale"],
-    "data": ["views/ir_filters_views.xml"],
+    "data": ["views/ir_filters_views.xml", "views/suggested_products_list.xml"],
     "assets": {
         "web.assets_frontend": [
             "website_sale_product_assortment/static/src/xml/*.xml",

--- a/website_sale_product_assortment/controllers/website_sale.py
+++ b/website_sale_product_assortment/controllers/website_sale.py
@@ -2,6 +2,8 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from werkzeug.exceptions import NotFound
 
+from odoo import _, http
+from odoo.exceptions import UserError
 from odoo.http import request, route
 
 from odoo.addons.website_sale.controllers.main import WebsiteSale
@@ -81,3 +83,27 @@ class WebsiteSale(WebsiteSale):
                 ("product_variant_ids", "in", list(allowed_product_ids))
             ]
         return res
+
+    @http.route()
+    def shop_payment(self, **post):
+        order = request.website.sale_get_order()
+        restricted_product_names = []
+        order_lines = order.order_line.filtered(lambda l: not l.display_type and l.product_id.website_published)
+        restricted_product_ids = request.env["product.template"].get_product_assortment_restriction_info(
+            order_lines.product_id.ids
+        )
+        restricted_product_names = [
+            line.name
+            for line in order_lines
+            if line.product_id.id in restricted_product_ids
+        ]
+        if restricted_product_names:
+            restricted_products_str = ", ".join(restricted_product_names)
+            raise UserError(
+                _(
+                    "The following products cannot be added to the cart because "
+                    "they are restricted: %s. Please remove the product to continue."
+                )
+                % restricted_products_str
+            )
+        return super().shop_payment(**post)

--- a/website_sale_product_assortment/i18n/es.po
+++ b/website_sale_product_assortment/i18n/es.po
@@ -93,6 +93,14 @@ msgid "Filters"
 msgstr "Filtros"
 
 #. module: website_sale_product_assortment
+#. odoo-python
+#: code:addons/website_sale_product_assortment/models/sale_order.py:0
+#, python-format
+msgid "It cannot be added to the cart because the product is restricted."
+msgstr ""
+"No se puede añadir al carrito porque el producto está restringido."
+
+#. module: website_sale_product_assortment
 #: model:ir.model.fields,help:website_sale_product_assortment.field_ir_filters__message_unavailable
 msgid ""
 "Message showed when some product is not available and the option\n"
@@ -118,6 +126,17 @@ msgstr "No disponible"
 #: model:ir.model,name:website_sale_product_assortment.model_product_template
 msgid "Product Template"
 msgstr "Plantilla de producto"
+
+#. module: website_sale_product_assortment
+#. odoo-python
+#: code:addons/website_sale_product_assortment/controllers/website_sale.py:0
+#, python-format
+msgid ""
+"The following products cannot be added to the cart because they are "
+"restricted: %s. Please remove the product to continue."
+msgstr ""
+"Los siguientes productos no se pueden añadir al carrito porque están "
+"restringidos: %s. Por favor, elimínelos para continuar."
 
 #. module: website_sale_product_assortment
 #. openerp-web

--- a/website_sale_product_assortment/i18n/website_sale_product_assortment.pot
+++ b/website_sale_product_assortment/i18n/website_sale_product_assortment.pot
@@ -71,6 +71,13 @@ msgid "Filters"
 msgstr ""
 
 #. module: website_sale_product_assortment
+#. odoo-python
+#: code:addons/website_sale_product_assortment/models/sale_order.py:0
+#, python-format
+msgid "It cannot be added to the cart because the product is restricted."
+msgstr ""
+
+#. module: website_sale_product_assortment
 #: model:ir.model.fields,help:website_sale_product_assortment.field_ir_filters__message_unavailable
 msgid ""
 "Message showed when some product is not available and the option\n"
@@ -93,6 +100,15 @@ msgstr ""
 #. module: website_sale_product_assortment
 #: model:ir.model,name:website_sale_product_assortment.model_product_template
 msgid "Product"
+msgstr ""
+
+#. module: website_sale_product_assortment
+#. odoo-python
+#: code:addons/website_sale_product_assortment/controllers/website_sale.py:0
+#, python-format
+msgid ""
+"The following products cannot be added to the cart because they are "
+"restricted: %s. Please remove the product to continue."
 msgstr ""
 
 #. module: website_sale_product_assortment

--- a/website_sale_product_assortment/models/__init__.py
+++ b/website_sale_product_assortment/models/__init__.py
@@ -1,2 +1,4 @@
 from . import ir_filters
 from . import product_template
+from . import website_snippet_filter
+from . import product_product

--- a/website_sale_product_assortment/models/__init__.py
+++ b/website_sale_product_assortment/models/__init__.py
@@ -2,3 +2,4 @@ from . import ir_filters
 from . import product_template
 from . import website_snippet_filter
 from . import product_product
+from . import sale_order

--- a/website_sale_product_assortment/models/product_product.py
+++ b/website_sale_product_assortment/models/product_product.py
@@ -1,0 +1,15 @@
+from odoo import models
+
+
+class ProductProduct(models.Model):
+    _inherit = "product.product"
+
+    def _show_quick_add_accesory_assortments(self):
+        res = self._website_show_quick_add()
+        if not res:
+            return res
+        return not bool(
+            self.env["product.template"].get_product_assortment_restriction_info(
+                self.ids
+            )
+        )

--- a/website_sale_product_assortment/models/product_product.py
+++ b/website_sale_product_assortment/models/product_product.py
@@ -5,6 +5,7 @@ class ProductProduct(models.Model):
     _inherit = "product.product"
 
     def _show_quick_add_accesory_assortments(self):
+        self.ensure_one()
         res = self._website_show_quick_add()
         if not res:
             return res

--- a/website_sale_product_assortment/models/product_template.py
+++ b/website_sale_product_assortment/models/product_template.py
@@ -85,3 +85,31 @@ class ProductTemplate(models.Model):
             domain.append(allowed_product_domain)
         res["base_domain"] = domain
         return res
+
+    def _get_allowed_show_products(self, products):
+        if not products:
+            return products
+        restricted_products_dict = self.get_product_assortment_restriction_info(
+            products.ids
+        )
+        if not restricted_products_dict:
+            return products
+
+        allowed_show_products = products.filtered(
+            lambda p: p.id not in restricted_products_dict
+            or not any(
+                assortment.website_availability == "no_show"
+                for assortment in restricted_products_dict[p.id]
+            )
+        )
+        return allowed_show_products
+
+    def _get_website_accessory_product(self):
+        res = super()._get_website_accessory_product()
+        visible_products = self._get_allowed_show_products(res)
+        return visible_products
+
+    def _get_website_alternative_product(self):
+        res = super()._get_website_alternative_product()
+        visible_products = self._get_allowed_show_products(res)
+        return visible_products

--- a/website_sale_product_assortment/models/product_template.py
+++ b/website_sale_product_assortment/models/product_template.py
@@ -95,21 +95,18 @@ class ProductTemplate(models.Model):
         if not restricted_products_dict:
             return products
 
-        allowed_show_products = products.filtered(
+        return products.filtered(
             lambda p: p.id not in restricted_products_dict
             or not any(
                 assortment.website_availability == "no_show"
                 for assortment in restricted_products_dict[p.id]
             )
         )
-        return allowed_show_products
 
     def _get_website_accessory_product(self):
-        res = super()._get_website_accessory_product()
-        visible_products = self._get_allowed_show_products(res)
-        return visible_products
+        return self._get_allowed_show_products(super()._get_website_accessory_product())
 
     def _get_website_alternative_product(self):
-        res = super()._get_website_alternative_product()
-        visible_products = self._get_allowed_show_products(res)
-        return visible_products
+        return self._get_allowed_show_products(
+            super()._get_website_alternative_product()
+        )

--- a/website_sale_product_assortment/models/sale_order.py
+++ b/website_sale_product_assortment/models/sale_order.py
@@ -1,0 +1,22 @@
+from odoo import _, models
+from odoo.exceptions import UserError
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    def _cart_update(self, product_id, line_id=None, add_qty=0, set_qty=0, **kwargs):
+        product = self.env["product.product"].browse(product_id)
+        if not product._show_quick_add_accesory_assortments() and not (
+            add_qty == 0 or (not add_qty and set_qty == 0)
+        ):
+            raise UserError(
+                _("It cannot be added to the cart because the product is restricted.")
+            )
+        return super()._cart_update(
+            product_id,
+            line_id=line_id,
+            add_qty=add_qty,
+            set_qty=set_qty,
+            **kwargs,
+        )

--- a/website_sale_product_assortment/models/website_snippet_filter.py
+++ b/website_sale_product_assortment/models/website_snippet_filter.py
@@ -1,0 +1,22 @@
+from odoo import models
+
+
+class WebsiteSnippetFilter(models.Model):
+    _inherit = "website.snippet.filter"
+
+    def _get_products_alternative_products(self, *args):
+        products = super()._get_products_alternative_products(*args)
+        if not products:
+            return products
+        restricted_products_dict = self.env[
+            "product.template"
+        ].get_product_assortment_restriction_info(products.ids)
+        if not restricted_products_dict:
+            return products
+        return products.filtered(
+            lambda p: p.id not in restricted_products_dict
+            or not any(
+                assortment.website_availability == "no_show"
+                for assortment in restricted_products_dict[p.id]
+            )
+        )

--- a/website_sale_product_assortment/tests/test_ui.py
+++ b/website_sale_product_assortment/tests/test_ui.py
@@ -1,5 +1,8 @@
 # Copyright 2021 Tecnativa - Carlos Roca
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from unittest.mock import patch
+
+from odoo.exceptions import UserError
 from odoo.tests import tagged
 from odoo.tests.common import HttpCase
 
@@ -22,6 +25,20 @@ class TestUI(HttpCase):
                 "is_published": True,
                 "website_sequence": 2,
                 "type": "consu",
+            }
+        )
+
+        # Configuración adicional para tests unitarios
+        self.partner = self.env["res.partner"].create(
+            {
+                "name": "Test Partner",
+                "email": "test@example.com",
+            }
+        )
+
+        self.sale_order = self.env["sale.order"].create(
+            {
+                "partner_id": self.partner.id,
             }
         )
 
@@ -98,3 +115,31 @@ class TestUI(HttpCase):
         self.start_tour(
             "/shop", "test_assortment_with_no_restriction_no_show", login="admin"
         )
+
+    def test_05_ui_cart_update_restricted_product(self):
+        product_patch_path = (
+            "odoo.addons.website_sale_product_assortment.models.product_product."
+            "ProductProduct._show_quick_add_accesory_assortments"
+        )
+        with patch(product_patch_path, return_value=False):
+            with self.assertRaises(UserError) as cm:
+                self.sale_order._cart_update(
+                    product_id=self.product.product_variant_id.id,
+                    add_qty=1,
+                    set_qty=1,
+                )
+            self.assertIn(
+                "It cannot be added to the cart because the product is restricted.",
+                str(cm.exception),
+            )
+
+    def test_06_ui_cart_update_allowed_product(self):
+        product_patch_path = (
+            "odoo.addons.website_sale_product_assortment.models.product_product."
+            "ProductProduct._show_quick_add_accesory_assortments"
+        )
+        with patch(product_patch_path, return_value=True):
+            result = self.sale_order._cart_update(
+                product_id=self.product.product_variant_id.id, add_qty=1
+            )
+            self.assertIsInstance(result, dict)

--- a/website_sale_product_assortment/views/suggested_products_list.xml
+++ b/website_sale_product_assortment/views/suggested_products_list.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <template
+        id="suggested_products_assortment_restriction"
+        inherit_id="website_sale.suggested_products_list"
+        name="Accessories with Assortment Restrictions"
+    >
+        <xpath
+            expr="//a[@t-if='product._website_show_quick_add()']"
+            position="attributes"
+        >
+            <attribute
+                name="t-if"
+            >product._show_quick_add_accesory_assortments()</attribute>
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
### Description

A user experience issue was identified where customers could accidentally add restricted products to their cart. This occurred in cases where the product assortment was configured as "_Avoid selling not available products_" 

Due to slow product loading times, the "_add to cart_" button could be clicked on a restricted product before the restriction was fully applied, allowing the customer to purchase it.

It was identified that a product could be added to the cart without restrictions. If restrictions were subsequently applied to that product while it was still in the cart, the payment could still be completed even though the product was now restricted.

### Cases Covered with This Improvement
This update introduces two layers of security to prevent the sale of restricted products:

1. Immediate Cart Restriction: A new security layer has been implemented to block restricted products from being added to the cart, even if the "add to cart" button is clicked due to a slow-loading product page. This ensures that only valid products can be added.

2. Checkout Restriction: An additional security check has been added to the checkout process. If a product in the cart was previously available but has since been restricted, the customer will receive an error message preventing them from completing the purchase.

### Implemented Solution
This issue was resolved by implementing assortment restrictions within the `_cart_update` method of `sale_order.py` and the `shop_payment` method of `website_sale.py`. 

The solution utilizes the `_show_quick_add_accesory_assortments` method, which was previously implemented in this pull request: https://github.com/OCA/e-commerce/pull/1038

FL-556-5722