### PR TITLE
[19.0][IMP] website_sale_order_type: add website many2one sale type

### DIFF
--- a/website_sale_order_type/README.rst
+++ b/website_sale_order_type/README.rst
@@ -33,7 +33,7 @@ Website sale order type
 |badge1| |badge2| |badge3| |badge4| |badge5|
 
 This module allows
-`sale_order_type <https://github.com/OCA/sale-workflow/tree/17.0/sale_order_type>`__
+`sale_order_type <https://github.com/OCA/sale-workflow/tree/19.0/sale_order_type>`__
 to work with websitesale.
 
 This module is useful for users having a sale order type defined in
@@ -41,8 +41,9 @@ their Partner form: when these users buy a product in the e-commerce,
 the sale order generated will have the same sale order type that is
 defined in their Partner form.
 
-Note that the sale order type is defined contact by contact and not at
-Company level.
+You can also define a sale order type on a website from the e-commerce
+settings. When set, this website sale order type takes precedence over
+the contact sale order type for orders created from that website.
 
 **Table of contents**
 
@@ -58,6 +59,10 @@ Usage
    product;
 3. Check that the created sale oder has the same sale order type that
    has been set in the contact.
+
+You can also set a sale order type on a website from the e-commerce
+settings. When configured, orders created from that website use the
+website sale order type instead of the contact sale order type.
 
 Bug Tracker
 ===========
@@ -92,6 +97,10 @@ Contributors
 - `Studio73 <https://www.studio73.es/>`__:
 
      - Vicent Castells
+
+- `Camptocamp <https://www.camptocamp.com>`__:
+
+     - Maksym Yankin
 
 Maintainers
 -----------

--- a/website_sale_order_type/__manifest__.py
+++ b/website_sale_order_type/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Website sale order type",
     "summary": "This module allows sale_order_type to work with website_sale.",
-    "version": "19.0.1.0.0",
+    "version": "19.0.1.0.1",
     "development_status": "Beta",
     "category": "Website",
     "website": "https://github.com/OCA/e-commerce",
@@ -12,6 +12,7 @@
     "author": "Agile Business Group, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "depends": ["website_sale", "sale_order_type"],
