### PR TITLE
[18.0][IMP] website_sale_checkout_skip_payment: Add message at payment step

### DIFF
--- a/website_sale_checkout_skip_payment/models/res_config_settings.py
+++ b/website_sale_checkout_skip_payment/models/res_config_settings.py
@@ -11,3 +11,8 @@ class ResConfigSettings(models.TransientModel):
         related="website_id.website_sale_checkout_skip_message",
         readonly=False,
     )
+    website_sale_checkout_payment_skip_message = fields.Html(
+        string="Message displayed instead of payment methods.",
+        related="website_id.website_sale_checkout_payment_skip_message",
+        readonly=False,
+    )

--- a/website_sale_checkout_skip_payment/models/website.py
+++ b/website_sale_checkout_skip_payment/models/website.py
@@ -1,7 +1,7 @@
 # Copyright 2017 Sergio Teruel <sergio.teruel@tecnativa.com>
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
-from odoo import _, fields, models
+from odoo import _, api, fields, models
 from odoo.http import request
 
 
@@ -20,6 +20,18 @@ class Website(models.Model):
         default=_get_default_skip_message,
     )
     checkout_skip_payment = fields.Boolean(compute="_compute_checkout_skip_payment")
+
+    website_sale_checkout_payment_skip_message = fields.Html(
+        string="Message displayed instead of payment methods.",
+        translate=True,
+        default=lambda self: self._get_default_payment_skip_message(),
+        help="Fill in this with a message for the customer to confirm the order as "
+        "payment will be skipped.",
+    )
+
+    @api.model
+    def _get_default_payment_skip_message(self):
+        return _("The payment step will be skipped. You can confirm the order.")
 
     def _compute_checkout_skip_payment(self):
         for rec in self:

--- a/website_sale_checkout_skip_payment/views/res_config_settings_views.xml
+++ b/website_sale_checkout_skip_payment/views/res_config_settings_views.xml
@@ -16,6 +16,17 @@
                         </div>
                     </div>
                 </setting>
+                <setting
+                    id="sale_checkout_payment_skip_message"
+                    string="Sale Checkout Payment Skip Message"
+                    help="Message shown to the user during the payment step when payment will be skipped"
+                >
+                    <div class="content-group">
+                        <div class="row">
+                            <field name="website_sale_checkout_payment_skip_message" />
+                        </div>
+                    </div>
+                </setting>
             </xpath>
         </field>
     </record>

--- a/website_sale_checkout_skip_payment/views/website_sale_template.xml
+++ b/website_sale_checkout_skip_payment/views/website_sale_template.xml
@@ -2,6 +2,12 @@
 <odoo>
     <!-- Copyright 2017 Sergio Teruel <sergio.teruel@tecnativa.com>
          License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl). -->
+
+    <template id="payment_form">
+        <div id="o_payment_form_skip" class="alert alert-success mb-4">
+            <span t-field="website.website_sale_checkout_payment_skip_message" />
+        </div>
+    </template>
     <template id="payment" inherit_id="website_sale.payment" priority="25">
         <xpath expr="//div[@name='website_sale_non_free_cart']" position="attributes">
             <attribute
@@ -10,6 +16,15 @@
                 add="not website.checkout_skip_payment"
             />
         </xpath>
+        <div name="website_sale_non_free_cart" position="after">
+            <div
+                t-if="not errors and website_sale_order.amount_total and website.checkout_skip_payment"
+                id="skip_payment_payment_form"
+                class="o_not_editable mt-4"
+            >
+                <t t-call="website_sale_checkout_skip_payment.payment_form" />
+            </div>
+        </div>
     </template>
     <template id="confirmation" inherit_id="website_sale.confirmation">
         <xpath


### PR DESCRIPTION
To ensure customer will be confident in clicking on 'Confirm' button, display a message:


<img width="1913" height="854" alt="image" src="https://github.com/user-attachments/assets/ed1e2a4f-e3c0-4a71-ac88-38e9dcec5cec" />
