### PR TITLE
[18.0][FIX] website_sale_*: remove deprecated test key from tour

### DIFF
--- a/website_sale_hide_empty_category/static/src/js/tour.esm.js
+++ b/website_sale_hide_empty_category/static/src/js/tour.esm.js
@@ -2,7 +2,6 @@
 import {registry} from "@web/core/registry";
 
 registry.category("web_tour.tours").add("website_sale_hide_empty_category", {
-    test: true,
     url: "/shop",
     steps: () => [
         {

--- a/website_sale_product_assortment/static/src/js/no_purchase_tour.esm.js
+++ b/website_sale_product_assortment/static/src/js/no_purchase_tour.esm.js
@@ -5,7 +5,6 @@ import {registry} from "@web/core/registry";
 
 registry.category("web_tour.tours").add("test_assortment_with_no_purchase", {
     url: "/shop",
-    test: true,
     steps: () => [
         {
             trigger:

--- a/website_sale_product_assortment/static/src/js/no_restriction_tour.esm.js
+++ b/website_sale_product_assortment/static/src/js/no_restriction_tour.esm.js
@@ -5,7 +5,6 @@ import {registry} from "@web/core/registry";
 
 registry.category("web_tour.tours").add("test_assortment_with_no_restriction", {
     url: "/shop",
-    test: true,
     steps: () => [
         {
             trigger: "a:contains('Test Product 1')",

--- a/website_sale_product_assortment/static/src/js/no_show_tour.esm.js
+++ b/website_sale_product_assortment/static/src/js/no_show_tour.esm.js
@@ -5,7 +5,6 @@ import {registry} from "@web/core/registry";
 
 registry.category("web_tour.tours").add("test_assortment_with_no_show", {
     url: "/shop",
-    test: true,
     steps: () => [
         {
             trigger:

--- a/website_sale_product_attribute_filter_category/static/tests/tours/website_sale_attribute_filter_category_tour.esm.js
+++ b/website_sale_product_attribute_filter_category/static/tests/tours/website_sale_attribute_filter_category_tour.esm.js
@@ -5,7 +5,6 @@ import {registry} from "@web/core/registry";
 registry
     .category("web_tour.tours")
     .add("website_sale_product_attribute_filter_category", {
-        test: true,
         url: "/shop",
         steps: () => [
             {

--- a/website_sale_product_brand/static/src/js/test_website_sale_filter_brand.esm.js
+++ b/website_sale_product_brand/static/src/js/test_website_sale_filter_brand.esm.js
@@ -1,7 +1,6 @@
 import {registry} from "@web/core/registry";
 
 registry.category("web_tour.tours").add("website_sale_filter_product_brand", {
-    test: true,
     url: "/shop",
     steps: () => [
         {

--- a/website_sale_product_brand/static/src/js/tour.esm.js
+++ b/website_sale_product_brand/static/src/js/tour.esm.js
@@ -3,7 +3,6 @@
 import {registry} from "@web/core/registry";
 
 registry.category("web_tour.tours").add("website_sale_product_brand", {
-    test: true,
     url: "/",
     steps: () => [
         {

--- a/website_sale_product_detail_attribute_image/static/tests/tours/website_sale_product_detail_attribute_image.esm.js
+++ b/website_sale_product_detail_attribute_image/static/tests/tours/website_sale_product_detail_attribute_image.esm.js
@@ -4,7 +4,6 @@
 import {registry} from "@web/core/registry";
 
 registry.category("web_tour.tours").add("website_sale_product_detail_attribute_image", {
-    test: true,
     url: "/shop",
     steps: () => [
         {

--- a/website_sale_product_minimal_price/static/src/tests/tours/test_product_with_no_prices_tour.esm.js
+++ b/website_sale_product_minimal_price/static/src/tests/tours/test_product_with_no_prices_tour.esm.js
@@ -5,7 +5,6 @@
 import {registry} from "@web/core/registry";
 registry.category("web_tour.tours").add("test_product_with_no_prices", {
     url: "/shop",
-    test: true,
     steps: () => [
         {
             trigger:

--- a/website_sale_product_minimal_price/static/src/tests/tours/tour.esm.js
+++ b/website_sale_product_minimal_price/static/src/tests/tours/tour.esm.js
@@ -5,7 +5,6 @@
 import {registry} from "@web/core/registry";
 registry.category("web_tour.tours").add("website_sale_product_minimal_price", {
     url: "/shop",
-    test: true,
     steps: () => [
         {
             trigger:

--- a/website_sale_secondary_unit/static/tests/tours/website_sale_secondary_unit_tour.esm.js
+++ b/website_sale_secondary_unit/static/tests/tours/website_sale_secondary_unit_tour.esm.js
@@ -3,7 +3,6 @@
 
 import {registry} from "@web/core/registry";
 registry.category("web_tour.tours").add("website_sale_secondary_unit", {
-    test: true,
     url: "/shop",
     steps: () => [
         {

--- a/website_sale_stock_provisioning_date/static/src/js/website_sale_stock_provisioning_date_tour.esm.js
+++ b/website_sale_stock_provisioning_date/static/src/js/website_sale_stock_provisioning_date_tour.esm.js
@@ -6,7 +6,6 @@ import {registry} from "@web/core/registry";
 import {searchProduct} from "@website_sale/js/tours/tour_utils";
 
 registry.category("web_tour.tours").add("website_sale_stock_provisioning_date", {
-    test: true,
     url: "/shop",
     steps: () => [
         ...searchProduct("provisioning date"),

--- a/website_sale_vat_required/static/tests/tours/website_sale_vat_required.esm.js
+++ b/website_sale_vat_required/static/tests/tours/website_sale_vat_required.esm.js
@@ -4,7 +4,6 @@
 
 import {registry} from "@web/core/registry";
 registry.category("web_tour.tours").add("website_sale_vat_required_tour", {
-    test: true,
     url: "/shop",
     steps: () => [
         {

--- a/website_sale_wishlist_keep/static/src/js/tour.esm.js
+++ b/website_sale_wishlist_keep/static/src/js/tour.esm.js
@@ -5,7 +5,6 @@
 import {registry} from "@web/core/registry";
 
 registry.category("web_tour.tours").add("website_sale_wishlist_keep", {
-    test: true,
     url: "/shop?search=Test Product",
     steps: () => [
         {


### PR DESCRIPTION
As set out in the migration guide: https://github.com/OCA/maintainer-tools/wiki/Migration-to-version-18.0#:~:text=On%20JS%20test%20tours%2C%20remove%20test%3A%20true%2C%20from%20the%20JS%20definition.

@Tecnativa 

@pedrobaeza please review