### PR TITLE
[18.0] [FIX] website_sale_order_type: remove deprecated test key from tour

### DIFF
--- a/website_sale_order_type/static/tests/tours/website_sale_order_type_tour.esm.js
+++ b/website_sale_order_type/static/tests/tours/website_sale_order_type_tour.esm.js
@@ -4,7 +4,6 @@
 import {registry} from "@web/core/registry";
 
 registry.category("web_tour.tours").add("website_sale_order_type_tour", {
-    test: true,
     url: "/shop",
     steps: () => [
         {


### PR DESCRIPTION
Odoo 18 introduced schema validation for the `web_tour.tours` registry via `addValidation(TourSchema)`. The schema only accepts `name`, `steps`, `url`, and `wait_for` keys. Any additional key triggers an `OwlError: Invalid object: unknown key` during module loading.

The `website_sale_order_type_tour` still declares `test: true`, which was valid in Odoo 17 but is now rejected by the validator in Odoo 18. This causes a JavaScript module loading failure when the tour assets bundle is loaded with `debug=assets,tests`.

**Steps to reproduce:**
1. Install `website_sale_order_type` on Odoo 18.0
2. Navigate to any page with `?debug=assets,tests` in the URL
3. Console shows: `Uncaught Error: Error while loading @website_sale_order_type/../tests/tours/website_sale_order_type_tour.esm: Error: Invalid object: unknown key 'test'`

**Fix:** Remove the deprecated `test: true` property from the tour registration object. Tours loaded from the `web.assets_tests` bundle are automatically treated as test tours in Odoo 18.

@BinhexTeam T23799