### PR TITLE
[19.0][IMP] website_sale_product_reference_displayed: show product reference in search results

### DIFF
--- a/website_sale_product_reference_displayed/README.rst
+++ b/website_sale_product_reference_displayed/README.rst
@@ -35,6 +35,11 @@ Display product reference in e-commerce
 This module extends the ``website_sale`` views to display the product's
 full display name, with its product reference included.
 
+It can also make the website product search render the result title from
+``display_name`` instead of ``name``. This keeps the search results
+consistent with the rest of the shop and exposes the product reference,
+and can be toggled per website like the rest of the options.
+
 **Table of contents**
 
 .. contents::
@@ -49,10 +54,12 @@ Just install and the products will be shown with their full display name
 To toggle the display per page type, open the website editor and use the
 **Product Reference** checkbox in the builder sidebar:
 
-- On the **shop listing page** (``/shop``): the option appears under the
-  *Products Page* section.
-- On a **product detail page** (``/shop/<product>``): the option appears
-  under the *Product Page* section.
+-  On the **shop listing page** (``/shop``): the option appears under
+   the *Products Page* section. It also controls whether the product
+   search results render their title from ``display_name`` (reference
+   included) or from ``name``.
+-  On a **product detail page** (``/shop/<product>``): the option
+   appears under the *Product Page* section.
 
 Disabling the option hides the reference from the product name in the
 selected area. Each website can have its own setting.
@@ -82,22 +89,23 @@ Authors
 Contributors
 ------------
 
-- `Tecnativa <https://www.tecnativa.com>`__:
+-  `Tecnativa <https://www.tecnativa.com>`__:
 
-  - David Vidal
-  - Carlos Roca
+   -  David Vidal
+   -  Carlos Roca
 
-- `Onestein <https://www.onestein.nl>`__:
+-  `Onestein <https://www.onestein.nl>`__:
 
-  - Anjeel Haria
+   -  Anjeel Haria
 
-- `Kencove <https://www.kencove.com/>`__:
+-  `Kencove <https://www.kencove.com/>`__:
 
-  - Mohamed Alkobrosli
+   -  Mohamed Alkobrosli
 
-- `ForgeFlow <https://www.forgeflow.com>`__:
+-  `ForgeFlow <https://www.forgeflow.com>`__:
 
-  - Jasmin Solanki
+   -  Jasmin Solanki
+   -  Miquel Raïch
 
 Maintainers
 -----------

--- a/website_sale_product_reference_displayed/models/__init__.py
+++ b/website_sale_product_reference_displayed/models/__init__.py
@@ -1,1 +1,2 @@
+from . import product_template
 from . import website_snippet_filter

--- a/website_sale_product_reference_displayed/models/product_template.py
+++ b/website_sale_product_reference_displayed/models/product_template.py
@@ -1,0 +1,34 @@
+# Copyright 2026 ForgeFlow S.L. (https://www.forgeflow.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class ProductTemplate(models.Model):
+    _inherit = "product.template"
+
+    @api.model
+    def _search_get_detail(self, website, order, options):
+        """Render the search title from ``display_name`` instead of ``name``.
+
+        This keeps the search results consistent with
+        the rest of the shop and exposes the reference.
+
+        The behaviour is toggleable per website, like the rest of the
+        options, through the ``search_display_name`` view.
+        """
+        detail = super()._search_get_detail(website, order, options)
+        if not (
+            website
+            and website.is_view_active(
+                "website_sale_product_reference_displayed.search_display_name"
+            )
+        ):
+            return detail
+        fetch_fields = detail.get("fetch_fields", [])
+        if "display_name" not in fetch_fields:
+            fetch_fields.append("display_name")
+        name_mapping = detail.get("mapping", {}).get("name")
+        if name_mapping:
+            name_mapping["name"] = "display_name"
+        return detail

