### PR TITLE
[ADD] website_sale_affiliate: Added copy button

### DIFF
--- a/website_sale_affiliate/models/sale_affiliate.py
+++ b/website_sale_affiliate/models/sale_affiliate.py
@@ -65,6 +65,11 @@ class Affiliate(models.Model):
         help="Sale count / Request count",
     )
 
+    affiliate_link = fields.Char(
+        compute="_compute_affiliate_link",
+        help="Copy this link to share your affiliate reference.",
+    )
+
     @api.depends("request_ids", "request_ids.sale_ids")
     def _compute_sales_per_request(self):
         for record in self:
@@ -127,3 +132,13 @@ class Affiliate(models.Model):
                 }
             )
         return matching_request
+
+    def _compute_affiliate_link(self):
+        base_url = (
+            self.env["ir.config_parameter"].sudo().get_param("web.base.url", default="")
+        )
+        for record in self:
+            if record.exists():
+                record.affiliate_link = f"{base_url}/shop?aff_ref={record.id}"
+            else:
+                record.affiliate_link = ""

--- a/website_sale_affiliate/views/sale_affiliate_view.xml
+++ b/website_sale_affiliate/views/sale_affiliate_view.xml
@@ -11,6 +11,15 @@
                     <group>
                         <field name="name" />
                         <field name="id" />
+                         <label for="affiliate_link" />
+                        <div class="o_row" name="affiliate_link_row">
+                            <field name="affiliate_link" widget="url" readonly="1" />
+                            <field
+                                name="affiliate_link"
+                                widget="CopyClipboardButton"
+                                nolabel="1"
+                            />
+                        </div>
                     </group>
                     <group col="4">
                         <field name="company_id" />


### PR DESCRIPTION
This PR adds a referral URL field with a copy-to-clipboard button on the Affiliate form view to allow quick sharing of affiliate referral links.

### Changes:
- **`sale.affiliate` Model**: Added computed `affiliate_link` field (`{base_url}/shop?aff_ref={id}`).
- **Form View (`sale_affiliate_view.xml`)**: Displayed `affiliate_link` with `CopyClipboardButton` widget alongside the URL field.

### Testing:
- Open **Sales > Affiliates** and open an affiliate record.
- Verify the generated affiliate URL and click the copy button to test clipboard copying.
