### PR TITLE
[18.0][FIX] website_sale_attribute_filter_form_submit: make select attribute filters work in offcanvas

### DIFF
--- a/website_sale_attribute_filter_form_submit/templates/website_sale.xml
+++ b/website_sale_attribute_filter_form_submit/templates/website_sale.xml
@@ -46,18 +46,29 @@
                 class="list-group list-group-flush"
                 t-if="a.display_type == 'select' or a.display_type == 'multi'"
             >
-                <select
-                    name="attrib"
-                    t-att-id="'%s-%s' % (a.id,v.id)"
-                    t-att-value="'%s-%s' % (a.id,v.id)"
-                    t-attf-class="form-control"
+                <div
+                    class="list-group list-group-flush"
+                    t-if="a.display_type in ('select', 'multi')"
                 >
-                    <t t-foreach="a.value_ids" t-as="v">
-                        <option t-att-value="'%s-%s' % (a.id,v.id)">
-                            <span t-field="v.name" />
-                        </option>
-                    </t>
-                </select>
+                    <select
+                        class="form-select js_attribute_select"
+                        t-att-id="'attrib_%s' % a.id"
+                        name="attribute_value"
+                        t-att-multiple="a.display_type == 'multi' and 'multiple' or None"
+                    >
+                        <t t-if="a.display_type == 'select'">
+                            <option value="">-</option>
+                        </t>
+                        <t t-foreach="a.value_ids" t-as="v">
+                            <option
+                                t-att-value="'%s-%s' % (a.id, v.id)"
+                                t-att-selected="v.id in attrib_set and 'selected' or None"
+                            >
+                                <t t-out="v.name" />
+                            </option>
+                        </t>
+                    </select>
+                </div>
             </div>
         </xpath>
         <xpath


### PR DESCRIPTION
The offcanvas attribute select and multi-select filters were not applying any
filter because they were using a different field name than the standard
checkbox inputs.

Align select inputs with the standard `attribute_value` parameter so they are
handled by the existing website_sale JS logic.

Also fix invalid option rendering and ensure the Apply button actually submits
the filters form.

@Tecnativa TT60818

@juancarlosonate-tecnativa @sergio-teruel please review