### PR TITLE
[17.0][FIX] website_sale_product_matrix: Keep variant selector in DOM for matrix products

### DIFF
--- a/website_sale_product_matrix/templates/product_template.xml
+++ b/website_sale_product_matrix/templates/product_template.xml
@@ -107,10 +107,12 @@
         customize_show="True"
     >
         <xpath
-            expr="//div[hasclass('js_product')]//t[@t-placeholder='select']"
+            expr="//div[hasclass('js_product')]//t[@t-placeholder='select']//t[@t-set='ul_class']"
             position="attributes"
         >
-            <attribute name="t-if">product.product_add_mode != 'matrix'</attribute>
+            <attribute name="t-valuef">
+                flex-column #{'d-none' if product.product_add_mode == 'matrix' else ''}
+            </attribute>
         </xpath>
         <xpath expr="//div[@id='add_to_cart_wrap']" position="after">
             <a


### PR DESCRIPTION
The matrix add mode was hiding the standard variant selector by adding a `t-if` on the `select` placeholder. This removed the whole block from the DOM, including the hidden `product_id` / `product_template_id` inputs and the standard variant selection data.

This breaks features that rely on the selected variant being available in the website product page, such as the dynamic alternative products filter. When the selector is not rendered, there is no selected variant/product context for the filter to use, so alternative products are not found.

Instead of removing the selector, keep it rendered and only add `d-none` to the variant list through `ul_class` when the product uses matrix mode. This keeps the standard website_sale data available for frontend widgets while preserving the matrix UI as the visible product configurator.

@Tecnativa TT62939

@carlos-lopez-tecnativa @victoralmau please review