### PR TITLE
[16.0][FIX] website_sale_require_legal: fix race condition in UI tour test

### DIFF
--- a/website_sale_require_legal/static/tests/tours/tour.js
+++ b/website_sale_require_legal/static/tests/tours/tour.js
@@ -59,13 +59,14 @@ odoo.define("website_sale_require_legal.tour", function (require) {
             trigger: "div[name='o_checkbox_container'] input",
         },
         {
-            trigger: ".btn-primary:contains('Pay Now')",
-        },
-        {
             trigger: '#payment_method label:contains("Dummy Provider")',
         },
         {
-            trigger: 'button[name="o_payment_submit_button"]',
+            trigger: 'button[name="o_payment_submit_button"]:not([disabled])',
+        },
+        {
+            content: "Wait for payment to be processed and redirect",
+            trigger: "form.oe_product_cart",
         },
     ];
 

--- a/website_sale_require_legal/tests/test_ui.py
+++ b/website_sale_require_legal/tests/test_ui.py
@@ -38,9 +38,7 @@ class UICase(HttpCase):
         # Create a dummy payment provider to ensure that the tour has at least one
         # available to it.
         arch = """
-        <form action="dummy" method="post">
-            <input type="hidden" name="view_id" t-att-value="viewid"/>
-            <input type="hidden" name="user_id" t-att-value="user_id.id"/>
+        <form action="/shop/payment/validate" method="get">
         </form>
         """
         redirect_form = self.env["ir.ui.view"].create(


### PR DESCRIPTION
### Context                                                                                                                                                                                     
- Fix a race condition in the UI tour test that caused intermittent failures when `sale_loyalty` is installed alongside `website_sale_require_legal`.                                         
- The Odoo payment widget (`web.assets_frontend_lazy`) initializes asynchronously. The submit button starts as `disabled="true"` in the HTML template and is only enabled by the widget's `_enableButton()` after async initialization completes.
- The Tour Manager can become ready before the payment widget finishes initializing. When the tour clicked `button[name="o_payment_submit_button"]` while it was still disabled, no event handler fired, no AJAX was sent to /shop/payment/transaction, and the browser never navigated — causing the final form.oe_product_cart step to time out.
- The presence of sale_loyalty adds enough overhead during page load to make this timing window consistently reproducible.
    
### Changes
- `static/tests/tours/tour.js`:
    - Add a final tour step waiting for `form.oe_product_cart` on the shop page, ensuring the AJAX call has completed before the tour ends.
- `tests/test_ui.py`:
    - Change the dummy provider's redirect form to `action="/shop/payment/validate"` so the browser navigates to /shop only after the AJAX response is received.
