### PR TITLE
[19.0][IMP] website_sale_product_brand: add brand logo to the product page

### DIFF
--- a/website_sale_product_brand/README.rst
+++ b/website_sale_product_brand/README.rst
@@ -119,6 +119,9 @@ specific website from the product brand form and list views. Brands are
 only shown on the website they belong to, while global brands remain
 available on every website.
 
+When a product has a brand with a logo configured, that logo is
+displayed on the product page and links to the brand's landing page.
+
 Bug Tracker
 ===========
 

--- a/website_sale_product_brand/models/website.py
+++ b/website_sale_product_brand/models/website.py
@@ -25,7 +25,7 @@ class Website(models.Model):
         result = super()._search_get_details(search_type, order, options)
         if not self.has_ecommerce_access():
             return result
-        if search_type in ["products", "products_only", "all"]:
+        if search_type in ["products", "all"]:
             result.append(
                 self.env["product.brand"]._search_get_detail(self, order, options)
             )

--- a/website_sale_product_brand/readme/USAGE.md
+++ b/website_sale_product_brand/readme/USAGE.md
@@ -31,3 +31,6 @@ If your database uses multiple websites, each brand can be assigned to a
 specific website from the product brand form and list views. Brands are
 only shown on the website they belong to, while global brands remain
 available on every website.
+
+When a product has a brand with a logo configured, that logo is displayed
+on the product page and links to the brand's landing page.

--- a/website_sale_product_brand/static/description/index.html
+++ b/website_sale_product_brand/static/description/index.html
@@ -464,6 +464,8 @@ In the brand form view, you can configure:</p>
 specific website from the product brand form and list views. Brands are
 only shown on the website they belong to, while global brands remain
 available on every website.</p>
+<p>When a product has a brand with a logo configured, that logo is
+displayed on the product page and links to the brand’s landing page.</p>
 </div>
 <div class="section" id="bug-tracker">
 <h2><a class="toc-backref" href="#toc-entry-3">Bug Tracker</a></h2>

--- a/website_sale_product_brand/views/templates.xml
+++ b/website_sale_product_brand/views/templates.xml
@@ -230,4 +230,25 @@
             </section>
         </xpath>
     </template>
+
+    <template
+        id="product_title_brand_logo"
+        inherit_id="website_sale.product_title"
+        name="Product Page Brand Logo"
+    >
+        <xpath expr="//h1[@t-field='product.name']" position="after">
+            <a
+                t-if="product.product_brand_id and product.product_brand_id.logo"
+                t-att-href="product.product_brand_id.website_url"
+                class="d-inline-block mb-3"
+            >
+                <img
+                    style="max-height: 48px; max-width: 160px; object-fit: contain;"
+                    t-att-src="'/web/image/product.brand/%s/logo/256x256' % product.product_brand_id.id"
+                    t-att-alt="product.product_brand_id.name"
+                    loading="lazy"
+                />
+            </a>
+        </xpath>
+    </template>
 </odoo>


### PR DESCRIPTION
1. Add brand logo to the product page.
2. Fix pager counts, so brands counts aren't falsy added to the pages sum.