### PR TITLE
[18.0][FIX] website_sale_require_legal: if not active it will not show error

### DIFF
--- a/website_sale_require_legal/controllers/main.py
+++ b/website_sale_require_legal/controllers/main.py
@@ -33,7 +33,12 @@ class WebsiteSale(main.WebsiteSale):
                 **_kwargs,
             )
         )
-        if not _kwargs.get("accepted_legal_terms"):
+        if (
+            not _kwargs.get("accepted_legal_terms")
+            and request.website.viewref(
+                "website_sale_require_legal.address_require_legal"
+            ).active
+        ):
             error_messages.append(
                 request.env._("You must accept the terms & conditions to continue.")
             )


### PR DESCRIPTION
cc @Tecnativa
ping @pilarvargas-tecnativa @david-banon-tecnativa 

Minor fix to also check if it is active in the view. I was causing problems in this PR https://github.com/OCA/e-commerce/pull/1160 Tours