+    "data": ["views/res_config_settings_views.xml"],
     "assets": {
         "web.assets_tests": [
             "/website_sale_order_type/static/tests/tours/website_sale_order_type_tour.esm.js"

--- a/website_sale_order_type/models/__init__.py
+++ b/website_sale_order_type/models/__init__.py
@@ -1,3 +1,4 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+from . import res_config_settings
 from . import website

--- a/website_sale_order_type/models/res_config_settings.py
+++ b/website_sale_order_type/models/res_config_settings.py
@@ -1,0 +1,16 @@
+# Copyright 2026 Camptocamp SA (https://www.camptocamp.com).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    sale_type_id = fields.Many2one(
+        related="website_id.sale_type_id",
+        readonly=False,
+        check_company=True,
+        help="If set, this sale order type is used for all orders created "
+        "from this website and takes precedence over the partner sale order type.",
+    )

--- a/website_sale_order_type/models/website.py
+++ b/website_sale_order_type/models/website.py
@@ -1,17 +1,28 @@
 # Copyright 2023 Tecnativa - Pilar Vargas
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import models
+from odoo import fields, models
 
 
 class Website(models.Model):
     _inherit = "website"
 
+    sale_type_id = fields.Many2one(
+        comodel_name="sale.order.type",
+        check_company=True,
+        help="If set, this sale order type is used for all orders created "
+        "from this website and takes precedence over the partner sale order type.",
+    )
+
+    def _get_sale_order_type(self, partner_sudo):
+        self.ensure_one()
+        return self.sudo().sale_type_id or partner_sudo.sudo().sale_type
+
     def _prepare_sale_order_values(self, partner_sudo):
         self.ensure_one()
         so_data = super()._prepare_sale_order_values(partner_sudo)
 
-        sale_type = partner_sudo.sale_type
+        sale_type = self._get_sale_order_type(partner_sudo)
         if sale_type:
             so_data["type_id"] = sale_type.id
             if sale_type.payment_term_id:
@@ -22,8 +33,9 @@ class Website(models.Model):
         website = self.with_company(self.company_id)
         partner_sudo = website.env.user.partner_id
         pricelists = super().get_pricelist_available(show_visible)
-        if partner_sudo.sale_type.pricelist_id:
+        sale_type = website._get_sale_order_type(partner_sudo)
+        if sale_type.pricelist_id:
             pricelists = pricelists.filtered(
-                lambda p: p.id == partner_sudo.sale_type.pricelist_id.id
+                lambda pricelist: pricelist.id == sale_type.pricelist_id.id
             )
         return pricelists

--- a/website_sale_order_type/readme/CONTRIBUTORS.md
+++ b/website_sale_order_type/readme/CONTRIBUTORS.md
@@ -9,3 +9,7 @@
 
 - [Studio73](https://www.studio73.es/):
   > - Vicent Castells
+
+- [Camptocamp](https://www.camptocamp.com):
+
+  > - Maksym Yankin

--- a/website_sale_order_type/readme/DESCRIPTION.md
+++ b/website_sale_order_type/readme/DESCRIPTION.md
@@ -1,5 +1,5 @@
 This module allows
-[sale_order_type](https://github.com/OCA/sale-workflow/tree/17.0/sale_order_type)
+[sale_order_type](https://github.com/OCA/sale-workflow/tree/19.0/sale_order_type)
 to work with websitesale.
 
 This module is useful for users having a sale order type defined in
@@ -7,5 +7,6 @@ their Partner form: when these users buy a product in the e-commerce,
 the sale order generated will have the same sale order type that is
 defined in their Partner form.
 
-Note that the sale order type is defined contact by contact and not at
-Company level.
+You can also define a sale order type on a website from the e-commerce
+settings. When set, this website sale order type takes precedence over
+the contact sale order type for orders created from that website.

--- a/website_sale_order_type/readme/USAGE.md
+++ b/website_sale_order_type/readme/USAGE.md
@@ -4,3 +4,7 @@
     product;
 3.  Check that the created sale oder has the same sale order type that
     has been set in the contact.
+
+You can also set a sale order type on a website from the e-commerce
+settings. When configured, orders created from that website use the
+website sale order type instead of the contact sale order type.

--- a/website_sale_order_type/static/description/index.html
+++ b/website_sale_order_type/static/description/index.html
@@ -376,14 +376,15 @@ ul.auto-toc {
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/license-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/e-commerce/tree/19.0/website_sale_order_type"><img alt="OCA/e-commerce" src="https://img.shields.io/badge/github-OCA%2Fe--commerce-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/e-commerce-19-0/e-commerce-19-0-website_sale_order_type"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/e-commerce&amp;target_branch=19.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
 <p>This module allows
-<a class="reference external" href="https://github.com/OCA/sale-workflow/tree/17.0/sale_order_type">sale_order_type</a>
+<a class="reference external" href="https://github.com/OCA/sale-workflow/tree/19.0/sale_order_type">sale_order_type</a>
 to work with websitesale.</p>
 <p>This module is useful for users having a sale order type defined in
 their Partner form: when these users buy a product in the e-commerce,
 the sale order generated will have the same sale order type that is
 defined in their Partner form.</p>
-<p>Note that the sale order type is defined contact by contact and not at
-Company level.</p>
+<p>You can also define a sale order type on a website from the e-commerce
+settings. When set, this website sale order type takes precedence over
+the contact sale order type for orders created from that website.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
@@ -407,6 +408,9 @@ product;</li>
 <li>Check that the created sale oder has the same sale order type that
 has been set in the contact.</li>
 </ol>
+<p>You can also set a sale order type on a website from the e-commerce
+settings. When configured, orders created from that website use the
+website sale order type instead of the contact sale order type.</p>
 </div>
 <div class="section" id="bug-tracker">
 <h2><a class="toc-backref" href="#toc-entry-2">Bug Tracker</a></h2>
@@ -443,6 +447,13 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <blockquote>
 <ul class="simple">
 <li>Vicent Castells</li>
+</ul>
+</blockquote>
+</li>
+<li><p class="first"><a class="reference external" href="https://www.camptocamp.com">Camptocamp</a>:</p>
+<blockquote>
+<ul class="simple">
+<li>Maksym Yankin</li>
 </ul>
 </blockquote>
 </li>

--- a/website_sale_order_type/tests/test_website_sale_order_type.py
+++ b/website_sale_order_type/tests/test_website_sale_order_type.py
@@ -59,6 +59,7 @@ class TestFrontend(HttpCase):
         )
 
     def test_website_sale_order_type(self):
+        self.website.sale_type_id = False
         self.partner.sale_type = self.sale_type
         # In frontend, create an order
         with RecordCapturer(self.env["sale.order"], []) as capture:
@@ -79,6 +80,7 @@ class TestFrontend(HttpCase):
             "product.group_product_pricelist"
         ):
             self.skipTest("Pricelist feature is disabled.")
+        self.website.sale_type_id = False
         self.partner.sale_type = self.sale_type
         admin = self.env.ref("base.user_admin")
         website = self.env["website"].get_current_website().with_user(admin)
@@ -86,3 +88,54 @@ class TestFrontend(HttpCase):
         pricelists = website.get_pricelist_available()
 
         self.assertEqual(pricelists, self.sale_type.pricelist_id)
+
+    def test_website_sale_type(self):
+        self.partner.sale_type = False
+        self.website.sale_type_id = self.sale_type
+
+        with RecordCapturer(self.env["sale.order"], []) as capture:
+            self.start_tour("/shop", "website_sale_order_type_tour", login="admin")
+
+        created_order = capture.records
+        self.assertEqual(created_order.type_id, self.sale_type)
+        self.assertEqual(created_order.payment_term_id, self.sale_type.payment_term_id)
+
+    def test_website_sale_type_takes_precedence_over_partner_sale_type(self):
+        website_sale_type = self.sale_type.copy({"name": "Website Sale Order Type"})
+        partner_sale_type = self.sale_type.copy({"name": "Partner Sale Order Type"})
+        self.website.sale_type_id = website_sale_type
+        self.partner.sale_type = partner_sale_type
+
+        sale_type = self.website._get_sale_order_type(self.partner)
+
+        self.assertEqual(sale_type, website_sale_type)
+
+    def test_get_pricelist_available_filtered_by_website_sale_type(self):
+        if not self.env["res.groups"]._is_feature_enabled(
+            "product.group_product_pricelist"
+        ):
+            self.skipTest("Pricelist feature is disabled.")
+        self.partner.sale_type = False
+        self.website.sale_type_id = self.sale_type
+        admin = self.env.ref("base.user_admin")
+        website = self.env["website"].get_current_website().with_user(admin)
+
+        pricelists = website.get_pricelist_available()
+
+        self.assertEqual(pricelists, self.sale_type.pricelist_id)
+
+    def test_public_cart_creation_with_website_sale_type(self):
+        self.partner.sale_type = False
+        self.website.sale_type_id = self.sale_type
+
+        with RecordCapturer(self.env["sale.order"], []) as capture:
+            self.make_jsonrpc_request(
+                "/shop/cart/add",
+                {
+                    "product_template_id": self.product_template.id,
+                    "product_id": self.product_template.product_variant_id.id,
+                    "quantity": 1,
+                },
+            )
+
+        self.assertEqual(capture.records.type_id, self.sale_type)

--- a/website_sale_order_type/views/res_config_settings_views.xml
+++ b/website_sale_order_type/views/res_config_settings_views.xml
@@ -1,0 +1,21 @@
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="website_sale.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//field[@name='salesperson_id']/ancestor::div[1]"
+                position="after"
+            >
+                <div class="row" groups="sales_team.group_sale_salesman">
+                    <label
+                        for="sale_type_id"
+                        string="Sale Order Type"
+                        class="o_light_label col-lg-3"
+                    />
+                    <field name="sale_type_id" />
+                </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Add an optional website many2one sale order type that takes precedence over partner configuration for website created orders.