### PR TITLE
[19.0][IMP] website_sale_product_brand: add configurable brand filter display

### DIFF
--- a/website_sale_product_brand/README.rst
+++ b/website_sale_product_brand/README.rst
@@ -70,6 +70,18 @@ brand's Website field on the product brand form to scope the brand to a
 specific website. The field is shown to users in the
 ``website.group_multi_website`` group.
 
+To configure how brands are displayed in the shop filter:
+
+1. Go to *Website > Configuration > Settings*.
+
+2. In the *Shop - Products* section, set *Brand Filter Display* to one
+   of the following values:
+
+   -  *Full list*: show all available brands.
+   -  *Limited list*: show the first 5 brands and a *Show more* option.
+   -  *Alphabetical accordion*: group brands by letter when there are
+      more than 50 brands.
+
 Usage
 =====
 
@@ -85,9 +97,9 @@ and define the brand to a product.
 To create product brand go to *Website > Settings > Products > Product
 brands*:
 
-   - User can assign a nice logo with brand description.
-   - After configuring the brand, user can assign a particular brand to
-     a particular products.
+   -  User can assign a nice logo with brand description.
+   -  After configuring the brand, user can assign a particular brand to
+      a particular products.
 
 Based on this configuration, you will see the menuitem shop by brand
 next to shop menu. It will show all the brands and once you select that
@@ -97,10 +109,10 @@ When a user selects a published brand from ``/shop/brands``, the request
 is redirected to that brand landing page (``/shop/brand/<brand-slug>``).
 In the brand form view, you can configure:
 
-   - Cover image
-   - Header website description block
-   - Footer website description block
-   - Header alignment and visibility of brand name/description
+   -  Cover image
+   -  Header website description block
+   -  Footer website description block
+   -  Header alignment and visibility of brand name/description
 
 If your database uses multiple websites, each brand can be assigned to a
 specific website from the product brand form and list views. Brands are
@@ -129,22 +141,22 @@ Authors
 Contributors
 ------------
 
-- Jay Vora <jay.vora@serpentcs.com>
+-  Jay Vora <jay.vora@serpentcs.com>
 
-- Meet Dholakia <m.dholakia.serpentcs@gmail.com>
+-  Meet Dholakia <m.dholakia.serpentcs@gmail.com>
 
-- `Tecnativa <https://www.tecnativa.com>`__:
+-  `Tecnativa <https://www.tecnativa.com>`__:
 
-     - Ernesto Tejeda <ernesto.tejeda@tecnativa.com>
-     - Sergio Teruel <sergio.teruel@tecnativa.com>
-     - Alexandre Díaz
-     - David Vidal
-     - Carlos López
-     - Pilar Vargas
+      -  Ernesto Tejeda <ernesto.tejeda@tecnativa.com>
+      -  Sergio Teruel <sergio.teruel@tecnativa.com>
+      -  Alexandre Díaz
+      -  David Vidal
+      -  Carlos López
+      -  Pilar Vargas
 
-- `Studio73 <https://www.studio73.es>`__:
+-  `Studio73 <https://www.studio73.es>`__:
 
-     - Alex Garcia <[alex@studio73.es]>
+      -  Alex Garcia <[alex@studio73.es]>
 
 Maintainers
 -----------

--- a/website_sale_product_brand/__manifest__.py
+++ b/website_sale_product_brand/__manifest__.py
@@ -16,6 +16,7 @@
         "data/website_menu.xml",
         "views/product_brand.xml",
         "views/product_brand_views.xml",
