### PR TITLE
[I18N] website_sale_product_brand: complete Dutch (nl) translation

### DIFF
--- a/website_sale_product_brand/i18n/nl.po
+++ b/website_sale_product_brand/i18n/nl.po
@@ -4,127 +4,126 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 13.0\n"
+"Project-Id-Version: Odoo Server 19.0\n"
 "Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: 2026-02-25 07:30+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
+"PO-Revision-Date: 2026-06-18 00:00+0000\n"
+"Last-Translator: Code Agency <info@codeagency.be>\n"
 "Language-Team: none\n"
 "Language: nl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.15.2\n"
 
 #. module: website_sale_product_brand
 #: model_terms:ir.ui.view,arch_db:website_sale_product_brand.website_sale_filter_brand_products_brands
 msgid "<b>Brand</b>"
-msgstr ""
+msgstr "<b>Merk</b>"
 
 #. module: website_sale_product_brand
 #: model:ir.model.fields,field_description:website_sale_product_brand.field_product_brand__align_brand_content
 msgid "Align Brand Content"
-msgstr ""
+msgstr "Uitlijning merkinhoud"
 
 #. module: website_sale_product_brand
 #: model:ir.model.fields,field_description:website_sale_product_brand.field_product_brand__can_publish
 msgid "Can Publish"
-msgstr ""
+msgstr "Kan publiceren"
 
 #. module: website_sale_product_brand
 #: model:ir.model.fields.selection,name:website_sale_product_brand.selection__product_brand__align_brand_content__center
 msgid "Center"
-msgstr ""
+msgstr "Midden"
 
 #. module: website_sale_product_brand
 #: model:ir.model.fields,field_description:website_sale_product_brand.field_product_brand__cover_image
 msgid "Cover Image"
-msgstr ""
+msgstr "Omslagafbeelding"
 
 #. module: website_sale_product_brand
 #: model:ir.model.fields,field_description:website_sale_product_brand.field_product_brand__display_name
 #: model:ir.model.fields,field_description:website_sale_product_brand.field_product_template__display_name
 #: model:ir.model.fields,field_description:website_sale_product_brand.field_website__display_name
 msgid "Display Name"
-msgstr ""
+msgstr "Weergavenaam"
 
 #. module: website_sale_product_brand
 #: model:ir.model.fields,field_description:website_sale_product_brand.field_product_brand__id
 #: model:ir.model.fields,field_description:website_sale_product_brand.field_product_template__id
 #: model:ir.model.fields,field_description:website_sale_product_brand.field_website__id
 msgid "ID"
-msgstr ""
+msgstr "ID"
 
 #. module: website_sale_product_brand
 #: model:ir.model.fields,field_description:website_sale_product_brand.field_product_brand__image_1920
 msgid "Image"
-msgstr ""
+msgstr "Afbeelding"
 
 #. module: website_sale_product_brand
 #: model:ir.model.fields,field_description:website_sale_product_brand.field_product_brand__image_1024
 msgid "Image 1024"
-msgstr ""
+msgstr "Afbeelding 1024"
 
 #. module: website_sale_product_brand
 #: model:ir.model.fields,field_description:website_sale_product_brand.field_product_brand__image_128
 msgid "Image 128"
-msgstr ""
+msgstr "Afbeelding 128"
 
 #. module: website_sale_product_brand
 #: model:ir.model.fields,field_description:website_sale_product_brand.field_product_brand__image_256
 msgid "Image 256"
-msgstr ""
+msgstr "Afbeelding 256"
 
 #. module: website_sale_product_brand
 #: model:ir.model.fields,field_description:website_sale_product_brand.field_product_brand__image_512
 msgid "Image 512"
-msgstr ""
+msgstr "Afbeelding 512"
 
 #. module: website_sale_product_brand
 #: model:ir.model.fields,field_description:website_sale_product_brand.field_product_brand__is_published
 msgid "Is Published"
-msgstr ""
+msgstr "Is gepubliceerd"
 
 #. module: website_sale_product_brand
 #: model:ir.model.fields.selection,name:website_sale_product_brand.selection__product_brand__align_brand_content__left
 msgid "Left"
-msgstr ""
+msgstr "Links"
 
 #. module: website_sale_product_brand
 #: model_terms:ir.ui.view,arch_db:website_sale_product_brand.product_brands
 msgid "No Brands Found."
-msgstr "Geen Merken gevonden."
+msgstr "Geen merken gevonden."
 
 #. module: website_sale_product_brand
 #: model:ir.model,name:website_sale_product_brand.model_product_template
 msgid "Product"
-msgstr ""
+msgstr "Product"
 
 #. module: website_sale_product_brand
 #: model:ir.model,name:website_sale_product_brand.model_product_brand
 msgid "Product Brand"
-msgstr ""
+msgstr "Productmerk"
 
 #. module: website_sale_product_brand
 #: model:ir.ui.menu,name:website_sale_product_brand.menu_product_brand
 #: model_terms:ir.ui.view,arch_db:website_sale_product_brand.product_brands
 msgid "Product Brands"
-msgstr "Product Merken"
+msgstr "Productmerken"
 
 #. module: website_sale_product_brand
 #: model:ir.model.fields,field_description:website_sale_product_brand.field_product_brand__published_products_count
 msgid "Published Products Count"
-msgstr ""
+msgstr "Aantal gepubliceerde producten"
 
 #. module: website_sale_product_brand
 #: model:ir.model.fields,help:website_sale_product_brand.field_product_brand__website_id
 msgid "Restrict to a specific website."
