### PR TITLE
[19.0][IMP] website_sale_product_brand: show brand description on product page

### DIFF
--- a/website_sale_product_brand/README.rst
+++ b/website_sale_product_brand/README.rst
@@ -122,6 +122,11 @@ available on every website.
 When a product has a brand with a logo configured, that logo is
 displayed on the product page and links to the brand's landing page.
 
+The brand's website description can also be shown on the product page,
+right below the product description. This is disabled by default: enable
+*Show description on product page* on the brand form (*Website* tab) for
+each brand where you want it.
+
 Bug Tracker
 ===========
 

--- a/website_sale_product_brand/__manifest__.py
+++ b/website_sale_product_brand/__manifest__.py
@@ -8,7 +8,7 @@
     "Tecnativa, "
     "Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/e-commerce",
-    "version": "19.0.2.3.0",
+    "version": "19.0.2.4.0",
     "license": "AGPL-3",
     "depends": ["product_brand", "website", "website_sale"],
     "data": [

--- a/website_sale_product_brand/models/product_brand.py
+++ b/website_sale_product_brand/models/product_brand.py
@@ -20,6 +20,7 @@ class ProductBrand(models.Model):
     show_brand_name = fields.Boolean(default=True)
     show_brand_description = fields.Boolean(default=True)
     show_without_published_products = fields.Boolean(default=False)
+    show_description_on_product_page = fields.Boolean(default=False)
     align_brand_content = fields.Selection(
         selection=[
             ("left", "Left"),

--- a/website_sale_product_brand/readme/USAGE.md
+++ b/website_sale_product_brand/readme/USAGE.md
@@ -34,3 +34,8 @@ available on every website.
 
 When a product has a brand with a logo configured, that logo is displayed
 on the product page and links to the brand's landing page.
+
+The brand's website description can also be shown on the product page,
+right below the product description. This is disabled by default: enable
+*Show description on product page* on the brand form (*Website* tab) for
+each brand where you want it.

--- a/website_sale_product_brand/static/description/index.html
+++ b/website_sale_product_brand/static/description/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <meta name="generator" content="Docutils: https://docutils.sourceforge.io/" />
-<title>README.rst</title>
+<title>Product Brand Filtering in Website</title>
 <style type="text/css">
 
 /*
@@ -466,6 +466,10 @@ only shown on the website they belong to, while global brands remain
 available on every website.</p>
 <p>When a product has a brand with a logo configured, that logo is
 displayed on the product page and links to the brand’s landing page.</p>
+<p>The brand’s website description can also be shown on the product page,
+right below the product description. This is disabled by default: enable
+<em>Show description on product page</em> on the brand form (<em>Website</em> tab) for
+each brand where you want it.</p>
 </div>
 <div class="section" id="bug-tracker">
 <h2><a class="toc-backref" href="#toc-entry-3">Bug Tracker</a></h2>

--- a/website_sale_product_brand/tests/__init__.py
+++ b/website_sale_product_brand/tests/__init__.py
@@ -2,3 +2,4 @@
 
 from . import test_website_sale_filter_brand
 from . import test_website_sale_brand_landing
+from . import test_website_sale_brand_product_page

--- a/website_sale_product_brand/tests/test_website_sale_brand_product_page.py
+++ b/website_sale_product_brand/tests/test_website_sale_brand_product_page.py
@@ -1,0 +1,58 @@
+# Copyright 2026 Terrabit (https://www.terrabit.ro).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import Command
+from odoo.tests import HttpCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestWebsiteSaleBrandProductPage(HttpCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.public_category = cls.env["product.public.category"].create(
+            {"name": "Brand Product Page"}
+        )
+        cls.brand = cls.env["product.brand"].create(
+            {
+                "name": "Product Page Brand",
+                "website_published": True,
+                "website_description": "<p>Brand description on product page</p>",
+            }
+        )
+        cls.product = cls.env["product.template"].create(
+            {
+                "name": "Branded Product",
+                "type": "consu",
+                "list_price": 20.0,
+                "website_published": True,
+                "sale_ok": True,
+                "public_categ_ids": [Command.set([cls.public_category.id])],
+                "product_brand_id": cls.brand.id,
+            }
+        )
+
+    def test_brand_description_hidden_by_default(self):
+        self.authenticate(None, None)
+        response = self.url_open(self.product.website_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn("Brand description on product page", response.text)
+
+    def test_brand_description_shown_when_enabled(self):
+        self.brand.show_description_on_product_page = True
+        self.authenticate(None, None)
+        response = self.url_open(self.product.website_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Brand description on product page", response.text)
+
+    def test_brand_description_not_shown_when_empty(self):
+        self.brand.write(
+            {
+                "show_description_on_product_page": True,
+                "website_description": False,
+            }
+        )
+        self.authenticate(None, None)
+        response = self.url_open(self.product.website_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn("o_product_brand_description", response.text)

--- a/website_sale_product_brand/views/product_brand_views.xml
+++ b/website_sale_product_brand/views/product_brand_views.xml
@@ -27,6 +27,7 @@
                             <field name="show_brand_name" />
                             <field name="show_brand_description" />
                             <field name="show_without_published_products" />
+                            <field name="show_description_on_product_page" />
                             <field name="align_brand_content" />
                         </group>
                         <group>

--- a/website_sale_product_brand/views/templates.xml
+++ b/website_sale_product_brand/views/templates.xml
@@ -251,4 +251,18 @@
             </a>
         </xpath>
     </template>
+
+    <template
+        id="product_brand_description"
+        inherit_id="website_sale.product_title"
+        name="Product Page Brand Description"
+    >
+        <xpath expr="//div[@t-field='product.description_ecommerce']" position="after">
+            <div
+                t-if="product.product_brand_id.show_description_on_product_page and product.product_brand_id.website_description"
+                class="o_product_brand_description mb-3 text-muted"
+                t-field="product.product_brand_id.website_description"
+            />
+        </xpath>
+    </template>
 </odoo>


### PR DESCRIPTION
## What

The product page already shows the brand logo (added in #1267), linking to the brand landing page. This adds the option to show the brand's `website_description` there as well, right below the product description.

## Why

Downstream we carried a local patch on 18.0 that showed both the brand logo and its description on the product detail page. When adopting the 19.0 port, the logo part turned out to be covered by #1267, but the description was not — hence this PR instead of keeping the patch out of tree.

## How

- New `show_description_on_product_page` boolean on `product.brand`, default `False`, exposed on the *Website* tab of the brand form.
- New `product_brand_description` template inheriting `website_sale.product_title`, inserting the description after `product.description_ecommerce`.

It is opt-in on purpose: databases that already filled in `website_description` for the landing pages should not suddenly start showing it on every product page after the update.

## Tests

`tests/test_website_sale_brand_product_page.py` covers the three cases: hidden by default, shown when the flag is on, and not rendered when the description is empty.

Ran against a clean 19.0 database:

```
odoo.tests.stats: website_sale_product_brand: 34 tests 8.32s 2966 queries
odoo.tests.result: 0 failed, 0 error(s) of 26 tests
```

Also verified in the browser: with the flag enabled, both the brand logo and its description render on the product page; with it disabled, neither the description nor the `o_product_brand_description` wrapper is emitted.

Note on linting: `ruff`, `ruff format` and `prettier` (with `@prettier/plugin-xml`, using the repo's `prettier.config.cjs`) are clean on the changed files. The full `pre-commit` run could not be executed locally — several hooks pin `python3.12`, which is not available on this machine — so I am relying on CI for the rest.