### PR TITLE
[19.0][FIX] website_sale_checkout_skip_payment: disable confirm button on p…

### DIFF
--- a/website_sale_checkout_skip_payment/views/website_sale_template.xml
+++ b/website_sale_checkout_skip_payment/views/website_sale_template.xml
@@ -86,6 +86,7 @@
                         name="o_payment_submit_button"
                         type="submit"
                         class="btn btn-primary w-100 w-md-auto ms-auto px-5"
+                        disabled="disabled"
                     >
                         <span>Confirm <span
                             class="fa fa-angle-right ms-2 fw-light"


### PR DESCRIPTION
…age load

The skip-payment Confirm button shares the o_payment_submit_button name, so the PaymentButton interaction attaches to it. On setup it calls _enable(), which only sets enabled=true when _canSubmit() passes; it never explicitly disables the button. Because the button had no disabled attribute by default it was always clickable on first load, even when the T&C checkbox was present and unticked.

Add disabled="disabled" so the initial state is off. PaymentButton then correctly enables it once _canSubmit() returns true (either no T&C checkbox, or the user ticks it).