+        "views/res_config_settings_views.xml",
         "views/templates.xml",
     ],
     "assets": {

--- a/website_sale_product_brand/controllers/main.py
+++ b/website_sale_product_brand/controllers/main.py
@@ -18,6 +18,9 @@ from odoo.addons.website_sale.controllers.main import (
 
 
 class WebsiteSale(WebsiteSaleBase):
+    BRAND_LIMIT = 5
+    BRAND_LETTER_LIMIT = 50
+
     def _as_int_list(self, values):
         return [int(value) for value in values if str(value).isdigit()]
 
@@ -109,6 +112,145 @@ class WebsiteSale(WebsiteSaleBase):
         return brand_model.search(domain).filtered(
             lambda x: x.published_products_count > 0
             or x.show_without_published_products
+        )
+
+    def _get_product_counts_by_brand_ids(self, domain):
+        public_brand_ids = (
+            request.env["product.brand"]
+            .sudo()
+            .search(request.env["product.brand"]._website_public_domain())
+            .ids
+        )
+        domain = Domain.AND(
+            [
+                domain,
+                [
+                    ("product_brand_id", "!=", False),
+                    ("product_brand_id", "in", public_brand_ids),
+                ],
+            ]
+        )
+        return {
+            brand.id: count
+            for brand, count in request.env["product.template"]
+            .sudo()
+            ._read_group(domain, ["product_brand_id"], ["__count"])
+        }
+
+    def _get_available_brands(self, domain, selected_brand_ids=None):
+        selected_brand_ids = selected_brand_ids or []
+        brand_model = request.env["product.brand"].sudo()
+        brand_counts = self._get_product_counts_by_brand_ids(domain)
+        brand_ids = list(brand_counts)
+        brands = brand_model.browse(brand_ids)
+        brands |= brand_model.search(
+            Domain.AND(
+                [
+                    brand_model._website_public_domain(),
+                    [("show_without_published_products", "=", True)],
+                ]
+            )
+        )
+        selected_brand_ids = [
+            brand_id for brand_id in selected_brand_ids if brand_id not in brand_ids
+        ]
+        if selected_brand_ids:
+            selected_brands = brand_model.search(
+                Domain.AND(
+                    [
+                        brand_model._website_public_domain(),
+                        [
+                            ("id", "in", selected_brand_ids),
+                        ],
+                    ]
+                )
+            )
+            brands |= selected_brands
+        return brands.sorted("name"), brand_counts
+
+    def _get_brand_letters(self, brands, brand_counts, selected_brand_ids):
+        letters = {}
+        for brand in brands:
+            letter = (brand.name or "#")[0].upper()
+            if not letter.isalpha():
+                letter = "#"
+            values = letters.setdefault(
+                letter,
+                {
+                    "letter": letter,
+                    "key": letter if letter != "#" else "other",
+                    "count": 0,
+                    "active": False,
+                    "brands": request.env["product.brand"],
+                    "has_more": False,
+                },
+            )
+            values["count"] += brand_counts.get(brand.id, 0)
+            if brand.id in selected_brand_ids:
+                values["active"] = True
+                values["brands"] |= brand
+        return [letters[letter] for letter in sorted(letters)]
+
+    def _get_brand_filter_values(self, domain, selected_brand_ids):
+        mode = request.website.brand_filter_display_mode
+        brands, brand_counts = self._get_available_brands(domain, selected_brand_ids)
+        values = {
+            "brand_filter_display_mode": mode,
+            "brand_filter_limit": self.BRAND_LIMIT,
+            "brand_letter_limit": self.BRAND_LETTER_LIMIT,
+            "brand_has_more": False,
+            "brand_letters": [],
+        }
+        if mode == "limited":
+            selected_brands = brands.filtered(lambda b: b.id in selected_brand_ids)
+            first_brands = brands[: self.BRAND_LIMIT]
+            visible_brands = (selected_brands | first_brands).sorted("name")
+            values.update(
+                {
+                    "brands": visible_brands,
+                    "brand_has_more": len(brands - visible_brands) > 0,
+                    "brand_next_offset": 0,
+                }
+            )
+        elif mode == "letters":
+            values.update(
+                {
+                    "brands": brands,
+                    "brand_letters": self._get_brand_letters(
+                        brands, brand_counts, selected_brand_ids
+                    ),
+                }
+            )
+        else:
+            values["brands"] = brands
+        return values
+
+    def _get_brand_rpc_domain(self, search="", category_id=None, attribute_values=None):
+        category = None
+        if category_id:
+            category = request.env["product.public.category"].browse(int(category_id))
+        attribute_value_dict = self._get_attribute_value_dict(attribute_values or [])
+        return self._get_shop_domain_no_brands(
+            search,
+            category,
+            attribute_value_dict,
+            search_in_description=False,
+        )
+
+    def _get_selected_brand_ids_from_request(self, brand_ids=None):
+        return [
+            int(brand_id)
+            for brand_id in brand_ids or []
+            if brand_id and str(brand_id).isdigit()
+        ]
+
+    def _render_brand_items(self, brands, selected_brand_ids):
+        return request.env["ir.ui.view"]._render_template(
+            "website_sale_product_brand.brand_filter_items",
+            {
+                "brands": brands,
+                "selected_brand_ids": selected_brand_ids,
+            },
         )
 
     def _get_shop_domain_no_brands(
@@ -251,13 +393,9 @@ class WebsiteSale(WebsiteSaleBase):
         domain = self._get_shop_domain_no_brands(
             search, category, attrib_values, search_in_description=False
         )
-        search_products = request.env["product.template"].search(domain)
+        product_query = request.env["product.template"]._search(domain)
         # build brands list
         selected_brand_ids = brands_list
-        brands = self._build_brands_list(
-            selected_brand_ids, search, products, search_products, category
-        )
-        brands = self._remove_extra_brands(brands, search_products, attrib_values)
         # use search() domain instead of mapped() for better performance:
         # will basically search for product's related attribute values
         attrib_valid_ids = (
@@ -268,7 +406,7 @@ class WebsiteSale(WebsiteSaleBase):
                     (
                         "pav_attribute_line_ids.product_tmpl_id",
                         "in",
-                        search_products._ids,
+                        product_query,
                     ),
                     ("pav_attribute_line_ids.value_ids", "!=", False),
                 ]
@@ -282,9 +420,11 @@ class WebsiteSale(WebsiteSaleBase):
         # assign values for usage in qweb
         qcontext.update(
             {
-                "brands": brands,
                 "selected_brand_ids": selected_brand_ids,
                 "attr_valid": attrib_valid_ids,
+                "brand_filter_category_id": category.id if category else False,
+                "brand_filter_attribute_values": attribute_values,
+                **self._get_brand_filter_values(domain, selected_brand_ids),
             }
         )
         return res
@@ -338,6 +478,72 @@ class WebsiteSale(WebsiteSaleBase):
             return response
         finally:
             self._clear_current_brand()
+
+    @http.route(
+        ["/shop/brand_filter/load_more"],
+        type="jsonrpc",
+        auth="public",
+        website=True,
+    )
+    def brand_filter_load_more(
+        self,
+        offset=0,
+        limit=None,
+        search="",
+        category_id=None,
+        attribute_values=None,
+        brand_ids=None,
+        exclude_brand_ids=None,
+        **post,
+    ):
+        limit = int(limit or self.BRAND_LIMIT)
+        selected_brand_ids = self._get_selected_brand_ids_from_request(brand_ids)
+        exclude_brand_ids = self._get_selected_brand_ids_from_request(exclude_brand_ids)
+        domain = self._get_brand_rpc_domain(search, category_id, attribute_values)
+        all_brands, _brand_counts = self._get_available_brands(
+            domain, selected_brand_ids
+        )
+        all_brands -= all_brands.filtered(lambda b: b.id in exclude_brand_ids)
+        brands = all_brands[int(offset) : int(offset) + limit]
+        return {
+            "html": self._render_brand_items(brands, selected_brand_ids),
+            "has_more": int(offset) + limit < len(all_brands),
+            "next_offset": int(offset) + limit,
+        }
+
+    @http.route(
+        ["/shop/brand_filter/load_letter"],
+        type="jsonrpc",
+        auth="public",
+        website=True,
+    )
+    def brand_filter_load_letter(
+        self,
+        letter,
+        offset=0,
+        limit=None,
+        search="",
+        category_id=None,
+        attribute_values=None,
+        brand_ids=None,
+        **post,
+    ):
+        limit = int(limit or self.BRAND_LETTER_LIMIT)
+        selected_brand_ids = self._get_selected_brand_ids_from_request(brand_ids)
+        domain = self._get_brand_rpc_domain(search, category_id, attribute_values)
+        brands, _brand_counts = self._get_available_brands(domain, selected_brand_ids)
+        if letter == "#":
+            brands = brands.filtered(lambda b: not (b.name or "#")[0].isalpha())
+        else:
+            brands = brands.filtered(
+                lambda b: (b.name or "").upper().startswith(letter)
+            )
+        visible_brands = brands[int(offset) : int(offset) + limit]
+        return {
+            "html": self._render_brand_items(visible_brands, selected_brand_ids),
+            "has_more": int(offset) + limit < len(brands),
+            "next_offset": int(offset) + limit,
+        }
 
     # Method to get the brands.
     @http.route(["/page/product_brands"], type="http", auth="public", website=True)

--- a/website_sale_product_brand/models/__init__.py
+++ b/website_sale_product_brand/models/__init__.py
@@ -1,3 +1,4 @@
 from . import product_brand
 from . import product_template
+from . import res_config_settings
 from . import website

--- a/website_sale_product_brand/models/product_brand.py
+++ b/website_sale_product_brand/models/product_brand.py
@@ -43,13 +43,19 @@ class ProductBrand(models.Model):
         return res
 
     def _compute_published_products_count(self):
-        for brand in self:
-            brand.published_products_count = self.env["product.template"].search_count(
+        count_by_brand = {
+            brand.id: count
+            for brand, count in self.env["product.template"]._read_group(
                 [
-                    ("product_brand_id", "=", brand.id),
+                    ("product_brand_id", "in", self.ids),
                     ("website_published", "=", True),
-                ]
+                ],
+                ["product_brand_id"],
+                ["__count"],
             )
+        }
+        for brand in self:
+            brand.published_products_count = count_by_brand.get(brand.id, 0)
 
     @api.model
     def _website_scope_domain(self, website=None):

--- a/website_sale_product_brand/models/res_config_settings.py
+++ b/website_sale_product_brand/models/res_config_settings.py
@@ -1,0 +1,13 @@
+# Copyright 2026 Studio73
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    brand_filter_display_mode = fields.Selection(
+        related="website_id.brand_filter_display_mode",
+        readonly=False,
+    )

--- a/website_sale_product_brand/models/website.py
+++ b/website_sale_product_brand/models/website.py
@@ -1,11 +1,25 @@
 # Copyright 2026 Camptocamp
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import models
+from odoo import fields, models
 
 
 class Website(models.Model):
     _inherit = "website"
+
+    brand_filter_display_mode = fields.Selection(
+        selection=[
+            ("list", "Full list"),
+            ("limited", "Limited list"),
+            ("letters", "Alphabetical accordion"),
+        ],
+        default="list",
+        required=True,
+        help="Controls how brands are displayed in the shop filter: "
+        "'Full list' shows all brands, 'Limited list' shows the first 5 brands "
+        "with an option to load more using 'Show more', and 'Alphabetical accordion' "
+        "groups brands by letter when there are more than 50 brands.",
+    )
 
     def _search_get_details(self, search_type, order, options):
         result = super()._search_get_details(search_type, order, options)

--- a/website_sale_product_brand/readme/CONFIGURE.md
+++ b/website_sale_product_brand/readme/CONFIGURE.md
@@ -8,3 +8,14 @@ If your database has multiple websites enabled, you can also set the
 brand's Website field on the product brand form to scope the brand to a
 specific website. The field is shown to users in the
 `website.group_multi_website` group.
+
+To configure how brands are displayed in the shop filter:
+
+1.  Go to *Website > Configuration > Settings*.
+2.  In the *Shop - Products* section, set *Brand Filter Display* to one
+    of the following values:
+
+    -  *Full list*: show all available brands.
+    -  *Limited list*: show the first 5 brands and a *Show more* option.
+    -  *Alphabetical accordion*: group brands by letter when there are
+       more than 50 brands.

--- a/website_sale_product_brand/static/src/interactions/website_sale_brand_filter.esm.js
+++ b/website_sale_product_brand/static/src/interactions/website_sale_brand_filter.esm.js
@@ -1,7 +1,139 @@
 import {WebsiteSale} from "@website_sale/interactions/website_sale";
 import {patch} from "@web/core/utils/patch";
+import {rpc} from "@web/core/network/rpc";
 
 patch(WebsiteSale.prototype, {
+    start() {
+        super.start(...arguments);
+        this.setupBrandFilter();
+    },
+
+    setupBrandFilter() {
+        this.brandFilterForm = this.el.querySelector("form[data-brand-filter-mode]");
+        if (!this.brandFilterForm) {
+            return;
+        }
+        const loadMoreButton = this.brandFilterForm.querySelector(
+            ".o_wsale_brand_load_more"
+        );
+        if (loadMoreButton) {
+            this.onBrandLoadMore = this.loadMoreBrands.bind(this);
+            loadMoreButton.addEventListener("click", this.onBrandLoadMore);
+            this.registerCleanup(() =>
+                loadMoreButton.removeEventListener("click", this.onBrandLoadMore)
+            );
+        }
+        this.onBrandLetterShown = this.loadBrandLetter.bind(this);
+        for (const letter of this.brandFilterForm.querySelectorAll("[data-letter]")) {
+            letter.addEventListener("shown.bs.collapse", this.onBrandLetterShown);
+            this.registerCleanup(() =>
+                letter.removeEventListener("shown.bs.collapse", this.onBrandLetterShown)
+            );
+        }
+        for (const openedLetter of this.brandFilterForm.querySelectorAll(
+            "[data-letter].show"
+        )) {
+            this.loadBrandLetter({currentTarget: openedLetter});
+        }
+    },
+
+    getBrandRpcParams(extraParams = {}) {
+        const url = new URL(window.location.href);
+        return {
+            search: this.brandFilterForm.dataset.search || "",
+            category_id: this.brandFilterForm.dataset.categoryId || false,
+            attribute_values: url.searchParams.getAll("attribute_values"),
+            brand_ids: [
+                ...url.searchParams.getAll("brand"),
+                ...url.searchParams.getAll("brand_ids"),
+            ],
+            ...extraParams,
+        };
+    },
+
+    async loadMoreBrands(ev) {
+        const button = ev.currentTarget;
+        button.disabled = true;
+        const result = await this.waitFor(
+            rpc(
+                "/shop/brand_filter/load_more",
+                this.getBrandRpcParams({
+                    offset: parseInt(button.dataset.offset || "0", 10),
+                    limit: parseInt(this.brandFilterForm.dataset.brandLimit || "5", 10),
+                    exclude_brand_ids: (button.dataset.excludeBrandIds || "")
+                        .split(",")
+                        .filter(Boolean),
+                })
+            )
+        );
+        this.brandFilterForm
+            .querySelector("[data-brand-filter-items]")
+            .insertAdjacentHTML("beforeend", result.html);
+        if (result.has_more) {
+            button.dataset.offset = result.next_offset;
+            button.disabled = false;
+        } else {
+            button.remove();
+        }
+    },
+
+    async loadBrandLetter(ev) {
+        const panel = ev.currentTarget;
+        if (panel.dataset.loaded === "1") {
+            return;
+        }
+        const button = panel.querySelector(".o_wsale_brand_letter_load_more");
+        const result = await this.waitFor(
+            rpc(
+                "/shop/brand_filter/load_letter",
+                this.getBrandRpcParams({
+                    letter: panel.dataset.letter,
+                    offset: 0,
+                    limit: parseInt(
+                        this.brandFilterForm.dataset.brandLetterLimit || "50",
+                        10
+                    ),
+                })
+            )
+        );
+        panel.querySelector("[data-brand-filter-items]").innerHTML = result.html;
+        panel.dataset.loaded = "1";
+        if (button && result.has_more) {
+            button.dataset.offset = result.next_offset;
+            button.classList.remove("d-none");
+            const onClick = (clickEv) => this.loadMoreBrandLetter(clickEv, panel);
+            button.addEventListener("click", onClick);
+            this.registerCleanup(() => button.removeEventListener("click", onClick));
+        }
+    },
+
+    async loadMoreBrandLetter(ev, panel) {
+        const button = ev.currentTarget;
+        button.disabled = true;
+        const result = await this.waitFor(
+            rpc(
+                "/shop/brand_filter/load_letter",
+                this.getBrandRpcParams({
+                    letter: panel.dataset.letter,
+                    offset: parseInt(button.dataset.offset || "0", 10),
+                    limit: parseInt(
+                        this.brandFilterForm.dataset.brandLetterLimit || "50",
+                        10
+                    ),
+                })
+            )
+        );
+        panel
+            .querySelector("[data-brand-filter-items]")
+            .insertAdjacentHTML("beforeend", result.html);
+        if (result.has_more) {
+            button.dataset.offset = result.next_offset;
+            button.disabled = false;
+        } else {
+            button.remove();
+        }
+    },
+
     onChangeAttribute(ev) {
         const container =
             ev.currentTarget.closest(".o_wsale_products_grid_before_rail") ||

--- a/website_sale_product_brand/tests/test_website_sale_filter_brand.py
+++ b/website_sale_product_brand/tests/test_website_sale_filter_brand.py
@@ -86,6 +86,8 @@ class WebsiteSale(BaseCommon):
                 "website_id": cls.other_website.id,
             }
         )
+        cls.selected_brand = cls.env["product.brand"].create({"name": "Selected Brand"})
+        cls.numeric_brand = cls.env["product.brand"].create({"name": "1 Brand"})
         cls.product = cls.env["product.template"].create(
             {
                 "name": "Test Product",
@@ -108,6 +110,26 @@ class WebsiteSale(BaseCommon):
                 "sale_ok": True,
                 "website_published": True,
                 "product_brand_id": cls.other_brand.id,
+            }
+        )
+        cls.extra_brands = cls.env["product.brand"].create(
+            [{"name": f"A Brand {index}"} for index in range(6)]
+        )
+        for brand in cls.extra_brands:
+            cls.env["product.template"].create(
+                {
+                    "name": f"Product {brand.name}",
+                    "sale_ok": True,
+                    "website_published": True,
+                    "product_brand_id": brand.id,
+                }
+            )
+        cls.env["product.template"].create(
+            {
+                "name": "Numeric Product",
+                "sale_ok": True,
+                "website_published": True,
+                "product_brand_id": cls.numeric_brand.id,
             }
         )
 
@@ -219,3 +241,109 @@ class WebsiteSale(BaseCommon):
                 self.assertIn(self.brand, brand_rec)
                 self.assertIn(self.global_brand, brand_rec)
                 self.assertNotIn(self.other_brand, brand_rec)
+
+    def test_brand_filter_display_mode_default(self):
+        self.assertEqual(self.website.brand_filter_display_mode, "list")
+
+    def test_brand_filter_limited_mode(self):
+        self.website.brand_filter_display_mode = "limited"
+        domain = [("website_published", "=", True)]
+        with MockRequest(self.env, website=self.website):
+            values = self.WebsiteSaleController._get_brand_filter_values(domain, [])
+        self.assertEqual(values["brand_filter_display_mode"], "limited")
+        self.assertLessEqual(len(values["brands"]), 5)
+        self.assertTrue(values["brand_has_more"])
+
+    def test_brand_filter_letters_mode(self):
+        self.website.brand_filter_display_mode = "letters"
+        domain = [("website_published", "=", True)]
+        with MockRequest(self.env, website=self.website):
+            values = self.WebsiteSaleController._get_brand_filter_values(domain, [])
+        self.assertEqual(values["brand_filter_display_mode"], "letters")
+        self.assertIn("A", [letter["letter"] for letter in values["brand_letters"]])
+
+    def test_available_brands_keep_selected_brand_without_products(self):
+        domain = [("website_published", "=", True)]
+        with MockRequest(self.env, website=self.website):
+            brands, brand_counts = self.WebsiteSaleController._get_available_brands(
+                domain, [self.selected_brand.id]
+            )
+        self.assertIn(self.selected_brand, brands)
+        self.assertNotIn(self.other_brand, brands)
+        self.assertEqual(brand_counts.get(self.selected_brand.id, 0), 0)
+
+    def test_brand_filter_letters_group_non_alpha_names(self):
+        domain = [("website_published", "=", True)]
+        with MockRequest(self.env, website=self.website):
+            brands, brand_counts = self.WebsiteSaleController._get_available_brands(
+                domain, []
+            )
+            letters = self.WebsiteSaleController._get_brand_letters(
+                brands, brand_counts, []
+            )
+        self.assertIn("#", [letter["letter"] for letter in letters])
+
+    def test_get_brand_rpc_domain_with_category_and_attribute_values(self):
+        category = self.env["product.public.category"].create({"name": "Test Category"})
+        with MockRequest(self.env, website=self.website):
+            with patch.object(
+                self.WebsiteSaleController, "_get_shop_domain_no_brands"
+            ) as mock_domain:
+                mock_domain.return_value = [("id", "in", self.product.ids)]
+                domain = self.WebsiteSaleController._get_brand_rpc_domain(
+                    search="Test",
+                    category_id=category.id,
+                    attribute_values=["1-2,3"],
+                )
+        self.assertEqual(domain, [("id", "in", self.product.ids)])
+        args, kwargs = mock_domain.call_args
+        self.assertEqual(args[0], "Test")
+        self.assertEqual(args[1], category)
+
+    def test_brand_filter_load_more(self):
+        with MockRequest(self.env, website=self.website):
+            with patch.object(
+                self.WebsiteSaleController,
+                "_render_brand_items",
+                return_value="<div>brands</div>",
+            ):
+                result = self.WebsiteSaleController.brand_filter_load_more(
+                    offset=0,
+                    limit=2,
+                    brand_ids=[str(self.selected_brand.id)],
+                    exclude_brand_ids=[str(self.brand.id)],
+                )
+        self.assertEqual(result["html"], "<div>brands</div>")
+        self.assertTrue(result["has_more"])
+        self.assertEqual(result["next_offset"], 2)
+
+    def test_brand_filter_load_letter(self):
+        with MockRequest(self.env, website=self.website):
+            with patch.object(
+                self.WebsiteSaleController,
+                "_render_brand_items",
+                return_value="<div>a-brands</div>",
+            ) as mock_render:
+                result = self.WebsiteSaleController.brand_filter_load_letter(
+                    letter="A",
+                    offset=0,
+                    limit=50,
+                )
+        self.assertEqual(result["html"], "<div>a-brands</div>")
+        brands = mock_render.call_args.args[0]
+        self.assertTrue(all(brand.name.startswith("A") for brand in brands))
+
+    def test_brand_filter_load_letter_non_alpha(self):
+        with MockRequest(self.env, website=self.website):
+            with patch.object(
+                self.WebsiteSaleController,
+                "_render_brand_items",
+                return_value="<div>other-brands</div>",
+            ) as mock_render:
+                result = self.WebsiteSaleController.brand_filter_load_letter(
+                    letter="#",
+                    offset=0,
+                    limit=50,
+                )
+        self.assertEqual(result["html"], "<div>other-brands</div>")
+        self.assertIn(self.numeric_brand, mock_render.call_args.args[0])

--- a/website_sale_product_brand/views/res_config_settings_views.xml
+++ b/website_sale_product_brand/views/res_config_settings_views.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="website_sale.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <setting id="product_attributes_setting" position="after">
+                <setting
+                    id="brand_filter_display_mode_setting"
+                    string="Brand Filter Display"
+                    help="Choose how product brands are displayed in the shop filters."
+                >
+                    <field name="brand_filter_display_mode" widget="radio" />
+                </setting>
+            </setting>
+        </field>
+    </record>
+</odoo>

--- a/website_sale_product_brand/views/templates.xml
+++ b/website_sale_product_brand/views/templates.xml
@@ -1,5 +1,25 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
+    <template id="brand_filter_items" name="Brand Filter Items">
+        <t t-foreach="brands" t-as="brand">
+            <div class="form-check mb-1">
+                <input
+                    type="checkbox"
+                    name="brand"
+                    class="form-check-input"
+                    t-attf-id="brand_#{brand.id}"
+                    t-att-value="brand.id"
+                    t-att-checked="'checked' if brand.id in selected_brand_ids else None"
+                />
+                <label
+                    class="form-check-label fw-normal"
+                    t-attf-for="brand_#{brand.id}"
+                    t-field="brand.name"
+                />
+            </div>
+        </t>
+    </template>
+
     <template
         id="website_sale_filter_brand_products_brands"
         inherit_id="website_sale.products"
@@ -13,10 +33,15 @@
             position="inside"
         >
             <form
-                t-if="brands"
+                t-if="brands or brand_letters"
                 class="js_attributes wsale_accordion_collapsible accordion accordion-flush mb-3"
                 method="get"
                 t-att-action="keep(brand=0, brand_ids=0)"
+                t-att-data-brand-filter-mode="brand_filter_display_mode"
+                t-att-data-search="search or ''"
+                t-att-data-category-id="brand_filter_category_id or ''"
+                t-att-data-brand-limit="brand_filter_limit"
+                t-att-data-brand-letter-limit="brand_letter_limit"
             >
                 <div class="accordion-item nav-item rounded-0">
                     <div class="accordion-header h6 mb-0">
@@ -35,21 +60,68 @@
                         t-attf-id="o_products_attributes_brand"
                         class="accordion-collapse collapse show pt-2"
                     >
-                        <t t-foreach="brands" t-as="brand">
-                            <div class="form-check mb-1">
-                                <input
-                                    type="checkbox"
-                                    name="brand"
-                                    class="form-check-input"
-                                    t-attf-id="brand_#{brand.id}"
-                                    t-att-value="brand.id"
-                                    t-att-checked="'checked' if brand.id in selected_brand_ids else None"
+                        <t t-if="brand_filter_display_mode in ('list', 'limited')">
+                            <div data-brand-filter-items="">
+                                <t
+                                    t-call="website_sale_product_brand.brand_filter_items"
                                 />
-                                <label
-                                    class="form-check-label fw-normal"
-                                    t-attf-for="brand_#{brand.id}"
-                                    t-field="brand.name"
-                                />
+                            </div>
+                            <button
+                                t-if="brand_filter_display_mode == 'limited' and brand_has_more"
+                                type="button"
+                                class="btn btn-link px-0 py-1 o_wsale_brand_load_more"
+                                t-att-data-offset="brand_next_offset"
+                                t-att-data-exclude-brand-ids="','.join([str(brand.id) for brand in brands])"
+                            >
+                                Show more
+                            </button>
+                        </t>
+                        <t t-if="brand_filter_display_mode == 'letters'">
+                            <div
+                                class="accordion accordion-flush o_wsale_brand_letters"
+                            >
+                                <t t-foreach="brand_letters" t-as="letter_data">
+                                    <div class="accordion-item rounded-0">
+                                        <div class="accordion-header">
+                                            <button
+                                                t-attf-class="accordion-button px-0 py-1 bg-transparent shadow-none #{'' if letter_data['active'] else 'collapsed'}"
+                                                type="button"
+                                                data-bs-toggle="collapse"
+                                                t-attf-data-bs-target="#o_products_brand_letter_#{letter_data['key']}"
+                                                t-attf-aria-controls="o_products_brand_letter_#{letter_data['key']}"
+                                                t-att-aria-expanded="letter_data['active']"
+                                            >
+                                                <span t-out="letter_data['letter']" />
+                                                <span class="text-muted ms-1">
+                                                    (<t t-out="letter_data['count']" />)
+                                                </span>
+                                            </button>
+                                        </div>
+                                        <div
+                                            t-attf-id="o_products_brand_letter_#{letter_data['key']}"
+                                            t-attf-class="accordion-collapse collapse #{'show' if letter_data['active'] else ''}"
+                                            t-att-data-letter="letter_data['letter']"
+                                            data-loaded="0"
+                                        >
+                                            <div data-brand-filter-items="">
+                                                <t
+                                                    t-set="brands"
+                                                    t-value="letter_data['brands']"
+                                                />
+                                                <t
+                                                    t-call="website_sale_product_brand.brand_filter_items"
+                                                />
+                                            </div>
+                                            <button
+                                                type="button"
+                                                class="btn btn-link px-0 py-1 o_wsale_brand_letter_load_more d-none"
+                                                data-offset="0"
+                                            >
+                                                Show more
+                                            </button>
+                                        </div>
+                                    </div>
+                                </t>
                             </div>
                         </t>
                     </div>


### PR DESCRIPTION
# Configurable website brand filter display

## Description

This PR improves the performance of the brand filter on `/shop` by making its display mode configurable per website.

## Changes

- Add `brand_filter_display_mode` on `website`.
- Expose the setting in Website/eCommerce configuration.
- Support three display modes:
  - Full list
  - Limited list with “Show more”
  - Alphabetical accordion with lazy loading
- Add JSONRPC endpoints to load more brands or brands by letter.
- Keep selected brands visible in lazy modes.
- Optimize published product counts with `_read_group`.