### PR TITLE
[17.0][FIX] website_sale_product_multi_website: avoid dropping websites

### DIFF
--- a/website_sale_product_multi_website/models/product_template.py
+++ b/website_sale_product_multi_website/models/product_template.py
@@ -29,7 +29,8 @@ class ProductTemplate(models.Model):
 
     def _inverse_website_id(self):
         for record in self:
-            record.website_ids = record.website_id
+            if record.website_id and record.website_id not in record.website_ids:
+                record.website_ids = [(4, record.website_id.id)]
 
     def can_access_from_current_website(self, website_id=False):
         # We overwrite this method completely in order to

--- a/website_sale_product_multi_website/tests/test_website_sale_product_multi_website.py
+++ b/website_sale_product_multi_website/tests/test_website_sale_product_multi_website.py
@@ -81,3 +81,26 @@ class TestWebsiteSaleProductMultiWebsite(HttpCase):
             )
             self.assertEqual(response.status_code, 200)
             self.assertNotIn(product_url, response.text)
+
+    def test_04_website_ids_are_preserved_when_multiple_websites_are_assigned(self):
+        self.product_template.website_ids = self.website1 + self.website2
+        self.assertEqual(self.product_template.website_id, self.website1)
+        self.assertEqual(
+            self.product_template.website_ids, self.website1 + self.website2
+        )
+
+    def test_05_inverse_adds_website_without_replacing_existing_websites(self):
+        self.product_template.website_ids = self.website1 + self.website2
+        self.product_template.website_id = self.website0
+        self.assertEqual(
+            set(self.product_template.website_ids.ids),
+            set((self.website0 + self.website1 + self.website2).ids),
+        )
+
+    def test_06_inverse_does_not_duplicate_existing_website(self):
+        self.product_template.website_ids = self.website1 + self.website2
+        self.product_template.website_id = self.website1
+        self.assertEqual(
+            set(self.product_template.website_ids.ids),
+            set((self.website1 + self.website2).ids),
+        )


### PR DESCRIPTION
Avoid replacing `website_ids` from the `website_id` inverse.

In this addon, `website_ids` is the source of truth and `website_id`
is kept as a computed compatibility field containing the first assigned
website.

The previous inverse replaced the full `website_ids` relation with the
single `website_id` value. This could silently drop website assignments
when editing `website_ids` or when legacy code wrote directly on
`website_id`.

Make the inverse non-destructive by adding the written `website_id` to
`website_ids` instead of replacing the whole relation.

@Tecnativa TT61624

@pedrobaeza @victoralmau please review