### PR TITLE
[17.0][FIX] website_sale_hide_empty_category: use shop product domain

### DIFF
--- a/website_sale_hide_empty_category/models/product_public_category.py
+++ b/website_sale_hide_empty_category/models/product_public_category.py
@@ -18,7 +18,7 @@ class ProductPublicCategory(models.Model):
     def _compute_has_product_recursive(self):
         for category in self:
             website = self.env["website"].get_current_website()
-            website_domain = website.website_domain()
+            website_domain = website.sale_product_domain()
             has_products = bool(
                 category.product_tmpl_ids.filtered_domain(website_domain)
             )


### PR DESCRIPTION
Use `sale_product_domain()` when checking whether a public category has products.

This computation controls the visibility of categories in the e-commerce navigation, so it should rely on the same product availability domain used by the shop.

Calling `website.website_domain()` directly only applies the generic website filter. This bypasses customizations done on `sale_product_domain()` and may mark a category as empty even when it contains products that are actually available in the current shop.

Using `sale_product_domain()` keeps category visibility aligned with the shop product search.

@Tecnativa TT62516

@pedrobaeza @carlos-lopez-tecnativa please review