### PR TITLE
[19.0][FIX] website_sale_product_minimal_price: Fix price scale rendering and currency

### DIFF
--- a/website_sale_product_minimal_price/models/product_template.py
+++ b/website_sale_product_minimal_price/models/product_template.py
@@ -177,7 +177,7 @@ class ProductTemplate(models.Model):
                     {
                         "min_qty": min_qty,
                         "price": new_price,
-                        "currency_id": product.currency_id.id,
+                        "currency_id": combination_info["currency"].id,
                     }
                 )
                 last_price = new_price

--- a/website_sale_product_minimal_price/static/src/js/website_sale_product_price_scale.esm.js
+++ b/website_sale_product_minimal_price/static/src/js/website_sale_product_price_scale.esm.js
@@ -2,60 +2,65 @@
  * Copyright 2025 Carlos Lopez - Tecnativa
  * License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). */
 
-import VariantMixin from "@website_sale/js/variant_mixin";
+import {WebsiteSale} from "@website_sale/interactions/website_sale";
 import {formatCurrency} from "@web/core/currency";
+import {patch} from "@web/core/utils/patch";
 import {renderToString} from "@web/core/utils/render";
 
-const oldOnChangeCombination = VariantMixin._onChangeCombination;
-
-VariantMixin._onChangeCombination = function (ev, parent, combination) {
-    oldOnChangeCombination.apply(this, arguments);
-    if (!this.isWebsite || combination.product_id === false) {
-        return;
-    }
-
-    const unitPrices = combination.minimal_price_scale || [];
-    const visiblePrices = unitPrices.filter((line) => line.price !== 0);
-    const uomName = combination.uom_name;
-    const form =
-        parent?.closest('form[action*="/shop/cart/update"]') ||
-        document.querySelector('form[action*="/shop/cart/update"]');
-    if (!form) {
-        return;
-    }
-
-    form.querySelectorAll(".o_wsmp_temp").forEach((el) => el.remove());
-    if (!visiblePrices.length) {
-        return;
-    }
-
-    form.insertAdjacentHTML("beforeend", '<hr class="o_wsmp_temp"/>');
-    form.insertAdjacentHTML(
-        "beforeend",
-        renderToString("website_sale_product_minimal_price.title", {uom: uomName})
-    );
-
-    const limitCol = 4;
-    let rowEl = null;
-    for (const [index, line] of visiblePrices.entries()) {
-        if (index % limitCol === 0) {
-            rowEl = document.createElement("div");
-            rowEl.className = "row o_wsmp_temp";
-            form.append(rowEl);
+patch(WebsiteSale.prototype, {
+    _onChangeCombination(ev, parent, combination) {
+        super._onChangeCombination(...arguments);
+        if (!this.isWebsite || combination.product_id === false) {
+            return;
         }
-        let unitPrice = formatCurrency(line.price, line.currency_id);
-        unitPrice = unitPrice.replace("&nbsp;", " ");
-        rowEl.insertAdjacentHTML(
-            "beforeend",
-            renderToString("website_sale_product_minimal_price.pricelist", {
-                quantity: line.min_qty,
-                price: unitPrice,
-            })
-        );
-    }
 
-    const rows = form.querySelectorAll(".row.o_wsmp_temp");
-    rows.forEach((row, index) => {
-        row.classList.toggle("border-bottom", index < rows.length - 1);
-    });
-};
+        const unitPrices = combination.minimal_price_scale || [];
+        const visiblePrices = unitPrices.filter((line) => line.price !== 0);
+        const uomName = combination.uom_name;
+        const form =
+            parent?.querySelector("form") || document.querySelector(".js_product form");
+        if (!form) {
+            return;
+        }
+
+        form.querySelectorAll(".o_wsmp_temp").forEach((el) => el.remove());
+        if (!visiblePrices.length) {
+            return;
+        }
+
+        const anchor =
+            form.querySelector("#o_wsale_cta_wrapper") || form.lastElementChild;
+        anchor.insertAdjacentHTML("afterend", '<div class="o_wsmp_temp"></div>');
+        const container = anchor.nextElementSibling;
+
+        container.insertAdjacentHTML("beforeend", "<hr/>");
+        container.insertAdjacentHTML(
+            "beforeend",
+            renderToString("website_sale_product_minimal_price.title", {uom: uomName})
+        );
+
+        const limitCol = 4;
+        let rowEl = null;
+        for (const [index, line] of visiblePrices.entries()) {
+            if (index % limitCol === 0) {
+                rowEl = document.createElement("div");
+                rowEl.className = "row";
+                container.append(rowEl);
+            }
+            let unitPrice = formatCurrency(line.price, line.currency_id);
+            unitPrice = unitPrice.replace("&nbsp;", " ");
+            rowEl.insertAdjacentHTML(
+                "beforeend",
+                renderToString("website_sale_product_minimal_price.pricelist", {
+                    quantity: line.min_qty,
+                    price: unitPrice,
+                })
+            );
+        }
+
+        const rows = container.querySelectorAll(".row");
+        rows.forEach((row, index) => {
+            row.classList.toggle("border-bottom", index < rows.length - 1);
+        });
+    },
+});


### PR DESCRIPTION
Fixes two v19 regressions in the price scale feature:

- **Rendering**: the `VariantMixin._onChangeCombination` monkey-patch is orphaned since core now copies it into `WebsiteSale.prototype` via `Object.assign` at import time. Switched to `patch(WebsiteSale.prototype, {...})`, and fixed the form selector/insertion point (the `<form>` has no `action` anymore and Terms/shipping/accordion now live inside it too).
- **Currency**: the price scale used `product.currency_id` instead of the pricelist's currency, causing a mismatch between the amount and its symbol.

@Tecnativa TT64164
@pedrobaeza @pilarvargas-tecnativa 