### PR TITLE
[17.0][FIX] website_sale_stock_product_matrix: show template-wide availability in matrix mode

### DIFF
--- a/website_sale_stock_product_matrix/README.rst
+++ b/website_sale_stock_product_matrix/README.rst
@@ -72,6 +72,7 @@ Contributors
 
   - David Vidal
   - Pilar Vargas
+  - Carlos Roca
 
 Maintainers
 -----------

--- a/website_sale_stock_product_matrix/__init__.py
+++ b/website_sale_stock_product_matrix/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/website_sale_stock_product_matrix/models/__init__.py
+++ b/website_sale_stock_product_matrix/models/__init__.py
@@ -1,0 +1,1 @@
+from . import product_template

--- a/website_sale_stock_product_matrix/models/product_template.py
+++ b/website_sale_stock_product_matrix/models/product_template.py
@@ -1,0 +1,32 @@
+# Copyright 2026 Tecnativa - Carlos Roca
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+from odoo import models
+
+
+class ProductTemplate(models.Model):
+    _inherit = "product.template"
+
+    def _get_additionnal_combination_info(
+        self, product_or_template, quantity, date, website
+    ):
+        res = super()._get_additionnal_combination_info(
+            product_or_template, quantity, date, website
+        )
+        # For products sold through the variant matrix the variant selector is
+        # hidden, so the page-level availability message stays frozen on the first
+        # variant and wrongly shows "out of stock" when only the first size/color
+        # is depleted. The message must reflect the whole template instead: if ANY
+        # variant has stock the product isn't out of stock. The matrix grid cells
+        # still need the per-variant quantity, so those calls are flagged with the
+        # `product_matrix_cell` context and left untouched.
+        if (
+            self.product_add_mode == "matrix"
+            and self.type == "product"
+            and product_or_template.is_product_variant
+            and not self.env.context.get("product_matrix_cell")
+        ):
+            res["free_qty"] = sum(
+                website._get_product_available_qty(variant)
+                for variant in self.sudo().product_variant_ids
+            )
+        return res

--- a/website_sale_stock_product_matrix/readme/CONTRIBUTORS.md
+++ b/website_sale_stock_product_matrix/readme/CONTRIBUTORS.md
@@ -1,3 +1,4 @@
 * Tecnativa (https://www.tecnativa.com)
   * David Vidal
   * Pilar Vargas
+  * Carlos Roca

--- a/website_sale_stock_product_matrix/static/description/index.html
+++ b/website_sale_stock_product_matrix/static/description/index.html
@@ -418,6 +418,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Tecnativa (<a class="reference external" href="https://www.tecnativa.com">https://www.tecnativa.com</a>)<ul>
 <li>David Vidal</li>
 <li>Pilar Vargas</li>
+<li>Carlos Roca</li>
 </ul>
 </li>
 </ul>

--- a/website_sale_stock_product_matrix/templates/product_template.xml
+++ b/website_sale_stock_product_matrix/templates/product_template.xml
@@ -13,7 +13,7 @@
             <t t-set="qty" t-value="cell['qty']" />
             <t
                 t-set="combination_info"
-                t-value="product.with_context(website_sale_stock_get_quantity=True)._get_combination_info(combination, add_qty=cell['qty'] or 1)"
+                t-value="product.with_context(website_sale_stock_get_quantity=True, product_matrix_cell=True)._get_combination_info(combination, add_qty=cell['qty'] or 1)"
             />
             <t t-set="free_qty" t-value="combination_info['free_qty']" />
             <t


### PR DESCRIPTION
For products sold through the variant matrix the variant selector is hidden, so the page-level availability message stayed frozen on the first variant and wrongly showed "out of stock" when only the first size/color was depleted.

The page-level free_qty now aggregates the stock of all variants: if any variant has stock the product is no longer flagged as out of stock. The matrix grid cells still need the per-variant quantity, so those calls are marked with the `product_matrix_cell` context and left untouched.

cc @Tecnativa TT63318

ping @pilarvargas-tecnativa @pedrobaeza 