### PR TITLE
[18.0][FIX] website_sale_empty_cart: pass cart args as keywords

### DIFF
--- a/website_sale_empty_cart/controllers/main.py
+++ b/website_sale_empty_cart/controllers/main.py
@@ -15,4 +15,8 @@ class WebsiteSaleEmptyCart(WebsiteSale):
             order = request.website.sale_get_order()
             if order:
                 order.order_line.unlink()
-        return super().cart(access_token, revive, **post)
+        return super().cart(
+            access_token=access_token,
+            revive=revive,
+            **post,
+        )


### PR DESCRIPTION
**Current behavior**

Accessing /shop/cart may raise:

TypeError: WebsiteSale.cart() takes 1 positional argument but 3 were given

when another controller override in the inheritance chain expects keyword arguments.

**Cause**

website_sale_empty_cart forwards access_token and revive as positional arguments:

return super().cart(access_token, revive, **post)

This may be incompatible with kwargs-based controller signatures.

**Fix**

Pass the arguments by keyword:

return super().cart(
    access_token=access_token,
    revive=revive,
    **post,
)

This is backward compatible and avoids signature mismatches in controller inheritance chains.

**Reproduction**

I could not reproduce the traceback on a clean local setup with:

website_sale
website_sale_loyalty
website_sale_empty_cart

However, the traceback reported in the issue is consistent with forwarding positional arguments through super(), and the proposed fix is backward compatible.