### PR TITLE
[19.0][FIX] website_sale_checkout_skip_payment: ensure correct order state

### DIFF
--- a/website_sale_checkout_skip_payment/README.rst
+++ b/website_sale_checkout_skip_payment/README.rst
@@ -78,18 +78,23 @@ Authors
 Contributors
 ------------
 
-- `Tecnativa <https://www.tecnativa.com>`__
+-  `Tecnativa <https://www.tecnativa.com>`__
 
-  - Sergio Teruel
-  - David Vidal
-  - Alexandre Díaz
-  - Carlos Roca
-  - Pilar Vargas
+   -  Sergio Teruel
+   -  David Vidal
+   -  Alexandre Díaz
+   -  Carlos Roca
+   -  Pilar Vargas
 
-- Martin Wilderoth <martin.wilderoth@linserv.se>
-- `Studio73 <https://www.studio73.es>`__:
+-  Martin Wilderoth <martin.wilderoth@linserv.se>
+-  `Studio73 <https://www.studio73.es>`__:
 
-  - Miguel Gandia <miguel@studio73.es>
+   -  Miguel Gandia <miguel@studio73.es>
+
+-  `NICO SOLUTIONS - ENGINEERING &
+   IT <https://www.nico-solutions.de>`__:
+
+   -  Nils Coenen <nils.coenen@nico-solutions.de>
 
 Maintainers
 -----------

--- a/website_sale_checkout_skip_payment/controllers/main.py
+++ b/website_sale_checkout_skip_payment/controllers/main.py
@@ -25,13 +25,15 @@ class CheckoutSkipPaymentWebsite(WebsiteSale):
             return super().shop_payment_confirmation(**post)
         order = request.env["sale.order"].sudo().browse(order_id)
         try:
-            order.with_context(mark_so_as_sent=True)._send_order_confirmation_mail()
+            order.with_context(
+                send_email=True,
+                mark_so_as_sent=True,
+            ).action_confirm()
+
         except Exception:
             return request.render(
                 "website_sale_checkout_skip_payment.confirmation_order_error"
             )
-        # This could not finish (e.g.: sale_financial_risk exceeded)
-        order.action_confirm()
         request.website.sale_reset()
         values = self._prepare_shop_payment_confirmation_values(order)
         return request.render("website_sale.confirmation", values)

--- a/website_sale_checkout_skip_payment/controllers/main.py
+++ b/website_sale_checkout_skip_payment/controllers/main.py
@@ -24,13 +24,11 @@ class CheckoutSkipPaymentWebsite(WebsiteSale):
         if not request.website.checkout_skip_payment or not order_id:
             return super().shop_payment_confirmation(**post)
         order = request.env["sale.order"].sudo().browse(order_id)
-        try:
-            order.with_context(
-                send_email=True,
-                mark_so_as_sent=True,
-            ).action_confirm()
-
-        except Exception:
+        result = order.with_context(
+            send_email=True,
+            mark_so_as_sent=True,
+        ).action_confirm()
+        if isinstance(result, dict) or order.state != "sale":
             return request.render(
                 "website_sale_checkout_skip_payment.confirmation_order_error"
             )

--- a/website_sale_checkout_skip_payment/readme/CONTRIBUTORS.md
+++ b/website_sale_checkout_skip_payment/readme/CONTRIBUTORS.md
@@ -7,3 +7,5 @@
 - Martin Wilderoth \<<martin.wilderoth@linserv.se>\>
 - [Studio73](https://www.studio73.es):
   - Miguel Gandia \<<miguel@studio73.es>\>
+- [NICO SOLUTIONS - ENGINEERING & IT](https://www.nico-solutions.de):
+  - Nils Coenen \<<nils.coenen@nico-solutions.de>\>

--- a/website_sale_checkout_skip_payment/static/description/index.html
+++ b/website_sale_checkout_skip_payment/static/description/index.html
@@ -440,6 +440,11 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Miguel Gandia &lt;<a class="reference external" href="mailto:miguel&#64;studio73.es">miguel&#64;studio73.es</a>&gt;</li>
 </ul>
 </li>
+<li><a class="reference external" href="https://www.nico-solutions.de">NICO SOLUTIONS - ENGINEERING &amp;
+IT</a>:<ul>
+<li>Nils Coenen &lt;<a class="reference external" href="mailto:nils.coenen&#64;nico-solutions.de">nils.coenen&#64;nico-solutions.de</a>&gt;</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/website_sale_checkout_skip_payment/static/tests/tours/website_sale_checkout_skip_payment_tour.esm.js
+++ b/website_sale_checkout_skip_payment/static/tests/tours/website_sale_checkout_skip_payment_tour.esm.js
@@ -1,5 +1,5 @@
-import {registry} from "@web/core/registry";
 import * as tourUtils from "@website_sale/js/tours/tour_utils";
+import {registry} from "@web/core/registry";
 
 registry.category("web_tour.tours").add("website_sale_checkout_skip_payment", {
     url: "/shop",


### PR DESCRIPTION
This is to ensure the sale order is confirmed before the confirmation email is generated.

Previously, the confirmation email was sent before calling action_confirm(), resulting in email content being rendered with an outdated order state.