### PR TITLE
16.0 [IMP] website_sale_order_type: ensure sequence is applied on creation

### DIFF
--- a/website_sale_order_type/models/website.py
+++ b/website_sale_order_type/models/website.py
@@ -16,3 +16,19 @@ class Website(models.Model):
         if partner_sudo.sale_type.pricelist_id:
             return partner_sudo.sale_type.pricelist_id.id
         return super()._get_current_pricelist_id(partner_sudo)
+
+    def _prepare_sale_order_values(self, partner_sudo):
+        self.ensure_one()
+        values = super()._prepare_sale_order_values(partner_sudo)
+        sale_order_model = self.env["sale.order"].with_company(self.company_id)
+        partner = partner_sudo.with_company(self.company_id)
+        sale_type_id = (
+            partner.sale_type.id or partner.commercial_partner_id.sale_type.id
+        )
+        if not sale_type_id:
+            sale_type_id = sale_order_model.default_get(["type_id"]).get("type_id")
+        if not sale_type_id:
+            sale_type_id = sale_order_model._default_type_id().id
+        if sale_type_id:
+            values["type_id"] = sale_type_id
+        return values

--- a/website_sale_order_type/tests/test_website_sale_order_type.py
+++ b/website_sale_order_type/tests/test_website_sale_order_type.py
@@ -1,6 +1,7 @@
 # Copyright 2018 Simone Rubino - Agile Business Group
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from odoo.tests import HttpCase, tagged
+from odoo.addons.website.tools import MockRequest
 
 
 @tagged("post_install", "-at_install")
@@ -53,3 +54,24 @@ class TestFrontend(HttpCase):
             [("id", "not in", existing_orders.ids)]
         )
         self.assertEqual(created_order.type_id, self.sale_type)
+
+    def test_prepare_sale_order_values(self):
+        self.partner.sale_type = self.sale_type
+        website = self.env["website"].get_current_website()
+        with MockRequest(self.env, website=website):
+            vals = website._prepare_sale_order_values(self.partner)
+            self.assertIn(
+                "type_id",
+                vals,
+                "The key 'type_id' should be in the returned values dictionary.",
+            )
+            self.assertEqual(
+                vals["type_id"],
+                self.sale_type.id,
+                f"The type_id in vals ({vals['type_id']}) should match the partner's type ({self.sale_type.id})",
+            )
+            order = self.env["sale.order"].create(vals)
+            self.assertTrue(
+                order.name.startswith("TSO"),
+                f"The sequence failed to apply. Expected prefix 'TSO', got '{order.name}'",
+            )


### PR DESCRIPTION
The sale order sequence (determined by the order type) was not being correctly applied when orders were created via the website. This happened because 'type_id' was missing from the initial values in _prepare_sale_order_values, causing the order to be created with the default Odoo sequence before the type was assigned.

This commit:
- Overrides _prepare_sale_order_values to inject the partner's sale type.
- Adds a test case to verify the sequence prefix is correctly applied.