--- a/website_sale_product_reference_displayed/readme/CONTRIBUTORS.md
+++ b/website_sale_product_reference_displayed/readme/CONTRIBUTORS.md
@@ -7,3 +7,4 @@
   - Mohamed Alkobrosli
 - [ForgeFlow](https://www.forgeflow.com):
   - Jasmin Solanki
+  - Miquel Raïch

--- a/website_sale_product_reference_displayed/readme/DESCRIPTION.md
+++ b/website_sale_product_reference_displayed/readme/DESCRIPTION.md
@@ -1,2 +1,7 @@
 This module extends the `website_sale` views to display the product's
 full display name, with its product reference included.
+
+It can also make the website product search render the result title from
+`display_name` instead of `name`. This keeps the search results
+consistent with the rest of the shop and exposes the product reference,
+and can be toggled per website like the rest of the options.

--- a/website_sale_product_reference_displayed/readme/USAGE.md
+++ b/website_sale_product_reference_displayed/readme/USAGE.md
@@ -5,7 +5,9 @@ To toggle the display per page type, open the website editor and use the
 **Product Reference** checkbox in the builder sidebar:
 
 - On the **shop listing page** (`/shop`): the option appears under the
-  *Products Page* section.
+  *Products Page* section. It also controls whether the product search
+  results render their title from `display_name` (reference included) or
+  from `name`.
 - On a **product detail page** (`/shop/<product>`): the option appears
   under the *Product Page* section.
 

--- a/website_sale_product_reference_displayed/static/description/index.html
+++ b/website_sale_product_reference_displayed/static/description/index.html
@@ -377,6 +377,10 @@ ul.auto-toc {
 <p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/license-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/e-commerce/tree/19.0/website_sale_product_reference_displayed"><img alt="OCA/e-commerce" src="https://img.shields.io/badge/github-OCA%2Fe--commerce-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/e-commerce-19-0/e-commerce-19-0-website_sale_product_reference_displayed"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/e-commerce&amp;target_branch=19.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
 <p>This module extends the <tt class="docutils literal">website_sale</tt> views to display the product’s
 full display name, with its product reference included.</p>
+<p>It can also make the website product search render the result title from
+<tt class="docutils literal">display_name</tt> instead of <tt class="docutils literal">name</tt>. This keeps the search results
+consistent with the rest of the shop and exposes the product reference,
+and can be toggled per website like the rest of the options.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
@@ -397,10 +401,12 @@ full display name, with its product reference included.</p>
 <p>To toggle the display per page type, open the website editor and use the
 <strong>Product Reference</strong> checkbox in the builder sidebar:</p>
 <ul class="simple">
-<li>On the <strong>shop listing page</strong> (<tt class="docutils literal">/shop</tt>): the option appears under the
-<em>Products Page</em> section.</li>
-<li>On a <strong>product detail page</strong> (<tt class="docutils literal"><span class="pre">/shop/&lt;product&gt;</span></tt>): the option appears
-under the <em>Product Page</em> section.</li>
+<li>On the <strong>shop listing page</strong> (<tt class="docutils literal">/shop</tt>): the option appears under
+the <em>Products Page</em> section. It also controls whether the product
+search results render their title from <tt class="docutils literal">display_name</tt> (reference
+included) or from <tt class="docutils literal">name</tt>.</li>
+<li>On a <strong>product detail page</strong> (<tt class="docutils literal"><span class="pre">/shop/&lt;product&gt;</span></tt>): the option
+appears under the <em>Product Page</em> section.</li>
 </ul>
 <p>Disabling the option hides the reference from the product name in the
 selected area. Each website can have its own setting.</p>
@@ -440,6 +446,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </li>
 <li><a class="reference external" href="https://www.forgeflow.com">ForgeFlow</a>:<ul>
 <li>Jasmin Solanki</li>
+<li>Miquel Raïch</li>
 </ul>
 </li>
 </ul>

--- a/website_sale_product_reference_displayed/static/src/website_builder/product_reference_option.xml
+++ b/website_sale_product_reference_displayed/static/src/website_builder/product_reference_option.xml
@@ -5,7 +5,10 @@
         <BuilderRow label.translate="Product Reference">
             <BuilderCheckbox
                 action="'websiteConfig'"
-                actionParam="{views: ['website_sale_product_reference_displayed.products_item']}"
+                actionParam="{views: [
+                'website_sale_product_reference_displayed.products_item',
+                'website_sale_product_reference_displayed.search_display_name',
+            ]}"
             />
         </BuilderRow>
     </t>

--- a/website_sale_product_reference_displayed/tests/__init__.py
+++ b/website_sale_product_reference_displayed/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_search_display_name

--- a/website_sale_product_reference_displayed/tests/test_search_display_name.py
+++ b/website_sale_product_reference_displayed/tests/test_search_display_name.py
@@ -1,0 +1,39 @@
+# Copyright 2026 ForgeFlow S.L. (https://www.forgeflow.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests.common import TransactionCase
+
+
+class TestSearchDisplayName(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.website = cls.env["website"].search([], limit=1)
+        cls.view = cls.env.ref(
+            "website_sale_product_reference_displayed.search_display_name"
+        )
+        cls.options = {
+            "displayImage": False,
+            "displayDescription": False,
+            "displayExtraLink": False,
+            "displayDetail": False,
+        }
+
+    def _get_detail(self):
+        return self.env["product.template"]._search_get_detail(
+            self.website, "", self.options
+        )
+
+    def test_search_detail_uses_display_name_when_active(self):
+        self.view.active = True
+        self.env.registry.clear_cache()
+        detail = self._get_detail()
+        self.assertEqual(detail["mapping"]["name"]["name"], "display_name")
+        self.assertIn("display_name", detail["fetch_fields"])
+
+    def test_search_detail_keeps_name_when_inactive(self):
+        self.view.active = False
+        self.env.registry.clear_cache()
+        detail = self._get_detail()
+        self.assertEqual(detail["mapping"]["name"]["name"], "name")
+        self.assertNotIn("display_name", detail["fetch_fields"])

--- a/website_sale_product_reference_displayed/views/website_sale_views.xml
+++ b/website_sale_product_reference_displayed/views/website_sale_views.xml
@@ -31,6 +31,17 @@
             <span t-field="product.display_name" />
         </xpath>
     </template>
+    <!-- Feature flag toggled from the website builder. When active, the
+         website product search renders the result title from display_name
+         instead of name (see models/product_template.py). It is kept as a
+         view so it can be enabled/disabled per website like the rest of the
+         options. -->
+    <template
+        id="search_display_name"
+        name="Display product reference in search results"
+    >
+        <t />
+    </template>
     <template
         id="product_title"
         name="Display product reference"


### PR DESCRIPTION
Commented in https://github.com/OCA/e-commerce/pull/1230.

<img width="451" height="504" alt="Selection_5965" src="https://github.com/user-attachments/assets/4ce4798a-8434-4ca3-8df9-0c649daf63d3" />
