### PR TITLE
[16.0][FIX] website_sale_hide_price: hide header cart icon when prices are hidden

### DIFF
--- a/website_sale_hide_price/__init__.py
+++ b/website_sale_hide_price/__init__.py
@@ -1,1 +1,2 @@
+from . import controllers
 from . import models

--- a/website_sale_hide_price/controllers/__init__.py
+++ b/website_sale_hide_price/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import main

--- a/website_sale_hide_price/controllers/main.py
+++ b/website_sale_hide_price/controllers/main.py
@@ -1,0 +1,26 @@
+# Copyright 2026 FactorLibre - Sushan Voong
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import http
+from odoo.http import request
+
+from odoo.addons.website_sale.controllers.main import WebsiteSale
+
+
+class WebsiteSale(WebsiteSale):
+    def checkout_redirection(self, order):
+        if request.website and not request.website.website_show_price:
+            return request.redirect("/shop")
+        return super().checkout_redirection(order=order)
+
+    @http.route()
+    def cart(self, **post):
+        if request.website and not request.website.website_show_price:
+            return request.redirect("/shop")
+        return super().cart(**post)
+
+    @http.route()
+    def cart_update(self, *args, **kw):
+        if request.website and not request.website.website_show_price:
+            return request.redirect("/shop")
+        return super().cart_update(*args, **kw)

--- a/website_sale_hide_price/models/website.py
+++ b/website_sale_hide_price/models/website.py
@@ -24,7 +24,6 @@ class Website(models.Model):
 
     def _compute_website_show_price(self):
         for rec in self:
-            rec.website_show_price = (
-                not rec.website_hide_price
-                and request.env.user.partner_id.website_show_price
+            rec.website_show_price = not rec.website_hide_price and (
+                not request or request.env.user.partner_id.website_show_price
             )

--- a/website_sale_hide_price/views/website_sale_template.xml
+++ b/website_sale_hide_price/views/website_sale_template.xml
@@ -108,5 +108,10 @@
             />
         </xpath>
     </template>
+    <template id="header_cart_link" inherit_id="website_sale.header_cart_link">
+        <xpath expr="//t[@t-set='show_cart']" position="after">
+            <t t-set="show_cart" t-value="show_cart and website.website_show_price" />
+        </xpath>
+    </template>
 
 </odoo>


### PR DESCRIPTION
  
  ### Description

  An issue was identified in the `website_sale_hide_price` module where the cart icon in the website header (and its quantity badge) remained visible even when the
   "Hide prices" feature was active.

  When a customer browses the shop with hidden prices, the cart icon at the top of the header still appears and remains clickable. From there the user reaches
  `/shop/cart`, where the prices of items added to the cart before the toggle was activated are still shown — defeating the intent of the "Hide prices" toggle.

  ### Root Cause

  The module overrides several templates of `website_sale` to hide prices across different surfaces (product detail, product listing, add-to-cart button, quantity
  selector, buy-now button, search box, extra-price badge, variant badges). However, the `website_sale.header_cart_link` template — which renders the cart icon in
  the website header — was never extended. As a result, the cart icon stayed visible across the whole site even when the global "Hide prices" toggle was active.

  The core `website_sale` module already provides a sibling override (`header_hide_empty_cart_link`) that redefines the `show_cart` variable to hide the cart when
  empty. This is the canonical extension point intended for additional `show_cart` overrides, but the hide-price module did not make use of it.

  ### Implemented Solution

  The solution introduces a single QWeb override of `website_sale.header_cart_link` that follows the same pattern as the existing `header_hide_empty_cart_link`
  template shipped by `website_sale`.

  These changes ensure that the cart icon visibility is consistently enforced across all hide-price configurations, while remaining composable with any other
  module that overrides `show_cart`.

FL-666-8864