### PR TITLE
[19.0][FIX] website_sale_product_minimal_price: crash on shop with lazy request.pricelist (Odoo 19)

### DIFF
--- a/website_sale_product_minimal_price/models/product_template.py
+++ b/website_sale_product_minimal_price/models/product_template.py
@@ -13,7 +13,13 @@ class ProductTemplate(models.Model):
     def _get_website_current_pricelist(self, website=None):
         website = website or self.env["website"].get_current_website()
         if request and getattr(request, "pricelist", False):
-            return request.pricelist
+            # In Odoo 19 request.pricelist is a lazy() proxy
+            # (website_sale/models/ir_http.py). Returning it as-is makes the
+            # in-place union in _get_pricelist_variant_items
+            # ("visited_pricelists |= pricelist") delegate to
+            # product.pricelist.__ior__, which no longer exists on recordsets,
+            # raising AttributeError. Materialise it into a real recordset.
+            return self.env["product.pricelist"].browse(request.pricelist.ids)
         pricelist = website._get_and_cache_current_pricelist()
         if pricelist:
             return pricelist

--- a/website_sale_product_minimal_price/readme/CONTRIBUTORS.md
+++ b/website_sale_product_minimal_price/readme/CONTRIBUTORS.md
@@ -9,3 +9,7 @@
 - [Studio73](https://www.studio73.es):
 
     - Alex Garcia
+
+- [Akyado](https://www.akyado.com):
+
+    - Antoine Guex

--- a/website_sale_product_minimal_price/tests/test_product_template.py
+++ b/website_sale_product_minimal_price/tests/test_product_template.py
@@ -1,7 +1,8 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from odoo.http import request
 from odoo.tests import TransactionCase, tagged
+from odoo.tools import lazy
 
 
 @tagged("post_install", "-at_install")
@@ -48,10 +49,20 @@ class TestProductTemplateMinimalPrice(TransactionCase):
     def test_get_website_current_pricelist(self):
         from odoo.addons.website_sale.tests.common import MockRequest
 
+        pricelist = self.env["product.pricelist"].create({"name": "Request Pricelist"})
         with MockRequest(self.env, website=self.website):
-            request.pricelist = MagicMock()
+            # In Odoo 19 ``request.pricelist`` is a ``lazy()`` proxy. The method
+            # must return a materialised recordset, otherwise the in-place union
+            # in ``_get_pricelist_variant_items`` ("visited_pricelists |= ...")
+            # raises ``AttributeError: 'product.pricelist' object has no
+            # attribute '__ior__'``.
+            request.pricelist = lazy(lambda: pricelist)
             res = self.product_tmpl._get_website_current_pricelist()
-            self.assertEqual(res, request.pricelist)
+            self.assertEqual(res, pricelist)
+            # Regression: the result must support in-place set operations.
+            accumulator = self.env["product.pricelist"]
+            accumulator |= res
+            self.assertEqual(accumulator, pricelist)
         with patch.object(
             type(self.website), "_get_and_cache_current_pricelist"
         ) as mock_get_cache:


### PR DESCRIPTION
## Bug

On the eCommerce shop page, computing the cheapest variant of a product crashes with:

```
AttributeError: 'product.pricelist' object has no attribute '__ior__'
```

<details><summary>Traceback</summary>

```
File ".../website_sale/controllers/main.py", line 458, in shop
    variants = request.env['product.product'].sudo().browse(product._get_first_possible_variant_id() for product in products)
File ".../website_sale_product_minimal_price/models/product_template.py", line 111, in _get_first_possible_combination
    product = self._get_cheapest_info(pricelist)[0]
File ".../website_sale_product_minimal_price/models/product_template.py", line 72, in _get_cheapest_info
    variant_items = self._get_pricelist_variant_items(pricelist)
File ".../website_sale_product_minimal_price/models/product_template.py", line 55, in _get_pricelist_variant_items
    visited_pricelists |= pricelist
File ".../odoo/tools/func.py", line 235, in __ior__
    def __ior__(self, other): return self._value.__ior__(other)
AttributeError: 'product.pricelist' object has no attribute '__ior__'
```
</details>

## Root cause

Two Odoo 19 changes combine to trigger this:

1. **`request.pricelist` is now a `lazy()` proxy** — `website_sale/models/ir_http.py`:
   ```python
   request.pricelist = lazy(request.website._get_and_cache_current_pricelist)
   ```
   `_get_website_current_pricelist()` returns it as-is.
2. **Recordsets no longer implement in-place set operators** — `BaseModel` defines `__or__` but not `__ior__`. For a plain recordset, `x |= y` falls back to `__or__` (fine). For a `lazy`, `lazy.__ior__` (in `odoo/tools/func.py`) delegates to `product.pricelist.__ior__`, which no longer exists -> `AttributeError`.

`_get_pricelist_variant_items()` does `visited_pricelists |= pricelist`, where `visited_pricelists` was initialised from the lazy `request.pricelist`.

## How to reproduce

- A product with more than one variant (`product_variant_count > 1`).
- A pricelist with sub-pricelists (items with `compute_price = 'formula'`, `base = 'pricelist'`, `base_pricelist_id` set), so the `while next_pricelists:` loop actually runs and reaches `visited_pricelists |= pricelist`.
- Open the shop page -> crash. (A flat pricelist never enters the loop, which is why it is not hit by everyone.)

## Fix

`_get_website_current_pricelist` now materialises the pricelist into a real recordset, so downstream in-place set operations keep working. The existing test is updated to reproduce the lazy scenario as a regression test.
