### PR TITLE
[FIX] website_sale_product_attribute_value_filter_existing, fix caching

### DIFF
--- a/website_sale_product_attribute_value_filter_existing/views/templates.xml
+++ b/website_sale_product_attribute_value_filter_existing/views/templates.xml
@@ -19,6 +19,9 @@
                 name="t-if"
             >not attr_values_used_ids or v.id in attr_values_used_ids</attribute>
         </xpath>
+        <xpath expr="//t[@t-as='a']/t[@t-cache]" position="attributes">
+            <attribute name="t-cache" add="attr_values_used_ids" separator=","/>
+        </xpath>
     </template>
     <template id="o_wsale_offcanvas" inherit_id="website_sale.o_wsale_offcanvas">
         <xpath expr="//t[@t-foreach='a.value_ids']" position="attributes">
@@ -30,6 +33,9 @@
             <attribute
                 name="t-if"
             >not attr_values_used_ids or v.id in attr_values_used_ids</attribute>
+        </xpath>
+        <xpath expr="//t[@t-as='a']/t[@t-cache]" position="attributes">
+            <attribute name="t-cache" add="attr_values_used_ids" separator=","/>
         </xpath>
     </template>
     <template


### PR DESCRIPTION
The attribute filters were not being updated properly when changing the store page search conditions because of QWeb template caching. This commit adds the new ``attr_values_used_ids`` value to the cache key, used to determine whether to re-render the attribute filters section.