### PR TITLE
[19.0][FIX] website_sale_require_legal: Prevent an error when base_vat is installed

### DIFF
--- a/website_sale_require_legal/static/tests/tours/tour.esm.js
+++ b/website_sale_require_legal/static/tests/tours/tour.esm.js
@@ -32,7 +32,7 @@ registry.category("web_tour.tours").add("website_sale_require_legal_with_payment
         },
         {
             trigger: `input[name="vat"]`,
-            run: "edit BE04774722701",
+            run: "edit BE0428759497",
         },
         {
             trigger: `input[name="street"]`,
@@ -106,7 +106,7 @@ registry.category("web_tour.tours").add("website_sale_require_legal", {
         },
         {
             trigger: `input[name="vat"]`,
-            run: "edit BE04774722701",
+            run: "edit BE0428759497",
         },
         {
             trigger: `input[name="street"]`,


### PR DESCRIPTION
The tour fails when the base_vat module is installed because the VAT number is invalid.

<img width="1173" height="676" alt="image" src="https://github.com/user-attachments/assets/83661fb9-2e84-4fb0-a887-2067658bcbd8" />
TT64060
@Tecnativa @pedrobaeza @pilarvargas-tecnativa could you please review this?