### PR TITLE
[17.0][FIX] website_sale_product_attribute_value_filter_existing, fix caching

### DIFF
--- a/website_sale_product_attribute_value_filter_existing/views/templates.xml
+++ b/website_sale_product_attribute_value_filter_existing/views/templates.xml
@@ -19,6 +19,9 @@
                 name="t-if"
             >not attr_values_used_ids or v.id in attr_values_used_ids</attribute>
         </xpath>
+        <xpath expr="//t[@t-as='a']/t[@t-cache]" position="attributes">
+            <attribute name="t-cache" add="attr_values_used_ids" separator="," />
+        </xpath>
     </template>
     <template
         id="o_wsale_offcanvas_color_attribute"
@@ -48,6 +51,9 @@
             <attribute
                 name="t-if"
             >not attr_values_used_ids or v.id in attr_values_used_ids</attribute>
+        </xpath>
+        <xpath expr="//t[@t-as='a']/t[@t-cache]" position="attributes">
+            <attribute name="t-cache" add="attr_values_used_ids" separator="," />
         </xpath>
     </template>
 </odoo>


### PR DESCRIPTION
The attribute filters were not being updated properly when changing the store page search conditions because of QWeb template caching. This commit adds the new ``attr_values_used_ids`` value to the cache key, used to determine whether to re-render the attribute filters section.

bp https://github.com/OCA/e-commerce/pull/1177

@Tecnativa
@carlos-lopez-tecnativa @victoralmau please review