### PR TITLE
[18.0][FIX] website_sale_*: Fix eslint warning

### DIFF
--- a/website_sale_acquirer_confirm_order/static/src/js/website_sale_acquirer_confirm_order_tour.esm.js
+++ b/website_sale_acquirer_confirm_order/static/src/js/website_sale_acquirer_confirm_order_tour.esm.js
@@ -1,7 +1,7 @@
 /* Copyright 2025 Tecnativa - Pilar Vargas
  * License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). */
-import {registry} from "@web/core/registry";
 import * as tourUtils from "@website_sale/js/tours/tour_utils";
+import {registry} from "@web/core/registry";
 
 registry.category("web_tour.tours").add("website_sale_acquirer_confirm_order", {
     url: "/shop",

--- a/website_sale_checkout_skip_payment/static/tests/tours/website_sale_checkout_skip_payment_tour.esm.js
+++ b/website_sale_checkout_skip_payment/static/tests/tours/website_sale_checkout_skip_payment_tour.esm.js
@@ -1,5 +1,5 @@
-import {registry} from "@web/core/registry";
 import * as tourUtils from "@website_sale/js/tours/tour_utils";
+import {registry} from "@web/core/registry";
 
 registry.category("web_tour.tours").add("website_sale_checkout_skip_payment", {
     url: "/shop",

--- a/website_sale_checkout_skip_payment/static/tests/tours/website_sale_checkout_skip_payment_tour.esm.js
+++ b/website_sale_checkout_skip_payment/static/tests/tours/website_sale_checkout_skip_payment_tour.esm.js
@@ -1,5 +1,3 @@
-/** @odoo-module **/
-
 import {registry} from "@web/core/registry";
 import * as tourUtils from "@website_sale/js/tours/tour_utils";
 

--- a/website_sale_order_type/static/tests/tours/website_sale_order_type_tour.esm.js
+++ b/website_sale_order_type/static/tests/tours/website_sale_order_type_tour.esm.js
@@ -1,4 +1,3 @@
-/** @odoo-module */
 /* Copyright 2020 Tecnativa - João Marques
  * License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). */
 

--- a/website_sale_product_attribute_value_filter_existing/static/src/js/website_sale_product_attribute_value_filter_existing_search_desk_tour.esm.js
+++ b/website_sale_product_attribute_value_filter_existing/static/src/js/website_sale_product_attribute_value_filter_existing_search_desk_tour.esm.js
@@ -1,5 +1,3 @@
-/** @odoo-module **/
-
 import {registry} from "@web/core/registry";
 
 registry

--- a/website_sale_product_attribute_value_filter_existing/static/src/js/website_sale_product_attribute_value_filter_existing_tour.esm.js
+++ b/website_sale_product_attribute_value_filter_existing/static/src/js/website_sale_product_attribute_value_filter_existing_tour.esm.js
@@ -1,5 +1,3 @@
-/** @odoo-module **/
-
 import {registry} from "@web/core/registry";
 
 registry

--- a/website_sale_require_legal/static/tests/tours/tour.esm.js
+++ b/website_sale_require_legal/static/tests/tours/tour.esm.js
@@ -2,8 +2,8 @@
  * Copyright 2023 Pilar Vargas <pilar.vargas@tecnativa.com>
  * License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). */
 
-import {registry} from "@web/core/registry";
 import * as tourUtils from "@website_sale/js/tours/tour_utils";
+import {registry} from "@web/core/registry";
 
 registry.category("web_tour.tours").add("website_sale_require_legal_with_payment", {
     url: "/shop",

--- a/website_sale_secondary_unit/static/src/js/website_sale_secondary_unit.esm.js
+++ b/website_sale_secondary_unit/static/src/js/website_sale_secondary_unit.esm.js
@@ -52,16 +52,17 @@ publicWidget.registry.sale_secondary_unit = publicWidget.Widget.extend(VariantMi
     },
 
     _onChangeSecondaryUom: function (ev) {
-        if (!ev) {
+        let eventToUse = ev;
+        if (!eventToUse) {
             // HACK: Create a fake event to locate the form on "onChangeAddQuantity"
             // odoo method
-            ev = jQuery.Event("fakeEvent");
-            ev.currentTarget = $(".form-control.quantity");
+            eventToUse = jQuery.Event("fakeEvent");
+            eventToUse.currentTarget = $(".form-control.quantity");
         }
         this._setValues();
         const factor = this.secondary_uom_factor * this.product_uom_factor;
         this.$product_qty.val(this.secondary_uom_qty * factor);
-        this.onChangeAddQuantity(ev);
+        this.onChangeAddQuantity(eventToUse);
     },
     _onChangeProductQty: function () {
         this._setValues();

--- a/website_sale_stock_provisioning_date/static/src/js/website_sale_stock_provisioning_date_tour.esm.js
+++ b/website_sale_stock_provisioning_date/static/src/js/website_sale_stock_provisioning_date_tour.esm.js
@@ -1,9 +1,9 @@
 /* Copyright 2020 Tecnativa - Ernesto Tejeda
  * License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). */
 
+import {clickOnElement} from "@website/js/tours/tour_utils";
 import {registry} from "@web/core/registry";
 import {searchProduct} from "@website_sale/js/tours/tour_utils";
-import {clickOnElement} from "@website/js/tours/tour_utils";
 
 registry.category("web_tour.tours").add("website_sale_stock_provisioning_date", {
     test: true,

--- a/website_sale_wishlist_hide_price/static/tests/tours/website_sale_wishlist_hide_price_tour.esm.js
+++ b/website_sale_wishlist_hide_price/static/tests/tours/website_sale_wishlist_hide_price_tour.esm.js
@@ -1,5 +1,3 @@
-/** @odoo-module **/
-
 import {registry} from "@web/core/registry";
 
 registry.category("web_tour.tours").add("website_sale_wishlist_hide_price_tour", {

--- a/website_snippet_product_category/static/src/js/frontend.esm.js
+++ b/website_snippet_product_category/static/src/js/frontend.esm.js
@@ -1,9 +1,9 @@
 // Copyright 2020 Tecnativa - Alexandre Díaz
 // Copyright 2025 Tecnativa - Pilar Vargas
 // License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
-import sAnimation from "@website/js/content/snippets.animation";
 import {_t} from "@web/core/l10n/translation";
 import {rpc} from "@web/core/network/rpc";
+import sAnimation from "@website/js/content/snippets.animation";
 
 sAnimation.registry.js_product_category = sAnimation.Class.extend({
     selector: ".js_product_category",


### PR DESCRIPTION
### Context:
Fix various ESLint warnings in website sale JS modules:
- website_sale_product_attribute_value_filter_existing
- website_sale_acquirer_confirm_order
- website_sale_checkout_skip_payment
- website_sale_stock_provisioning_date
- website_sale_require_legal
- website_snippet_product_category
- website_sale_secondary_unit

### Changes

- `website_sale_product_attribute_value_filter_existing`: Adjust handling of the Odoo-specific module header to satisfy JSDoc / ESLint expectations in `website_sale_product_attribute_value_filter_existing_search_desk_tour.esm.js`.
- `website_sale_acquirer_confirm_order`: Reorder imports so that import * as comes before named imports, complying with the sort-imports rule in `website_sale_acquirer_confirm_order_tour.esm.js`.
- `website_sale_checkout_skip_payment`: Reorder imports so that import * as comes before named imports to satisfy sort-imports in `website_sale_checkout_skip_payment_tour.esm.js`.
- `website_sale_stock_provisioning_date`: Sort named imports alphabetically by module path to fix sort-imports warnings in `website_sale_stock_provisioning_date_tour.esm.js`.
- `website_sale_require_legal`: Reorder imports so that import * as comes before named imports, complying with the sort-imports rule in `tour.esm.js`.
- `website_snippet_product_category`: Sort imports alphabetically by module path to satisfy sort-imports in `frontend.esm.js`.
- `website_sale_secondary_unit`: Refactor _onChangeSecondaryUom to avoid reassigning the ev parameter by introducing a local eventToUse variable, keeping the existing fake-event hack while satisfying the no-param-reassign rule in `website_sale_secondary_unit.esm.js`.