### PR TITLE
[17.0][FIX] website_sale_hide_empty_categories: respect product website visibility

### DIFF
--- a/website_sale_hide_empty_category/models/product_public_category.py
+++ b/website_sale_hide_empty_category/models/product_public_category.py
@@ -14,9 +14,14 @@ class ProductPublicCategory(models.Model):
     )
 
     @api.depends("product_tmpl_ids", "child_id.has_product_recursive")
+    @api.depends_context("website_id")
     def _compute_has_product_recursive(self):
         for category in self:
-            category.has_product_recursive = bool(
-                category.product_tmpl_ids
-                or any(child.has_product_recursive for child in category.child_id)
+            website = self.env["website"].get_current_website()
+            website_domain = website.website_domain()
+            has_products = bool(
+                category.product_tmpl_ids.filtered_domain(website_domain)
+            )
+            category.has_product_recursive = has_products or any(
+                child.has_product_recursive for child in category.child_id
             )


### PR DESCRIPTION
The current behavior does not take the current website into account when deciding whether a category should be considered non-empty.

Because of this, in multi-website setups a category may still appear on a website even when none of its products are published there, simply because it contains products published on another website.

The expected behavior is that categories should only be considered non-empty on a website if they contain products published on that specific website.

@Tecnativa TT61762

@pedrobaeza @victoralmau please review