### PR TITLE
[19.0] [FIX] website_sale_product_attribute_value_filter_existing: filter attributes with more than 20 values

### DIFF
--- a/website_sale_product_attribute_value_filter_existing/tests/test_website_sale_product_attribute_value_filter_existing.py
+++ b/website_sale_product_attribute_value_filter_existing/tests/test_website_sale_product_attribute_value_filter_existing.py
@@ -1,8 +1,13 @@
 # Copyright 2019 Tecnativa - Sergio Teruel
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+from lxml import html
+
 from odoo.tests.common import HttpCase, tagged
 
 from odoo.addons.base.tests.common import DISABLED_MAIL_CONTEXT
+
+# radio and multi attributes render differently above 20 values
+LARGE_ATTRIBUTE_SIZE = 25
 
 
 @tagged("post_install", "-at_install")
@@ -108,6 +113,15 @@ class WebsiteSaleHttpCase(HttpCase):
         cls.product_template_2.write(
             {"attribute_line_ids": [(4, cls.product_attribute_line_2.id)]}
         )
+        # One attribute per display type, product 1 uses the first value,
+        # product 2 the second one, the remaining values are never used.
+        cls.attribute_radio = cls._create_attribute("radio")
+        cls.attribute_radio_large = cls._create_attribute("radio", LARGE_ATTRIBUTE_SIZE)
+        cls.attribute_multi = cls._create_attribute("multi")
+        cls.attribute_multi_large = cls._create_attribute("multi", LARGE_ATTRIBUTE_SIZE)
+        cls.attribute_select = cls._create_attribute("select")
+        cls.attribute_image = cls._create_attribute("image")
+        cls.attribute_pills = cls._create_attribute("pills")
         # Active attribute's filter in /shop. By default it's disabled.
         cls.env.ref("website_sale.products_attributes").active = True
         cls.env.ref("website_sale.search").active = True
@@ -118,6 +132,62 @@ class WebsiteSaleHttpCase(HttpCase):
         cls.env["website"].with_context(website_id=website.id).viewref(
             "website_sale.search"
         ).active = True
+
+    @classmethod
+    def _create_attribute(cls, display_type, size=3):
+        attribute = cls.env["product.attribute"].create(
+            {
+                "name": f"Test {display_type} {size}",
+                "display_type": display_type,
+                "create_variant": "no_variant",
+                "value_ids": [
+                    (0, 0, {"name": f"Test {display_type} value {i}"})
+                    for i in range(size)
+                ],
+            }
+        )
+        for product, value in (
+            (cls.product_template, attribute.value_ids[0]),
+            (cls.product_template_2, attribute.value_ids[1]),
+        ):
+            product.attribute_line_ids = [
+                (0, 0, {"attribute_id": attribute.id, "value_ids": [(4, value.id)]})
+            ]
+        return attribute
+
+    def _assert_only_used_values(self, attribute):
+        page = html.fromstring(self.url_open("/shop").content)
+        # Values render as checkbox inputs, or as options for select attributes
+        values = page.xpath(
+            f"""
+            //form[contains(concat(" ", @class, " "), " js_attributes ")]
+            //*[self::input or self::option]
+            [starts-with(@value, "{attribute.id}-")]/@value
+            """
+        )
+        rendered = {int(value.split("-")[1]) for value in values}
+        self.assertEqual(rendered, set(attribute.value_ids[:2].ids))
+
+    def test_radio(self):
+        self._assert_only_used_values(self.attribute_radio)
+
+    def test_radio_large(self):
+        self._assert_only_used_values(self.attribute_radio_large)
+
+    def test_multi(self):
+        self._assert_only_used_values(self.attribute_multi)
+
+    def test_multi_large(self):
+        self._assert_only_used_values(self.attribute_multi_large)
+
+    def test_select(self):
+        self._assert_only_used_values(self.attribute_select)
+
+    def test_image(self):
+        self._assert_only_used_values(self.attribute_image)
+
+    def test_pills(self):
+        self._assert_only_used_values(self.attribute_pills)
 
     def test_ui_website(self):
         # This test ensures that unused attributes are not visible in the filter panel.

--- a/website_sale_product_attribute_value_filter_existing/views/templates.xml
+++ b/website_sale_product_attribute_value_filter_existing/views/templates.xml
@@ -16,15 +16,20 @@
         id="filter_radio_and_multi_attributes"
         inherit_id="website_sale.filter_radio_and_multi_attributes"
     >
-        <xpath expr="//div[@t-foreach='sorted_values[:8]']" position="attributes">
-            <attribute
-                name="t-if"
-            >not attr_values_used_ids or v.id in attr_values_used_ids</attribute>
+        <xpath expr="//t[@t-set='sorted_values']" position="after">
+            <t
+                t-if="attr_values_used_ids"
+                t-set="sorted_values"
+                t-value="[v for v in sorted_values if v.id in attr_values_used_ids]"
+            />
         </xpath>
-        <xpath expr="//div[@t-foreach='sorted_values[8:]']" position="attributes">
+        <xpath
+            expr="//input[hasclass('o_wsale_attribute_search_bar')]"
+            position="attributes"
+        >
             <attribute
-                name="t-if"
-            >not attr_values_used_ids or v.id in attr_values_used_ids</attribute>
+                name="t-attf-placeholder"
+            >Search {{a.name}} ({{len(sorted_values)}})</attribute>
         </xpath>
     </template>
     <template


### PR DESCRIPTION
Odoo 19 renders radio and multi attributes with more than 20 values through a searchable list that was not covered by the module, so every value was displayed.
