### PR TITLE
[16.0][FIX] website_sale_stock_available

### DIFF
--- a/website_sale_stock_available/models/product_product.py
+++ b/website_sale_stock_available/models/product_product.py
@@ -13,11 +13,18 @@ class Product(models.Model):
         res = super()._compute_quantities_dict(
             lot_id, owner_id, package_id, from_date, to_date
         )
-        if self.env.context.get("website_sale_stock_available"):
-            products_no_ctx = self.with_context(website_sale_stock_available=False)
-            products_no_ctx._compute_available_quantities()
-            for product in products_no_ctx:
-                res[product.id]["free_qty"] = product.immediately_usable_qty
+        if not self.env.context.get("website_sale_stock_available"):
+            return res
+        products = self.with_context(
+            website_sale_stock_available=False,
+            lot_id=lot_id,
+            owner_id=owner_id,
+            package_id=package_id,
+            from_date=from_date,
+            to_date=to_date,
+        )
+        for data in products.read(["immediately_usable_qty"]):
+            res[data["id"]]["free_qty"] = data["immediately_usable_qty"]
         return res
 
     @api.depends_context("website_sale_stock_available")

--- a/website_sale_stock_available/models/product_product.py
+++ b/website_sale_stock_available/models/product_product.py
@@ -14,9 +14,10 @@ class Product(models.Model):
             lot_id, owner_id, package_id, from_date, to_date
         )
         if self.env.context.get("website_sale_stock_available"):
-            for product in self.with_context(website_sale_stock_available=False):
-                immediately = product.immediately_usable_qty
-                res[product.id]["free_qty"] = immediately
+            products_no_ctx = self.with_context(website_sale_stock_available=False)
+            products_no_ctx._compute_available_quantities()
+            for product in products_no_ctx:
+                res[product.id]["free_qty"] = product.immediately_usable_qty
         return res
 
     @api.depends_context("website_sale_stock_available")

--- a/website_sale_stock_available/tests/test_website_sale_stock_available.py
+++ b/website_sale_stock_available/tests/test_website_sale_stock_available.py
@@ -89,3 +89,38 @@ class SaleStockAvailableInfoPopup(TransactionCase):
         self.assertEqual(
             combination_info["free_qty"], self.product.immediately_usable_qty
         )
+
+    def test_compute_quantities_dict_multi_product_batch(self):
+        product_b = self.env["product.product"].create(
+            {"name": "Storable product B", "type": "product"}
+        )
+        product_c = self.env["product.product"].create(
+            {"name": "Storable product C", "type": "product"}
+        )
+        self.env["stock.quant"].create(
+            {
+                "product_id": product_b.id,
+                "location_id": self.stock_location.id,
+                "quantity": 20.0,
+            }
+        )
+        self.env["stock.quant"].create(
+            {
+                "product_id": product_c.id,
+                "location_id": self.stock_location.id,
+                "quantity": 30.0,
+            }
+        )
+        products = self.product | product_b | product_c
+        result = products.with_context(
+            website_sale_stock_available=True,
+        )._compute_quantities_dict(None, None, None)
+        for product in products:
+            self.assertIn(product.id, result)
+            self.assertEqual(
+                result[product.id]["free_qty"],
+                product.immediately_usable_qty,
+                "free_qty incorrect for product %s" % product.display_name,
+            )
+        free_qtys = {result[p.id]["free_qty"] for p in products}
+        self.assertEqual(len(free_qtys), 3, "Per-product values collapsed in batch")

--- a/website_sale_stock_available/tests/test_website_sale_stock_available.py
+++ b/website_sale_stock_available/tests/test_website_sale_stock_available.py
@@ -1,6 +1,8 @@
 # Copyright 2020 Tecnativa - Ernesto Tejeda
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
+from unittest.mock import patch
+
 from odoo.tests.common import TransactionCase
 
 
@@ -112,15 +114,26 @@ class SaleStockAvailableInfoPopup(TransactionCase):
             }
         )
         products = self.product | product_b | product_c
-        result = products.with_context(
-            website_sale_stock_available=True,
-        )._compute_quantities_dict(None, None, None)
-        for product in products:
-            self.assertIn(product.id, result)
-            self.assertEqual(
-                result[product.id]["free_qty"],
-                product.immediately_usable_qty,
-                "free_qty incorrect for product %s" % product.display_name,
-            )
+        product_product = type(self.env["product.product"])
+        with patch.object(
+            product_product,
+            "_compute_available_quantities",
+            autospec=True,
+            side_effect=product_product._compute_available_quantities,
+        ) as spy:
+            result = products.with_context(
+                website_sale_stock_available=True,
+            )._compute_quantities_dict(None, None, None)
+        self.assertEqual(spy.call_count, 1)
+        self.assertEqual(len(result), 3)
+        self.assertEqual(
+            result[self.product.id]["free_qty"], self.product.immediately_usable_qty
+        )
+        self.assertEqual(
+            result[product_b.id]["free_qty"], product_b.immediately_usable_qty
+        )
+        self.assertEqual(
+            result[product_c.id]["free_qty"], product_c.immediately_usable_qty
+        )
         free_qtys = {result[p.id]["free_qty"] for p in products}
-        self.assertEqual(len(free_qtys), 3, "Per-product values collapsed in batch")
+        self.assertEqual(len(free_qtys), 3)


### PR DESCRIPTION
## Description

  It was identified that within the `website_sale_stock_available` module, when computing stock quantities for a recordset of multiple products with the `website_sale_stock_available` context flag enabled, the `_compute_quantities_dict` override iterated the recordset one product at a time, reading `product.immediately_usable_qty` on each single-record recordset.

## Cases Covered with This Improvement

  - Rendering of /shop and `/shop/category/... pages` where multiple product cards are displayed and the stock cascade is evaluated for each one.
  - Any caller invoking `_compute_quantities_dict` on a multi-product recordset with website_sale_stock_available=True in context (for example bulk queries from API endpoints or batched reports).

## Implemented Solution

 - The `_compute_quantities_dict` override has been refactored to invoke `_compute_available_quantities` once on the full recordset before iterating. This pre-warm populates the ORM cache for `immediately_usable_qty` for every product at once, so the subsequent per-record reads inside the loop hit the cache instead of re-triggering the compute and the underlying cascade.

 - The behavior is functionally equivalent: the returned free_qty for each product still equals its `immediately_usable_qty`, just as before. Only the number of times the cascade executes changes — from N+1 to a single invocation on the full recordset.


FL-666-8676