### PR TITLE
[18.0][FIX] website_sale_product_brand: ensure brand is detected in product  microdata

### DIFF
--- a/website_sale_product_brand/views/templates.xml
+++ b/website_sale_product_brand/views/templates.xml
@@ -187,11 +187,12 @@
         <xpath expr="//span[@itemprop='image']" position="after">
             <span
                 t-if="product.product_brand_id"
+                class="d-none"
                 itemprop="brand"
                 itemscope="itemscope"
                 itemtype="https://schema.org/Brand"
             >
-                <meta itemprop="name" t-att-content="product.product_brand_id.name" />
+                <span itemprop="name" t-esc="product.product_brand_id.name" />
             </span>
         </xpath>
     </template>


### PR DESCRIPTION
The meta approach was correctly detected during the initial validation, but it is not being interpreted consistently in the deployed environment. Use an explicit Brand schema structure instead to ensure reliable detection.

@Tecnativa TT64220

@victoralmau @pedrobaeza please review