### PR TITLE
[17.0][FIX] website_sale_product_multi_website: apply multi-website domain to product snippets

### DIFF
--- a/website_sale_product_multi_website/models/__init__.py
+++ b/website_sale_product_multi_website/models/__init__.py
@@ -1,2 +1,3 @@
 from . import product_template
+from . import website_snippet_filter
 from . import website

--- a/website_sale_product_multi_website/models/website_snippet_filter.py
+++ b/website_sale_product_multi_website/models/website_snippet_filter.py
@@ -1,0 +1,30 @@
+# Copyright 2026 Tecnativa - Pilar Vargas
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class WebsiteSnippetFilter(models.Model):
+    _inherit = "website.snippet.filter"
+
+    def _get_products(self, mode, context):
+        # Dynamic product snippets build their base product domain through
+        # website.website_domain(). Enable the existing multi-website domain
+        # context here so snippets also consider products assigned through
+        # website_ids, not only the main website_id.
+        return super(
+            WebsiteSnippetFilter,
+            self.with_context(multi_website_domain=True),
+        )._get_products(mode, context)
+
+    def _filter_records_to_values(self, records, is_sample=False):
+        # The multi_website_domain context is only needed while building the
+        # product search domain. After products are found, Odoo computes their
+        # website values and renders templates; during that phase
+        # website.website_domain() may be called for non-product models such as
+        # ir.ui.view. Clear the context from the product records to avoid
+        # applying product-specific website_ids domains outside product searches.
+        return super()._filter_records_to_values(
+            records.with_context(multi_website_domain=False),
+            is_sample,
+        )


### PR DESCRIPTION
Dynamic product snippets, such as alternative products, build their product domain through website.website_domain(). This only takes website_id into account by default, so products assigned to the current website through website_ids were not shown.

Apply the existing multi_website_domain context when products are searched for snippets, and clear it again before rendering product values to avoid leaking that product-specific domain to other models rendered later in the same flow.

@Tecnativa TT62939

@carlos-lopez-tecnativa @victoralmau please review