### PR TITLE
[17.0][FIX] website_sale_secondary_unit_product_matrix: basic uom allowed in matrix although the product has 'allow_uom_sell' field to false

### DIFF
--- a/website_sale_secondary_unit_product_matrix/templates/product_template.xml
+++ b/website_sale_secondary_unit_product_matrix/templates/product_template.xml
@@ -23,6 +23,7 @@
                             id="secondary_unit"
                         >
                             <option
+                                t-if="product_matrix.get('allow_uom_sell')"
                                 value=""
                                 t-att-selected="'selected' if not secondary_unit_id else None"
                                 placeholder="Secondary unit"


### PR DESCRIPTION
cc @Tecnativa

ping @CarlosRoca13 @chienandalu 