### PR TITLE
[18.0][IMP] website_sale_product_attribute_value_filter_existing: improve performance using ID sets

### DIFF
--- a/website_sale_product_attribute_value_filter_existing/controllers/main.py
+++ b/website_sale_product_attribute_value_filter_existing/controllers/main.py
@@ -1,42 +1,29 @@
 # Copyright 2019 Tecnativa - Sergio Teruel
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
-from odoo import http
 from odoo.http import request
-from odoo.tools import lazy
 
 from odoo.addons.website_sale.controllers.main import WebsiteSale
 
 
 class ProductAttributeValues(WebsiteSale):
-    @http.route()
-    def shop(
-        self,
-        page=0,
-        category=None,
-        search="",
-        min_price=0.0,
-        max_price=0.0,
-        ppg=False,
-        **post,
-    ):
-        res = super().shop(
-            page=page,
-            category=category,
-            search=search,
-            min_price=min_price,
-            max_price=max_price,
-            ppg=ppg,
-            **post,
-        )
-
-        # getting existing templates by "search_product" in qcontext
-        # without searching again
-        templates = res.qcontext["search_product"]
-        ProductTemplateAttributeLine = request.env["product.template.attribute.line"]
-        attribute_values = lazy(
-            lambda: ProductTemplateAttributeLine.search(
-                [("product_tmpl_id", "in", templates.ids)]
+    def _get_additional_extra_shop_values(self, values, **post):
+        res = super()._get_additional_extra_shop_values(values, **post)
+        search_product = values.get("search_product")
+        attributes = values.get("attributes")
+        if search_product and attributes:
+            ProductTemplateAttributeLine = request.env[
+                "product.template.attribute.line"
+            ]
+            lines = ProductTemplateAttributeLine.search_read(
+                domain=[
+                    ("product_tmpl_id", "in", search_product.ids),
+                    ("attribute_id", "in", attributes.ids),
+                    ("attribute_id.visibility", "=", "visible"),
+                ],
+                fields=["value_ids"],
             )
-        )
-        res.qcontext["attr_values_used"] = attribute_values.mapped("value_ids")
+            used_value_ids = {
+                value_id for line in lines for value_id in line.get("value_ids", [])
+            }
+            res["attr_values_used_ids"] = used_value_ids
         return res

--- a/website_sale_product_attribute_value_filter_existing/views/templates.xml
+++ b/website_sale_product_attribute_value_filter_existing/views/templates.xml
@@ -7,21 +7,29 @@
             expr="//t[@t-if=&quot;a.display_type == 'select'&quot;]//t[@t-foreach='a.value_ids']/option"
             position="attributes"
         >
-            <attribute name="t-if">attr_values_used &amp; v</attribute>
+            <attribute
+                name="t-if"
+            >not attr_values_used_ids or v.id in attr_values_used_ids</attribute>
         </xpath>
         <xpath
             expr="//div[@t-elif=&quot;a.display_type in ('radio', 'pills', 'multi')&quot;]//t[@t-foreach='a.value_ids']"
             position="attributes"
         >
-            <attribute name="t-if">attr_values_used &amp; v</attribute>
+            <attribute
+                name="t-if"
+            >not attr_values_used_ids or v.id in attr_values_used_ids</attribute>
         </xpath>
     </template>
     <template id="o_wsale_offcanvas" inherit_id="website_sale.o_wsale_offcanvas">
         <xpath expr="//t[@t-foreach='a.value_ids']" position="attributes">
-            <attribute name="t-if">attr_values_used &amp; v</attribute>
+            <attribute
+                name="t-if"
+            >not attr_values_used_ids or v.id in attr_values_used_ids</attribute>
         </xpath>
         <xpath expr="//input[@name='attribute_value']/../.." position="attributes">
-            <attribute name="t-if">attr_values_used &amp; v</attribute>
+            <attribute
+                name="t-if"
+            >not attr_values_used_ids or v.id in attr_values_used_ids</attribute>
         </xpath>
     </template>
     <template
@@ -29,7 +37,9 @@
         inherit_id="website_sale.o_wsale_offcanvas_color_attribute"
     >
         <xpath expr="//t[@t-foreach='a.value_ids']/label" position="attributes">
-            <attribute name="t-if">attr_values_used &amp; v</attribute>
+            <attribute
+                name="t-if"
+            >not attr_values_used_ids or v.id in attr_values_used_ids</attribute>
         </xpath>
     </template>
 </odoo>


### PR DESCRIPTION
The overhead of extending the entire "shop()" method is eliminated and the logic is moved to "_get_additional_extra_shop_values()", the hook provided by Odoo to add data to the context without duplicating core code.

In addition, the filtering of unused values is optimized by avoiding the intersection of recordsets in QWeb ("attr_values_used & v"). Instead, the IDs of used values are precomputed as a set ("attr_values_used_ids") and the templates check "v.id in attr_values_used_ids", which drastically reduces the cost per iteration.

<img width="880" height="392" alt="image" src="https://github.com/user-attachments/assets/4c67827a-f938-4473-82e1-c9b750251f87" />

@Tecnativa