### PR TITLE
[19.0][IMP] website_sale_variant_extra_fields: support text fields

### DIFF
--- a/website_sale_variant_extra_fields/README.rst
+++ b/website_sale_variant_extra_fields/README.rst
@@ -42,9 +42,9 @@ This module removes both limitations:
 
 - product variant fields can be selected, in addition to product
   template fields;
-- more field types are supported: numbers, dates, datetimes, dropdown
-  (selection) values and linked records, in addition to char and binary
-  fields;
+- more field types are supported: multi-line text, numbers, dates,
+  datetimes, dropdown (selection) values and linked records, in addition
+  to char and binary fields;
 - when a variant field is selected, its value refreshes live on the
   product page as soon as the customer picks a different combination of
   attributes.
@@ -63,8 +63,8 @@ Usage
 1. Go to *Website > Configuration > Settings* and open the *Product Page
    Extra Fields* configuration of the website.
 2. Add a line and pick any field of a product or of a product variant.
-   Text, file, number, date, date and time, dropdown, and linked record
-   fields are available.
+   Text, multi-line text, file, number, date, date and time, dropdown,
+   and linked record fields are available.
 3. Go to the shop and open a product page. The label and the value of
    each selected field are displayed below the product details (if the
    field has a value on the displayed product or variant).

--- a/website_sale_variant_extra_fields/models/website_sale_extra_field.py
+++ b/website_sale_variant_extra_fields/models/website_sale_extra_field.py
@@ -11,6 +11,7 @@ EXTRA_FIELD_MODELS = ["product.template", "product.product"]
 
 EXTRA_FIELD_TTYPES = [
     "char",
+    "text",
     "binary",
     "integer",
     "float",

--- a/website_sale_variant_extra_fields/readme/DESCRIPTION.md
+++ b/website_sale_variant_extra_fields/readme/DESCRIPTION.md
@@ -8,9 +8,9 @@ This module removes both limitations:
 
 - product variant fields can be selected, in addition to product template
   fields;
-- more field types are supported: numbers, dates, datetimes, dropdown
-  (selection) values and linked records, in addition to char and binary
-  fields;
+- more field types are supported: multi-line text, numbers, dates, datetimes,
+  dropdown (selection) values and linked records, in addition to char and
+  binary fields;
 - when a variant field is selected, its value refreshes live on the product
   page as soon as the customer picks a different combination of attributes.
   - decimal numbers are displayed with the number of decimals configured for the

--- a/website_sale_variant_extra_fields/readme/USAGE.md
+++ b/website_sale_variant_extra_fields/readme/USAGE.md
@@ -1,8 +1,8 @@
 1.  Go to *Website \> Configuration \> Settings* and open the
     *Product Page Extra Fields* configuration of the website.
 2.  Add a line and pick any field of a product or of a product variant. Text,
-    file, number, date, date and time, dropdown, and linked record fields are
-    available.
+    multi-line text, file, number, date, date and time, dropdown, and linked
+    record fields are available.
 3.  Go to the shop and open a product page. The label and the value of each
     selected field are displayed below the product details (if the field has a value on the displayed product or variant).
 4.  Select another variant attribute on that page. The values coming from a product.variant field are updated immediately,

--- a/website_sale_variant_extra_fields/static/description/index.html
+++ b/website_sale_variant_extra_fields/static/description/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <meta name="generator" content="Docutils: https://docutils.sourceforge.io/" />
-<title>README.rst</title>
+<title>Website Sale Variant Extra Field</title>
 <style type="text/css">
 
 /*
@@ -384,9 +384,9 @@ when the customer switches variants.</p>
 <ul class="simple">
 <li>product variant fields can be selected, in addition to product
 template fields;</li>
-<li>more field types are supported: numbers, dates, datetimes, dropdown
-(selection) values and linked records, in addition to char and binary
-fields;</li>
+<li>more field types are supported: multi-line text, numbers, dates,
+datetimes, dropdown (selection) values and linked records, in addition
+to char and binary fields;</li>
 <li>when a variant field is selected, its value refreshes live on the
 product page as soon as the customer picks a different combination of
 attributes.<ul>
@@ -414,8 +414,8 @@ for the selected field.</li>
 <li>Go to <em>Website &gt; Configuration &gt; Settings</em> and open the <em>Product Page
 Extra Fields</em> configuration of the website.</li>
 <li>Add a line and pick any field of a product or of a product variant.
-Text, file, number, date, date and time, dropdown, and linked record
-fields are available.</li>
+Text, multi-line text, file, number, date, date and time, dropdown,
+and linked record fields are available.</li>
 <li>Go to the shop and open a product page. The label and the value of
 each selected field are displayed below the product details (if the
 field has a value on the displayed product or variant).</li>

--- a/website_sale_variant_extra_fields/tests/test_website_sale_variant_extra_fields.py
+++ b/website_sale_variant_extra_fields/tests/test_website_sale_variant_extra_fields.py
@@ -18,6 +18,7 @@ DUMMY_IMAGE = base64.b64encode(
 )
 
 NEW_TTYPES = [
+    "text",
     "integer",
     "float",
     "date",
@@ -118,6 +119,14 @@ class TestWebsiteSaleVariantExtraField(TransactionCase):
     def test_render_char_field(self):
         extra_field = self._create_extra_field("product.product", "default_code")
         self.assertEqual(extra_field._render_value(self.variant_1), "REF-1")
+
+    def test_render_text_field_keeps_line_breaks(self):
+        self.product_tmpl.description_sale = "First line\nSecond line"
+        extra_field = self._create_extra_field("product.template", "description_sale")
+        self.assertEqual(
+            extra_field._render_value(self.product_tmpl),
+            "First line<br>\nSecond line",
+        )
 
     def test_render_integer_field(self):
         self.variant_1.sequence = 42


### PR DESCRIPTION
Adds `text` to the field types that can be selected as Product Page Extra Fields.

Multi-line text is rendered through `ir.qweb.field.text`, so line breaks are kept on the product page.