-msgstr ""
+msgstr "Beperken tot een specifieke website."
 
 #. module: website_sale_product_brand
 #: model:ir.model.fields,field_description:website_sale_product_brand.field_product_brand__is_seo_optimized
 msgid "SEO optimized"
-msgstr ""
+msgstr "SEO geoptimaliseerd"
 
 #. module: website_sale_product_brand
 #: model_terms:ir.ui.view,arch_db:website_sale_product_brand.product_brands
@@ -139,7 +138,7 @@ msgstr "Zoeken..."
 #. module: website_sale_product_brand
 #: model:ir.model.fields,field_description:website_sale_product_brand.field_product_brand__seo_name
 msgid "Seo name"
-msgstr ""
+msgstr "SEO-naam"
 
 #. module: website_sale_product_brand
 #: model:website.menu,name:website_sale_product_brand.menu_website_sale_brand
@@ -149,76 +148,76 @@ msgstr "Winkel op merk"
 #. module: website_sale_product_brand
 #: model:ir.model.fields,field_description:website_sale_product_brand.field_product_brand__show_brand_description
 msgid "Show Brand Description"
-msgstr ""
+msgstr "Merkbeschrijving weergeven"
 
 #. module: website_sale_product_brand
 #: model:ir.model.fields,field_description:website_sale_product_brand.field_product_brand__show_brand_name
 msgid "Show Brand Name"
-msgstr ""
+msgstr "Merknaam weergeven"
 
 #. module: website_sale_product_brand
 #: model:ir.model.fields,field_description:website_sale_product_brand.field_product_brand__show_without_published_products
 msgid "Show Without Published Products"
-msgstr ""
+msgstr "Weergeven zonder gepubliceerde producten"
 
 #. module: website_sale_product_brand
 #: model:ir.model.fields,help:website_sale_product_brand.field_product_brand__website_absolute_url
 msgid "The full absolute URL to access the document through the website."
-msgstr ""
+msgstr "De volledige absolute URL om het document via de website te bekijken."
 
 #. module: website_sale_product_brand
 #: model:ir.model.fields,help:website_sale_product_brand.field_product_brand__website_url
 msgid "The full relative URL to access the document through the website."
-msgstr ""
+msgstr "De volledige relatieve URL om het document via de website te bekijken."
 
 #. module: website_sale_product_brand
 #: model:ir.model.fields,field_description:website_sale_product_brand.field_product_brand__website_published
 msgid "Visible on current website"
-msgstr ""
+msgstr "Zichtbaar op huidige website"
 
 #. module: website_sale_product_brand
 #: model:ir.model,name:website_sale_product_brand.model_website
 #: model:ir.model.fields,field_description:website_sale_product_brand.field_product_brand__website_id
 #: model_terms:ir.ui.view,arch_db:website_sale_product_brand.view_product_brand_form
 msgid "Website"
-msgstr ""
+msgstr "Website"
 
 #. module: website_sale_product_brand
 #: model:ir.model.fields,field_description:website_sale_product_brand.field_product_brand__website_absolute_url
 msgid "Website Absolute URL"
-msgstr ""
+msgstr "Absolute website-URL"
 
 #. module: website_sale_product_brand
 #: model:ir.model.fields,field_description:website_sale_product_brand.field_product_brand__website_description
 msgid "Website Description"
-msgstr ""
+msgstr "Websitebeschrijving"
 
 #. module: website_sale_product_brand
 #: model:ir.model.fields,field_description:website_sale_product_brand.field_product_brand__website_footer
 msgid "Website Footer"
-msgstr ""
+msgstr "Website-voettekst"
 
 #. module: website_sale_product_brand
 #: model:ir.model.fields,field_description:website_sale_product_brand.field_product_brand__website_url
 msgid "Website URL"
-msgstr ""
+msgstr "Website-URL"
 
 #. module: website_sale_product_brand
 #: model:ir.model.fields,field_description:website_sale_product_brand.field_product_brand__website_meta_description
 msgid "Website meta description"
-msgstr ""
+msgstr "Website meta-omschrijving"
 
 #. module: website_sale_product_brand
 #: model:ir.model.fields,field_description:website_sale_product_brand.field_product_brand__website_meta_keywords
 msgid "Website meta keywords"
-msgstr ""
+msgstr "Website meta-zoekwoorden"
 
 #. module: website_sale_product_brand
 #: model:ir.model.fields,field_description:website_sale_product_brand.field_product_brand__website_meta_title
 msgid "Website meta title"
-msgstr ""
+msgstr "Website meta-titel"
 
 #. module: website_sale_product_brand
 #: model:ir.model.fields,field_description:website_sale_product_brand.field_product_brand__website_meta_og_img
 msgid "Website opengraph image"
-msgstr ""
+msgstr "Website OpenGraph-afbeelding"


### PR DESCRIPTION
## Summary

- Completes the Dutch (`nl`) translation for `website_sale_product_brand`
- All 38 translatable strings are now translated (previously only 5 of 38 had translations; the rest fell back to English)
- Bumps the PO header version from `13.0` to `19.0` to match the current `.pot` template
- Fixes incorrect capitalisation in existing entry: `Geen Merken gevonden.` → `Geen merken gevonden.`
- Fixes compound noun spacing: `Product Merken` → `Productmerken` (Dutch compound nouns are written as a single word)

## Test plan

- [ ] Install the module on a 19.0 instance with Dutch language activated
- [ ] Verify the "Shop by Brand" page displays Dutch labels (e.g. "Productmerken", "Zoeken...", "Geen merken gevonden.")
- [ ] Verify backend brand form fields show Dutch field labels (e.g. "Merkbeschrijving weergeven", "Merknaam weergeven")