### PR TITLE
[16.0][IMP] website_sale_cart_selectable: add _is_add_to_cart_allowed()

### DIFF
--- a/website_sale_cart_selectable/README.rst
+++ b/website_sale_cart_selectable/README.rst
@@ -91,6 +91,9 @@ Contributors
 * David Vidal <david.vidal@tecnativa.com>
 * Chafique Delli <chafique.delli@akretion.com>
 * Carmen Bianca BAKKER <carmen@coopiteasy.be>
+* `Quartile <https://www.quartile.co>`_:
+
+  * Shinnosuke Morita
 
 Maintainers
 ~~~~~~~~~~~

--- a/website_sale_cart_selectable/models/__init__.py
+++ b/website_sale_cart_selectable/models/__init__.py
@@ -1,1 +1,2 @@
-from . import product
+from . import product_product
+from . import product_template

--- a/website_sale_cart_selectable/models/product_product.py
+++ b/website_sale_cart_selectable/models/product_product.py
@@ -1,0 +1,14 @@
+# Copyright 2026 Quartile (https://www.quartile.co)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class ProductProduct(models.Model):
+    _inherit = "product.product"
+
+    def _is_add_to_cart_allowed(self):
+        self.ensure_one()
+        if not self.website_btn_addtocart_published:
+            return False
+        return super()._is_add_to_cart_allowed()

--- a/website_sale_cart_selectable/models/product_template.py
+++ b/website_sale_cart_selectable/models/product_template.py
@@ -1,5 +1,5 @@
 # Copyright 2016 OpenSynergy Indonesia
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import fields, models
 

--- a/website_sale_cart_selectable/readme/CONTRIBUTORS.rst
+++ b/website_sale_cart_selectable/readme/CONTRIBUTORS.rst
@@ -2,3 +2,6 @@
 * David Vidal <david.vidal@tecnativa.com>
 * Chafique Delli <chafique.delli@akretion.com>
 * Carmen Bianca BAKKER <carmen@coopiteasy.be>
+* `Quartile <https://www.quartile.co>`_:
+
+  * Shinnosuke Morita

--- a/website_sale_cart_selectable/static/description/index.html
+++ b/website_sale_cart_selectable/static/description/index.html
@@ -438,6 +438,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>David Vidal &lt;<a class="reference external" href="mailto:david.vidal&#64;tecnativa.com">david.vidal&#64;tecnativa.com</a>&gt;</li>
 <li>Chafique Delli &lt;<a class="reference external" href="mailto:chafique.delli&#64;akretion.com">chafique.delli&#64;akretion.com</a>&gt;</li>
 <li>Carmen Bianca BAKKER &lt;<a class="reference external" href="mailto:carmen&#64;coopiteasy.be">carmen&#64;coopiteasy.be</a>&gt;</li>
+<li><a class="reference external" href="https://www.quartile.co">Quartile</a>:<ul>
+<li>Shinnosuke Morita</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">


### PR DESCRIPTION
Added _is_add_to_cart_allowed() to add a server-side guard. When website_btn_addtocart_published is false, _is_add_to_cart_allowed() returns false, which prevents the product from being added to the cart via _cart_update() by bypassing the button.

@qrtl QT6867